### PR TITLE
feat: shared adapter failure taxonomy and fallback chain (ANGA-184)

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -29,6 +29,8 @@ export type {
   StdoutLineParser,
   CLIAdapterModule,
   CreateConfigValues,
+  AdapterFailureCategory,
+  AdapterFallbackEntry,
 } from "./types.js";
 export type {
   SessionCompactionPolicy,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -21,6 +21,59 @@ export interface AdapterRuntime {
 }
 
 // ---------------------------------------------------------------------------
+// Canonical adapter failure taxonomy
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider-agnostic failure categories emitted by all local adapters.
+ * Adapters MUST map their provider-specific failures to these codes so the
+ * heartbeat runner can apply a uniform fallback / retry policy.
+ *
+ * | Category             | When to use                                              |
+ * |----------------------|----------------------------------------------------------|
+ * | auth_required        | CLI requires re-login / credentials missing              |
+ * | rate_limited         | Provider quota or rate-limit hit (retry later)           |
+ * | session_invalid      | Saved session is stale and cannot be resumed             |
+ * | startup_failed       | Process exited early with no usable output               |
+ * | timeout              | Execution wall-clock limit reached                      |
+ * | provider_unavailable | Provider binary missing or service unreachable           |
+ * | process_lost         | Process disappeared mid-run (DETACHED_PROCESS_ERROR)     |
+ * | crash_no_output      | Process crashed before producing any structured output   |
+ * | parse_error          | Output could not be parsed as expected format            |
+ * | cancelled            | Run was cancelled by the orchestrator                    |
+ * | nonzero_exit         | Process exited with non-zero code, no specific category  |
+ * | unknown              | Failure reason could not be determined                   |
+ */
+export type AdapterFailureCategory =
+  | "auth_required"
+  | "rate_limited"
+  | "session_invalid"
+  | "startup_failed"
+  | "timeout"
+  | "provider_unavailable"
+  | "process_lost"
+  | "crash_no_output"
+  | "parse_error"
+  | "cancelled"
+  | "nonzero_exit"
+  | "unknown";
+
+/**
+ * A single entry in the adapter fallback chain stored in `adapterConfig`.
+ * When the primary adapter fails with a category listed in `triggerOn`
+ * (or any category when `triggerOn` is omitted), the heartbeat runner
+ * retries the run using the fallback adapter configuration.
+ */
+export interface AdapterFallbackEntry {
+  adapterType: string;
+  adapterConfig?: Record<string, unknown>;
+  /** Limit this fallback to specific failure categories. Omit to match any failure. */
+  triggerOn?: AdapterFailureCategory[];
+  /** Maximum attempts for this fallback entry. Defaults to 1. */
+  maxAttempts?: number;
+}
+
+// ---------------------------------------------------------------------------
 // Execution types (moved from server/src/adapters/types.ts)
 // ---------------------------------------------------------------------------
 

--- a/server/src/__tests__/adapter-failure-taxonomy.test.ts
+++ b/server/src/__tests__/adapter-failure-taxonomy.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { categorizeAdapterError } from "../services/adapter-failure-taxonomy.js";
+import type { AdapterFailureCategory, AdapterFallbackEntry } from "@paperclipai/adapter-utils";
+
+describe("categorizeAdapterError", () => {
+  it("returns unknown for null/undefined", () => {
+    expect(categorizeAdapterError(null)).toBe("unknown");
+    expect(categorizeAdapterError(undefined)).toBe("unknown");
+    expect(categorizeAdapterError("")).toBe("unknown");
+  });
+
+  it("maps canonical codes directly", () => {
+    const cases: Array<[string, AdapterFailureCategory]> = [
+      ["auth_required", "auth_required"],
+      ["rate_limited", "rate_limited"],
+      ["session_invalid", "session_invalid"],
+      ["startup_failed", "startup_failed"],
+      ["timeout", "timeout"],
+      ["provider_unavailable", "provider_unavailable"],
+      ["process_lost", "process_lost"],
+      ["crash_no_output", "crash_no_output"],
+      ["parse_error", "parse_error"],
+      ["cancelled", "cancelled"],
+      ["nonzero_exit", "nonzero_exit"],
+    ];
+    for (const [code, expected] of cases) {
+      expect(categorizeAdapterError(code)).toBe(expected);
+    }
+  });
+
+  it("maps legacy claude-prefixed codes to canonical categories", () => {
+    expect(categorizeAdapterError("claude_auth_required")).toBe("auth_required");
+    expect(categorizeAdapterError("claude_rate_limited")).toBe("rate_limited");
+    expect(categorizeAdapterError("claude_session_invalid")).toBe("session_invalid");
+    expect(categorizeAdapterError("claude_crash_no_output")).toBe("crash_no_output");
+    expect(categorizeAdapterError("claude_json_parse_failed")).toBe("parse_error");
+  });
+
+  it("maps process_detached (DETACHED_PROCESS_ERROR_CODE) to process_lost", () => {
+    expect(categorizeAdapterError("process_detached")).toBe("process_lost");
+  });
+
+  it("maps startup_failure variant to startup_failed", () => {
+    expect(categorizeAdapterError("startup_failure")).toBe("startup_failed");
+  });
+
+  it("returns unknown for unrecognized codes", () => {
+    expect(categorizeAdapterError("adapter_failed")).toBe("unknown");
+    expect(categorizeAdapterError("some_random_error")).toBe("unknown");
+  });
+});
+
+describe("AdapterFallbackEntry triggerOn filtering (non-Claude fallback scenario)", () => {
+  it("correctly identifies when a fallback should trigger for rate_limited", () => {
+    // Simulates: codex_local is rate_limited → should fall back to claude_local
+    const fallbackEntry: AdapterFallbackEntry = {
+      adapterType: "claude_local",
+      adapterConfig: { model: "claude-sonnet-4-5" },
+      triggerOn: ["rate_limited", "provider_unavailable"],
+    };
+
+    const primaryErrorCode = "rate_limited";
+    const failureCategory = categorizeAdapterError(primaryErrorCode);
+
+    const shouldTrigger =
+      !fallbackEntry.triggerOn || fallbackEntry.triggerOn.includes(failureCategory);
+
+    expect(shouldTrigger).toBe(true);
+  });
+
+  it("does not trigger fallback when failure category is not in triggerOn", () => {
+    const fallbackEntry: AdapterFallbackEntry = {
+      adapterType: "claude_local",
+      triggerOn: ["rate_limited"],
+    };
+
+    const failureCategory = categorizeAdapterError("auth_required");
+    const shouldTrigger =
+      !fallbackEntry.triggerOn || fallbackEntry.triggerOn.includes(failureCategory);
+
+    expect(shouldTrigger).toBe(false);
+  });
+
+  it("triggers fallback for any failure when triggerOn is omitted", () => {
+    const fallbackEntry: AdapterFallbackEntry = {
+      adapterType: "claude_local",
+    };
+
+    for (const code of ["auth_required", "rate_limited", "crash_no_output", "unknown"]) {
+      const failureCategory = categorizeAdapterError(code);
+      const shouldTrigger =
+        !fallbackEntry.triggerOn || fallbackEntry.triggerOn.includes(failureCategory);
+      expect(shouldTrigger).toBe(true);
+    }
+  });
+});

--- a/server/src/services/adapter-failure-taxonomy.ts
+++ b/server/src/services/adapter-failure-taxonomy.ts
@@ -1,0 +1,43 @@
+import type { AdapterFailureCategory } from "@paperclipai/adapter-utils";
+
+/**
+ * Map an adapter-emitted errorCode to the canonical AdapterFailureCategory.
+ * Adapters are expected to use canonical codes directly, but legacy codes
+ * (e.g. claude_auth_required) are also handled for backwards compatibility.
+ */
+export function categorizeAdapterError(errorCode: string | null | undefined): AdapterFailureCategory {
+  if (!errorCode) return "unknown";
+  switch (errorCode) {
+    case "auth_required":
+    case "claude_auth_required":
+      return "auth_required";
+    case "rate_limited":
+    case "claude_rate_limited":
+      return "rate_limited";
+    case "session_invalid":
+    case "claude_session_invalid":
+      return "session_invalid";
+    case "startup_failed":
+    case "startup_failure":
+      return "startup_failed";
+    case "timeout":
+      return "timeout";
+    case "provider_unavailable":
+      return "provider_unavailable";
+    case "process_lost":
+    case "process_detached":
+      return "process_lost";
+    case "crash_no_output":
+    case "claude_crash_no_output":
+      return "crash_no_output";
+    case "parse_error":
+    case "claude_json_parse_failed":
+      return "parse_error";
+    case "cancelled":
+      return "cancelled";
+    case "nonzero_exit":
+      return "nonzero_exit";
+    default:
+      return "unknown";
+  }
+}

--- a/server/src/services/adapter-failure-taxonomy.ts
+++ b/server/src/services/adapter-failure-taxonomy.ts
@@ -37,6 +37,9 @@ export function categorizeAdapterError(errorCode: string | null | undefined): Ad
       return "cancelled";
     case "nonzero_exit":
       return "nonzero_exit";
+    case "all_adapters_exhausted":
+      // All adapters in the fallback chain were tried and failed
+      return "unknown";
     default:
       return "unknown";
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2682,10 +2682,22 @@ export function heartbeatService(db: Db) {
         const fallbackChain: AdapterFallbackEntry[] = Array.isArray(rawFallbackChain) ? rawFallbackChain as AdapterFallbackEntry[] : [];
         if (fallbackChain.length > 0) {
           const failureCategory = categorizeAdapterError(adapterResult.errorCode);
+          await appendRunEvent(currentRun, seq++, {
+            eventType: "adapter.fallback",
+            stream: "system",
+            level: "warn",
+            message: `primary adapter failed with category "${failureCategory}", attempting fallback chain`,
+            payload: {
+              primaryAdapterType: agent.adapterType,
+              primaryErrorCode: adapterResult.errorCode ?? null,
+              failureCategory,
+              fallbackChainLength: fallbackChain.length,
+            },
+          });
+          let fallbackSucceeded = false;
           for (const entry of fallbackChain) {
             if (entry.triggerOn && !entry.triggerOn.includes(failureCategory)) continue;
             const maxAttempts = entry.maxAttempts ?? 1;
-            let fallbackSucceeded = false;
             for (let attempt = 0; attempt < maxAttempts; attempt++) {
               try {
                 const fallbackAdapter = getServerAdapter(entry.adapterType);
@@ -2702,6 +2714,13 @@ export function heartbeatService(db: Db) {
                   sessionParams: null,
                   sessionDisplayId: null,
                 };
+                await appendRunEvent(currentRun, seq++, {
+                  eventType: "adapter.fallback",
+                  stream: "system",
+                  level: "info",
+                  message: `trying fallback adapter "${entry.adapterType}" (attempt ${attempt + 1}/${maxAttempts})`,
+                  payload: { fallbackAdapterType: entry.adapterType, attempt: attempt + 1, maxAttempts },
+                });
                 const fallbackResult = await fallbackAdapter.execute({
                   runId: run.id,
                   agent: { ...agent, adapterType: entry.adapterType, adapterConfig: entry.adapterConfig ?? agent.adapterConfig },
@@ -2722,16 +2741,58 @@ export function heartbeatService(db: Db) {
                 if (fallbackOk) {
                   adapterResult = fallbackResult;
                   fallbackSucceeded = true;
+                  await appendRunEvent(currentRun, seq++, {
+                    eventType: "adapter.fallback",
+                    stream: "system",
+                    level: "info",
+                    message: `fallback adapter "${entry.adapterType}" succeeded`,
+                    payload: { fallbackAdapterType: entry.adapterType },
+                  });
                   break;
+                } else {
+                  await appendRunEvent(currentRun, seq++, {
+                    eventType: "adapter.fallback",
+                    stream: "system",
+                    level: "warn",
+                    message: `fallback adapter "${entry.adapterType}" failed (attempt ${attempt + 1}/${maxAttempts})`,
+                    payload: {
+                      fallbackAdapterType: entry.adapterType,
+                      attempt: attempt + 1,
+                      errorCode: fallbackResult.errorCode ?? null,
+                      errorMessage: fallbackResult.errorMessage ?? null,
+                    },
+                  });
                 }
               } catch (fallbackErr) {
-                await onLog(
-                  "stderr",
-                  `[paperclip] Fallback adapter "${entry.adapterType}" attempt ${attempt + 1} threw: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}\n`,
-                );
+                const errMsg = fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
+                await onLog("stderr", `[paperclip] Fallback adapter "${entry.adapterType}" attempt ${attempt + 1} threw: ${errMsg}\n`);
+                await appendRunEvent(currentRun, seq++, {
+                  eventType: "adapter.fallback",
+                  stream: "system",
+                  level: "error",
+                  message: `fallback adapter "${entry.adapterType}" threw exception`,
+                  payload: { fallbackAdapterType: entry.adapterType, error: errMsg },
+                });
               }
             }
             if (fallbackSucceeded) break;
+          }
+          if (!fallbackSucceeded) {
+            // All fallback entries exhausted — override errorCode for clarity
+            adapterResult = {
+              ...adapterResult,
+              errorCode: "all_adapters_exhausted",
+              errorMessage:
+                adapterResult.errorMessage ??
+                `All adapters exhausted (primary: ${agent.adapterType}, failure: ${failureCategory})`,
+            };
+            await appendRunEvent(currentRun, seq++, {
+              eventType: "adapter.fallback",
+              stream: "system",
+              level: "error",
+              message: "all adapters in fallback chain exhausted",
+              payload: { primaryAdapterType: agent.adapterType, failureCategory },
+            });
           }
         }
       }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -57,8 +57,10 @@ import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.
 import {
   hasSessionCompactionThresholds,
   resolveSessionCompactionPolicy,
+  type AdapterFallbackEntry,
   type SessionCompactionPolicy,
 } from "@paperclipai/adapter-utils";
+import { categorizeAdapterError } from "./adapter-failure-taxonomy.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 1;
@@ -2654,7 +2656,7 @@ export function heartbeatService(db: Db) {
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
       }
-      const adapterResult = await adapter.execute({
+      let adapterResult = await adapter.execute({
         runId: run.id,
         agent,
         runtime: runtimeForAdapter,
@@ -2667,6 +2669,73 @@ export function heartbeatService(db: Db) {
         },
         authToken: authToken ?? undefined,
       });
+
+      // ---------------------------------------------------------------------------
+      // Adapter fallback chain
+      // ---------------------------------------------------------------------------
+      const primaryFailed =
+        adapterResult.timedOut ||
+        ((adapterResult.exitCode ?? 0) !== 0 && adapterResult.exitCode !== null) ||
+        !!adapterResult.errorMessage;
+      if (primaryFailed) {
+        const rawFallbackChain = (parseObject(agent.adapterConfig) as Record<string, unknown>).adapterFallbackChain;
+        const fallbackChain: AdapterFallbackEntry[] = Array.isArray(rawFallbackChain) ? rawFallbackChain as AdapterFallbackEntry[] : [];
+        if (fallbackChain.length > 0) {
+          const failureCategory = categorizeAdapterError(adapterResult.errorCode);
+          for (const entry of fallbackChain) {
+            if (entry.triggerOn && !entry.triggerOn.includes(failureCategory)) continue;
+            const maxAttempts = entry.maxAttempts ?? 1;
+            let fallbackSucceeded = false;
+            for (let attempt = 0; attempt < maxAttempts; attempt++) {
+              try {
+                const fallbackAdapter = getServerAdapter(entry.adapterType);
+                const fallbackAuthToken = fallbackAdapter.supportsLocalAgentJwt
+                  ? createLocalAgentJwt(agent.id, agent.companyId, entry.adapterType, run.id)
+                  : null;
+                const fallbackConfig = entry.adapterConfig
+                  ? { ...runtimeConfig, ...entry.adapterConfig }
+                  : runtimeConfig;
+                // Fallback does NOT inherit session state from the primary adapter
+                const fallbackRuntime = {
+                  ...runtimeForAdapter,
+                  sessionId: null,
+                  sessionParams: null,
+                  sessionDisplayId: null,
+                };
+                const fallbackResult = await fallbackAdapter.execute({
+                  runId: run.id,
+                  agent: { ...agent, adapterType: entry.adapterType, adapterConfig: entry.adapterConfig ?? agent.adapterConfig },
+                  runtime: fallbackRuntime,
+                  config: fallbackConfig,
+                  context,
+                  onLog,
+                  onMeta: onAdapterMeta,
+                  onSpawn: async (meta) => {
+                    await persistRunProcessMetadata(run.id, meta);
+                  },
+                  authToken: fallbackAuthToken ?? undefined,
+                });
+                const fallbackOk =
+                  !fallbackResult.timedOut &&
+                  (fallbackResult.exitCode ?? 0) === 0 &&
+                  !fallbackResult.errorMessage;
+                if (fallbackOk) {
+                  adapterResult = fallbackResult;
+                  fallbackSucceeded = true;
+                  break;
+                }
+              } catch (fallbackErr) {
+                await onLog(
+                  "stderr",
+                  `[paperclip] Fallback adapter "${entry.adapterType}" attempt ${attempt + 1} threw: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}\n`,
+                );
+              }
+            }
+            if (fallbackSucceeded) break;
+          }
+        }
+      }
+
       const adapterManagedRuntimeServices = adapterResult.runtimeServices
         ? await persistAdapterManagedRuntimeServices({
             db,


### PR DESCRIPTION
## Summary

- Adds `AdapterFailureCategory` type to `@paperclipai/adapter-utils` with 12 provider-agnostic error codes
- Adds `AdapterFallbackEntry` interface with `triggerOn`, `adapterConfig`, `maxAttempts` fields
- Introduces `categorizeAdapterError()` in `server/src/services/adapter-failure-taxonomy.ts` mapping legacy codes (e.g. `claude_auth_required` ? `auth_required`) to canonical categories
- Implements adapter fallback chain in heartbeat orchestrator: reads `adapterFallbackChain` from agent config, executes matching fallback adapters on primary failure, replaces result on success
- Fallback adapters do NOT inherit session state from the primary adapter

## Test plan

- [x] 9 unit tests in `server/src/__tests__/adapter-failure-taxonomy.test.ts` pass
- [x] `categorizeAdapterError` tested: canonical codes, legacy claude-prefixed codes, `process_detached` ? `process_lost`, unrecognized ? `unknown`
- [x] Fallback chain `triggerOn` filtering logic tested (non-Claude fallback scenario)
- [x] Full server vitest suite: no new failures introduced

Closes ANGA-184

?? Generated with [Claude Code](https://claude.com/claude-code)