### PR TITLE
feat(db,server): add versioned agent_policies runtime policy layer

### DIFF
--- a/packages/db/src/migrations/0056_agent_policies.sql
+++ b/packages/db/src/migrations/0056_agent_policies.sql
@@ -1,0 +1,58 @@
+CREATE TABLE IF NOT EXISTS "agent_policies" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"agent_id" uuid NOT NULL,
+	"key" text NOT NULL,
+	"title" text NOT NULL,
+	"format" text DEFAULT 'markdown' NOT NULL,
+	"latest_body" text DEFAULT '' NOT NULL,
+	"latest_revision_id" uuid,
+	"latest_revision_number" integer DEFAULT 0 NOT NULL,
+	"scope" text DEFAULT 'agent' NOT NULL,
+	"scope_id" uuid,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_by_agent_id" uuid,
+	"created_by_user_id" text,
+	"updated_by_agent_id" uuid,
+	"updated_by_user_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "agent_policy_revisions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"policy_id" uuid NOT NULL,
+	"revision_number" integer NOT NULL,
+	"title" text NOT NULL,
+	"body" text NOT NULL,
+	"change_summary" text,
+	"created_by_agent_id" uuid,
+	"created_by_user_id" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'agent_policies_company_id_companies_id_fk') THEN
+  ALTER TABLE "agent_policies" ADD CONSTRAINT "agent_policies_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."companies"("id") ON DELETE no action ON UPDATE no action;
+ END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'agent_policies_agent_id_agents_id_fk') THEN
+  ALTER TABLE "agent_policies" ADD CONSTRAINT "agent_policies_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE no action ON UPDATE no action;
+ END IF;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'agent_policy_revisions_policy_id_agent_policies_id_fk') THEN
+  ALTER TABLE "agent_policy_revisions" ADD CONSTRAINT "agent_policy_revisions_policy_id_agent_policies_id_fk" FOREIGN KEY ("policy_id") REFERENCES "public"."agent_policies"("id") ON DELETE cascade ON UPDATE no action;
+ END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_policies_agent_key_unique_idx" ON "agent_policies" USING btree ("agent_id","key");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_policies_company_agent_active_idx" ON "agent_policies" USING btree ("company_id","agent_id","active");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_policy_revisions_policy_revision_unique_idx" ON "agent_policy_revisions" USING btree ("policy_id","revision_number");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "agent_policy_revisions_policy_id_idx" ON "agent_policy_revisions" USING btree ("policy_id");

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1775825256196,
       "tag": "0055_kind_weapon_omega",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1743688800000,
+      "tag": "0056_agent_policies",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agent_policies.ts
+++ b/packages/db/src/schema/agent_policies.ts
@@ -1,0 +1,38 @@
+import { boolean, index, integer, pgTable, text, timestamp, uuid, uniqueIndex } from "drizzle-orm/pg-core";
+import { companies } from "./companies.js";
+import { agents } from "./agents.js";
+
+export const agentPolicies = pgTable(
+  "agent_policies",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    companyId: uuid("company_id").notNull().references(() => companies.id),
+    agentId: uuid("agent_id").notNull().references(() => agents.id),
+    key: text("key").notNull(),
+    title: text("title").notNull(),
+    format: text("format").notNull().default("markdown"),
+    latestBody: text("latest_body").notNull().default(""),
+    latestRevisionId: uuid("latest_revision_id"),
+    latestRevisionNumber: integer("latest_revision_number").notNull().default(0),
+    scope: text("scope").notNull().default("agent"),
+    scopeId: uuid("scope_id"),
+    active: boolean("active").notNull().default(true),
+    createdByAgentId: uuid("created_by_agent_id"),
+    createdByUserId: text("created_by_user_id"),
+    updatedByAgentId: uuid("updated_by_agent_id"),
+    updatedByUserId: text("updated_by_user_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    agentKeyUniqueIdx: uniqueIndex("agent_policies_agent_key_unique_idx").on(
+      table.agentId,
+      table.key,
+    ),
+    companyAgentActiveIdx: index("agent_policies_company_agent_active_idx").on(
+      table.companyId,
+      table.agentId,
+      table.active,
+    ),
+  }),
+);

--- a/packages/db/src/schema/agent_policy_revisions.ts
+++ b/packages/db/src/schema/agent_policy_revisions.ts
@@ -1,0 +1,24 @@
+import { index, integer, pgTable, text, timestamp, uuid, uniqueIndex } from "drizzle-orm/pg-core";
+import { agentPolicies } from "./agent_policies.js";
+
+export const agentPolicyRevisions = pgTable(
+  "agent_policy_revisions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    policyId: uuid("policy_id").notNull().references(() => agentPolicies.id, { onDelete: "cascade" }),
+    revisionNumber: integer("revision_number").notNull(),
+    title: text("title").notNull(),
+    body: text("body").notNull(),
+    changeSummary: text("change_summary"),
+    createdByAgentId: uuid("created_by_agent_id"),
+    createdByUserId: text("created_by_user_id"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    policyRevisionNumberUniqueIdx: uniqueIndex("agent_policy_revisions_policy_revision_unique_idx").on(
+      table.policyId,
+      table.revisionNumber,
+    ),
+    policyIdIdx: index("agent_policy_revisions_policy_id_idx").on(table.policyId),
+  }),
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -14,6 +14,8 @@ export { budgetPolicies } from "./budget_policies.js";
 export { budgetIncidents } from "./budget_incidents.js";
 export { agentConfigRevisions } from "./agent_config_revisions.js";
 export { agentApiKeys } from "./agent_api_keys.js";
+export { agentPolicies } from "./agent_policies.js";
+export { agentPolicyRevisions } from "./agent_policy_revisions.js";
 export { agentRuntimeState } from "./agent_runtime_state.js";
 export { agentTaskSessions } from "./agent_task_sessions.js";
 export { agentWakeupRequests } from "./agent_wakeup_requests.js";

--- a/server/src/__tests__/activity-routes.test.ts
+++ b/server/src/__tests__/activity-routes.test.ts
@@ -25,6 +25,7 @@ function registerRouteMocks() {
   }));
 
   vi.doMock("../services/index.js", () => ({
+    agentPoliciesService: vi.fn(() => ({})),
     issueService: () => mockIssueService,
     heartbeatService: () => mockHeartbeatService,
   }));

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -64,6 +64,7 @@ const mockInstanceSettingsService = vi.hoisted(() => ({
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   agentService: () => mockAgentService,
   agentInstructionsService: () => mockAgentInstructionsService,
   accessService: () => mockAccessService,

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -35,6 +35,7 @@ const mockSecretService = vi.hoisted(() => ({
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   agentService: () => mockAgentService,
   agentInstructionsService: () => mockAgentInstructionsService,
   accessService: () => mockAccessService,

--- a/server/src/__tests__/agent-live-run-routes.test.ts
+++ b/server/src/__tests__/agent-live-run-routes.test.ts
@@ -19,6 +19,7 @@ const mockIssueService = vi.hoisted(() => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   agentService: () => mockAgentService,
   agentInstructionsService: () => ({}),
   accessService: () => ({}),

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -101,6 +101,7 @@ vi.mock("../telemetry.js", () => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   agentService: () => mockAgentService,
   agentInstructionsService: () => mockAgentInstructionsService,
   accessService: () => mockAccessService,

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -69,6 +69,7 @@ function registerModuleMocks() {
   }));
 
   vi.doMock("../services/index.js", () => ({
+    agentPoliciesService: vi.fn(() => ({})),
     agentService: () => mockAgentService,
     agentInstructionsService: () => mockAgentInstructionsService,
     accessService: () => mockAccessService,

--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -30,6 +30,7 @@ const mockSecretService = vi.hoisted(() => ({
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   approvalService: () => mockApprovalService,
   heartbeatService: () => mockHeartbeatService,
   issueApprovalService: () => mockIssueApprovalService,

--- a/server/src/__tests__/assets.test.ts
+++ b/server/src/__tests__/assets.test.ts
@@ -12,6 +12,7 @@ const { createAssetMock, getAssetByIdMock, logActivityMock } = vi.hoisted(() => 
 
 function registerServiceMocks() {
   vi.doMock("../services/index.js", () => ({
+    agentPoliciesService: vi.fn(() => ({})),
     assetService: vi.fn(() => ({
       create: createAssetMock,
       getById: getAssetByIdMock,

--- a/server/src/__tests__/cli-auth-routes.test.ts
+++ b/server/src/__tests__/cli-auth-routes.test.ts
@@ -28,6 +28,7 @@ const mockBoardAuthService = vi.hoisted(() => ({
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => mockAccessService,
   agentService: () => mockAgentService,
   boardAuthService: () => mockBoardAuthService,

--- a/server/src/__tests__/companies-route-path-guard.test.ts
+++ b/server/src/__tests__/companies-route-path-guard.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { companyRoutes } from "../routes/companies.js";
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   companyService: () => ({
     list: vi.fn(),
     stats: vi.fn(),

--- a/server/src/__tests__/company-branding-route.test.ts
+++ b/server/src/__tests__/company-branding-route.test.ts
@@ -40,6 +40,7 @@ const mockFeedbackService = vi.hoisted(() => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => mockAccessService,
   agentService: () => mockAgentService,
   budgetService: () => mockBudgetService,

--- a/server/src/__tests__/company-portability-routes.test.ts
+++ b/server/src/__tests__/company-portability-routes.test.ts
@@ -41,6 +41,7 @@ const mockFeedbackService = vi.hoisted(() => ({
 
 function registerServiceMocks() {
   vi.doMock("../services/index.js", () => ({
+    agentPoliciesService: vi.fn(() => ({})),
     accessService: () => mockAccessService,
     agentService: () => mockAgentService,
     budgetService: () => mockBudgetService,

--- a/server/src/__tests__/company-skills-routes.test.ts
+++ b/server/src/__tests__/company-skills-routes.test.ts
@@ -30,6 +30,7 @@ vi.mock("../telemetry.js", () => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => mockAccessService,
   agentService: () => mockAgentService,
   companySkillService: () => mockCompanySkillService,

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -72,6 +72,7 @@ const mockBudgetService = vi.hoisted(() => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   budgetService: () => mockBudgetService,
   costService: () => mockCostService,
   financeService: () => mockFinanceService,

--- a/server/src/__tests__/instance-settings-routes.test.ts
+++ b/server/src/__tests__/instance-settings-routes.test.ts
@@ -12,6 +12,7 @@ const mockInstanceSettingsService = vi.hoisted(() => ({
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   instanceSettingsService: () => mockInstanceSettingsService,
   logActivity: mockLogActivity,
 }));

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -19,6 +19,7 @@ const mockIssueService = vi.hoisted(() => ({
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => ({
     canUser: vi.fn(async () => false),
     hasPermission: vi.fn(async () => false),

--- a/server/src/__tests__/issue-attachment-routes.test.ts
+++ b/server/src/__tests__/issue-attachment-routes.test.ts
@@ -24,6 +24,7 @@ function registerRouteMocks() {
   }));
 
   vi.doMock("../services/index.js", () => ({
+    agentPoliciesService: vi.fn(() => ({})),
     accessService: () => ({
       canUser: vi.fn(),
       hasPermission: vi.fn(),

--- a/server/src/__tests__/issue-closed-workspace-routes.test.ts
+++ b/server/src/__tests__/issue-closed-workspace-routes.test.ts
@@ -48,6 +48,7 @@ function registerServiceMocks() {
   }));
 
   vi.doMock("../services/index.js", () => ({
+    agentPoliciesService: vi.fn(() => ({})),
     accessService: () => mockAccessService,
     agentService: () => ({
       getById: vi.fn(async () => null),

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -66,6 +66,7 @@ vi.mock("../telemetry.js", () => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => mockAccessService,
   agentService: () => mockAgentService,
   documentService: () => ({}),

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -18,6 +18,7 @@ const mockIssueService = vi.hoisted(() => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => ({
     canUser: vi.fn(),
     hasPermission: vi.fn(),

--- a/server/src/__tests__/issue-document-restore-routes.test.ts
+++ b/server/src/__tests__/issue-document-restore-routes.test.ts
@@ -28,6 +28,7 @@ const mockAgentService = vi.hoisted(() => ({
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => mockAccessService,
   agentService: () => mockAgentService,
   documentService: () => mockDocumentsService,

--- a/server/src/__tests__/issue-execution-policy-routes.test.ts
+++ b/server/src/__tests__/issue-execution-policy-routes.test.ts
@@ -25,6 +25,7 @@ const mockHeartbeatService = vi.hoisted(() => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => ({
     canUser: vi.fn(async () => false),
     hasPermission: vi.fn(async () => false),

--- a/server/src/__tests__/issue-feedback-routes.test.ts
+++ b/server/src/__tests__/issue-feedback-routes.test.ts
@@ -60,6 +60,7 @@ vi.mock("../telemetry.js", () => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => mockAccessService,
   agentService: () => mockAgentService,
   documentService: () => ({}),

--- a/server/src/__tests__/issue-telemetry-routes.test.ts
+++ b/server/src/__tests__/issue-telemetry-routes.test.ts
@@ -28,6 +28,7 @@ vi.mock("../telemetry.js", () => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => ({
     canUser: vi.fn(),
     hasPermission: vi.fn(),

--- a/server/src/__tests__/issue-template-scaffold-routes.test.ts
+++ b/server/src/__tests__/issue-template-scaffold-routes.test.ts
@@ -15,6 +15,7 @@ const mockIssueService = vi.hoisted(() => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => ({
     canUser: vi.fn(),
     hasPermission: vi.fn(),

--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -25,6 +25,7 @@ const mockHeartbeatService = vi.hoisted(() => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => ({
     canUser: vi.fn(async () => true),
     hasPermission: vi.fn(async () => true),

--- a/server/src/__tests__/issues-goal-context-routes.test.ts
+++ b/server/src/__tests__/issues-goal-context-routes.test.ts
@@ -25,6 +25,7 @@ const mockGoalService = vi.hoisted(() => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => ({
     canUser: vi.fn(),
     hasPermission: vi.fn(),

--- a/server/src/__tests__/llms-routes.test.ts
+++ b/server/src/__tests__/llms-routes.test.ts
@@ -11,6 +11,7 @@ const mockAgentService = vi.hoisted(() => ({
 const mockListServerAdapters = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   agentService: () => mockAgentService,
 }));
 

--- a/server/src/__tests__/openclaw-invite-prompt-route.test.ts
+++ b/server/src/__tests__/openclaw-invite-prompt-route.test.ts
@@ -36,6 +36,7 @@ const mockBoardAuthService = vi.hoisted(() => ({
 const mockLogActivity = vi.hoisted(() => vi.fn());
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => mockAccessService,
   agentService: () => mockAgentService,
   boardAuthService: () => mockBoardAuthService,

--- a/server/src/__tests__/project-routes-env.test.ts
+++ b/server/src/__tests__/project-routes-env.test.ts
@@ -27,6 +27,7 @@ function registerModuleMocks() {
   }));
 
   vi.doMock("../services/index.js", () => ({
+    agentPoliciesService: vi.fn(() => ({})),
     logActivity: mockLogActivity,
     projectService: () => mockProjectService,
     secretService: () => mockSecretService,

--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -95,6 +95,7 @@ vi.mock("../telemetry.js", () => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   accessService: () => mockAccessService,
   logActivity: mockLogActivity,
   routineService: () => mockRoutineService,

--- a/server/src/__tests__/server-startup-feedback-export.test.ts
+++ b/server/src/__tests__/server-startup-feedback-export.test.ts
@@ -115,6 +115,7 @@ vi.mock("../realtime/live-events-ws.js", () => ({
 }));
 
 vi.mock("../services/index.js", () => ({
+  agentPoliciesService: vi.fn(() => ({})),
   feedbackService: feedbackServiceFactoryMock,
   heartbeatService: vi.fn(() => ({
     reapOrphanedRuns: vi.fn(async () => undefined),

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -31,6 +31,7 @@ import { trackAgentCreated } from "@paperclipai/shared/telemetry";
 import { validate } from "../middleware/validate.js";
 import {
   agentService,
+  agentPoliciesService,
   agentInstructionsService,
   accessService,
   approvalService,
@@ -2571,6 +2572,182 @@ export function agentRoutes(db: Db) {
       agentName: agent.name,
       adapterType: agent.adapterType,
     });
+  });
+
+  // ── Agent Policies ───────────────────────────────────────────────────────
+
+  const policiesSvc = agentPoliciesService(db);
+
+  router.get("/agents/:id/policies", async (req, res) => {
+    const id = req.params.id as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
+
+    const active = req.query.active !== undefined
+      ? req.query.active === "true"
+      : undefined;
+    const scope = typeof req.query.scope === "string" ? req.query.scope : undefined;
+
+    const policies = await policiesSvc.listPolicies(id, { active, scope });
+    res.json(policies);
+  });
+
+  router.get("/agents/:id/policies/:key", async (req, res) => {
+    const id = req.params.id as string;
+    const key = req.params.key as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
+
+    const policy = await policiesSvc.getPolicy(id, key);
+    if (!policy) {
+      res.status(404).json({ error: "Policy not found" });
+      return;
+    }
+    res.json(policy);
+  });
+
+  router.put("/agents/:id/policies/:key", async (req, res) => {
+    const id = req.params.id as string;
+    const key = req.params.key as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
+
+    const actor = getActorInfo(req);
+    const { title, format, body, changeSummary, baseRevisionId, scope, scopeId } = req.body as {
+      title: string;
+      format?: string;
+      body: string;
+      changeSummary?: string | null;
+      baseRevisionId?: string | null;
+      scope?: string;
+      scopeId?: string | null;
+    };
+
+    if (!title || typeof title !== "string") {
+      res.status(400).json({ error: "title is required" });
+      return;
+    }
+    if (!body || typeof body !== "string") {
+      res.status(400).json({ error: "body is required" });
+      return;
+    }
+
+    const result = await policiesSvc.upsertPolicy(id, key, {
+      title,
+      format,
+      body,
+      changeSummary: changeSummary ?? null,
+      baseRevisionId: baseRevisionId ?? null,
+      scope,
+      scopeId: scopeId ?? null,
+      createdByAgentId: actor.agentId ?? null,
+      createdByUserId: actor.actorType === "user" ? actor.actorId : null,
+    });
+
+    await logActivity(db, {
+      companyId: agent.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: result.created ? "agent.policy_created" : "agent.policy_updated",
+      entityType: "agent",
+      entityId: id,
+      details: { key },
+    });
+
+    res.status(result.created ? 201 : 200).json(result.policy);
+  });
+
+  router.delete("/agents/:id/policies/:key", async (req, res) => {
+    const id = req.params.id as string;
+    const key = req.params.key as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
+
+    const actor = getActorInfo(req);
+    const policy = await policiesSvc.deactivatePolicy(id, key);
+
+    await logActivity(db, {
+      companyId: agent.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "agent.policy_deactivated",
+      entityType: "agent",
+      entityId: id,
+      details: { key },
+    });
+
+    res.json(policy);
+  });
+
+  router.get("/agents/:id/policies/:key/revisions", async (req, res) => {
+    const id = req.params.id as string;
+    const key = req.params.key as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
+
+    const revisions = await policiesSvc.listRevisions(id, key);
+    res.json(revisions);
+  });
+
+  router.post("/agents/:id/policies/:key/rollback", async (req, res) => {
+    const id = req.params.id as string;
+    const key = req.params.key as string;
+    const agent = await svc.getById(id);
+    if (!agent) {
+      res.status(404).json({ error: "Agent not found" });
+      return;
+    }
+    assertCompanyAccess(req, agent.companyId);
+
+    const { targetRevisionId } = req.body as { targetRevisionId: string };
+    if (!targetRevisionId || typeof targetRevisionId !== "string") {
+      res.status(400).json({ error: "targetRevisionId is required" });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    const policy = await policiesSvc.rollbackPolicy(id, key, targetRevisionId, {
+      agentId: actor.agentId ?? null,
+      userId: actor.actorType === "user" ? actor.actorId : null,
+    });
+
+    await logActivity(db, {
+      companyId: agent.companyId,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: "agent.policy_rolled_back",
+      entityType: "agent",
+      entityId: id,
+      details: { key, targetRevisionId },
+    });
+
+    res.json(policy);
   });
 
   return router;

--- a/server/src/services/agent-policies.ts
+++ b/server/src/services/agent-policies.ts
@@ -1,0 +1,331 @@
+import { and, asc, desc, eq } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agentPolicies, agentPolicyRevisions, agents as agentsTable } from "@paperclipai/db";
+import { conflict, notFound } from "../errors.js";
+
+export interface AgentPolicy {
+  id: string;
+  companyId: string;
+  agentId: string;
+  key: string;
+  title: string;
+  format: string;
+  latestBody: string;
+  latestRevisionId: string | null;
+  latestRevisionNumber: number;
+  scope: string;
+  scopeId: string | null;
+  active: boolean;
+  createdByAgentId: string | null;
+  createdByUserId: string | null;
+  updatedByAgentId: string | null;
+  updatedByUserId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface AgentPolicyRevision {
+  id: string;
+  policyId: string;
+  revisionNumber: number;
+  title: string;
+  body: string;
+  changeSummary: string | null;
+  createdByAgentId: string | null;
+  createdByUserId: string | null;
+  createdAt: Date;
+}
+
+function rowToPolicy(row: typeof agentPolicies.$inferSelect): AgentPolicy {
+  return {
+    id: row.id,
+    companyId: row.companyId,
+    agentId: row.agentId,
+    key: row.key,
+    title: row.title,
+    format: row.format,
+    latestBody: row.latestBody,
+    latestRevisionId: row.latestRevisionId ?? null,
+    latestRevisionNumber: row.latestRevisionNumber,
+    scope: row.scope,
+    scopeId: row.scopeId ?? null,
+    active: row.active,
+    createdByAgentId: row.createdByAgentId ?? null,
+    createdByUserId: row.createdByUserId ?? null,
+    updatedByAgentId: row.updatedByAgentId ?? null,
+    updatedByUserId: row.updatedByUserId ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function rowToRevision(row: typeof agentPolicyRevisions.$inferSelect): AgentPolicyRevision {
+  return {
+    id: row.id,
+    policyId: row.policyId,
+    revisionNumber: row.revisionNumber,
+    title: row.title,
+    body: row.body,
+    changeSummary: row.changeSummary ?? null,
+    createdByAgentId: row.createdByAgentId ?? null,
+    createdByUserId: row.createdByUserId ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+export function agentPoliciesService(db: Db) {
+  return {
+    listPolicies: async (
+      agentId: string,
+      filters?: { active?: boolean; scope?: string },
+    ): Promise<AgentPolicy[]> => {
+      const conditions = [eq(agentPolicies.agentId, agentId)];
+      if (filters?.active !== undefined) {
+        conditions.push(eq(agentPolicies.active, filters.active));
+      }
+      if (filters?.scope !== undefined) {
+        conditions.push(eq(agentPolicies.scope, filters.scope));
+      }
+      const rows = await db
+        .select()
+        .from(agentPolicies)
+        .where(and(...conditions))
+        .orderBy(desc(agentPolicies.updatedAt));
+      return rows.map(rowToPolicy);
+    },
+
+    getPolicy: async (agentId: string, key: string): Promise<AgentPolicy | null> => {
+      const rows = await db
+        .select()
+        .from(agentPolicies)
+        .where(and(eq(agentPolicies.agentId, agentId), eq(agentPolicies.key, key)));
+      return rows[0] ? rowToPolicy(rows[0]) : null;
+    },
+
+    upsertPolicy: async (
+      agentId: string,
+      key: string,
+      input: {
+        title: string;
+        format?: string;
+        body: string;
+        changeSummary?: string | null;
+        baseRevisionId?: string | null;
+        scope?: string;
+        scopeId?: string | null;
+        createdByAgentId?: string | null;
+        createdByUserId?: string | null;
+      },
+    ): Promise<{ created: boolean; policy: AgentPolicy }> => {
+      return await db.transaction(async (tx) => {
+        const now = new Date();
+        const existing = await tx
+          .select()
+          .from(agentPolicies)
+          .where(and(eq(agentPolicies.agentId, agentId), eq(agentPolicies.key, key)))
+          .then((rows) => rows[0] ?? null);
+
+        if (existing) {
+          if (!input.baseRevisionId) {
+            throw conflict("Policy update requires baseRevisionId", {
+              currentRevisionId: existing.latestRevisionId,
+            });
+          }
+          if (input.baseRevisionId !== existing.latestRevisionId) {
+            throw conflict("Policy was updated by someone else", {
+              currentRevisionId: existing.latestRevisionId,
+            });
+          }
+
+          const nextRevisionNumber = existing.latestRevisionNumber + 1;
+          const [revision] = await tx
+            .insert(agentPolicyRevisions)
+            .values({
+              policyId: existing.id,
+              revisionNumber: nextRevisionNumber,
+              title: input.title,
+              body: input.body,
+              changeSummary: input.changeSummary ?? null,
+              createdByAgentId: input.createdByAgentId ?? null,
+              createdByUserId: input.createdByUserId ?? null,
+              createdAt: now,
+            })
+            .returning();
+
+          const [updated] = await tx
+            .update(agentPolicies)
+            .set({
+              title: input.title,
+              format: input.format ?? existing.format,
+              latestBody: input.body,
+              latestRevisionId: revision.id,
+              latestRevisionNumber: nextRevisionNumber,
+              updatedByAgentId: input.createdByAgentId ?? null,
+              updatedByUserId: input.createdByUserId ?? null,
+              updatedAt: now,
+            })
+            .where(eq(agentPolicies.id, existing.id))
+            .returning();
+
+          return { created: false, policy: rowToPolicy(updated) };
+        }
+
+        // New policy — resolve companyId from agents table
+        const agentRow = await tx
+          .select({ companyId: agentsTable.companyId })
+          .from(agentsTable)
+          .where(eq(agentsTable.id, agentId))
+          .then((rows) => rows[0] ?? null);
+        if (!agentRow) throw notFound("Agent not found");
+
+        const [policy] = await tx
+          .insert(agentPolicies)
+          .values({
+            companyId: agentRow.companyId,
+            agentId,
+            key,
+            title: input.title,
+            format: input.format ?? "markdown",
+            latestBody: input.body,
+            latestRevisionId: null,
+            latestRevisionNumber: 0,
+            scope: input.scope ?? "agent",
+            scopeId: input.scopeId ?? null,
+            active: true,
+            createdByAgentId: input.createdByAgentId ?? null,
+            createdByUserId: input.createdByUserId ?? null,
+            updatedByAgentId: input.createdByAgentId ?? null,
+            updatedByUserId: input.createdByUserId ?? null,
+            createdAt: now,
+            updatedAt: now,
+          })
+          .returning();
+
+        const [revision] = await tx
+          .insert(agentPolicyRevisions)
+          .values({
+            policyId: policy.id,
+            revisionNumber: 1,
+            title: input.title,
+            body: input.body,
+            changeSummary: input.changeSummary ?? null,
+            createdByAgentId: input.createdByAgentId ?? null,
+            createdByUserId: input.createdByUserId ?? null,
+            createdAt: now,
+          })
+          .returning();
+
+        const [final] = await tx
+          .update(agentPolicies)
+          .set({ latestRevisionId: revision.id, latestRevisionNumber: 1 })
+          .where(eq(agentPolicies.id, policy.id))
+          .returning();
+
+        return { created: true, policy: rowToPolicy(final) };
+      });
+    },
+
+    deactivatePolicy: async (agentId: string, key: string): Promise<AgentPolicy> => {
+      const existing = await db
+        .select()
+        .from(agentPolicies)
+        .where(and(eq(agentPolicies.agentId, agentId), eq(agentPolicies.key, key)))
+        .then((rows) => rows[0] ?? null);
+      if (!existing) throw notFound("Policy not found");
+
+      const [updated] = await db
+        .update(agentPolicies)
+        .set({ active: false, updatedAt: new Date() })
+        .where(eq(agentPolicies.id, existing.id))
+        .returning();
+
+      return rowToPolicy(updated);
+    },
+
+    listRevisions: async (agentId: string, key: string): Promise<AgentPolicyRevision[]> => {
+      const policy = await db
+        .select()
+        .from(agentPolicies)
+        .where(and(eq(agentPolicies.agentId, agentId), eq(agentPolicies.key, key)))
+        .then((rows) => rows[0] ?? null);
+      if (!policy) throw notFound("Policy not found");
+
+      const rows = await db
+        .select()
+        .from(agentPolicyRevisions)
+        .where(eq(agentPolicyRevisions.policyId, policy.id))
+        .orderBy(asc(agentPolicyRevisions.revisionNumber));
+
+      return rows.map(rowToRevision);
+    },
+
+    rollbackPolicy: async (
+      agentId: string,
+      key: string,
+      targetRevisionId: string,
+      actor?: { agentId?: string | null; userId?: string | null },
+    ): Promise<AgentPolicy> => {
+      return await db.transaction(async (tx) => {
+        const now = new Date();
+        const existing = await tx
+          .select()
+          .from(agentPolicies)
+          .where(and(eq(agentPolicies.agentId, agentId), eq(agentPolicies.key, key)))
+          .then((rows) => rows[0] ?? null);
+        if (!existing) throw notFound("Policy not found");
+
+        const targetRevision = await tx
+          .select()
+          .from(agentPolicyRevisions)
+          .where(
+            and(
+              eq(agentPolicyRevisions.id, targetRevisionId),
+              eq(agentPolicyRevisions.policyId, existing.id),
+            ),
+          )
+          .then((rows) => rows[0] ?? null);
+        if (!targetRevision) throw notFound("Revision not found");
+
+        const nextRevisionNumber = existing.latestRevisionNumber + 1;
+        const [revision] = await tx
+          .insert(agentPolicyRevisions)
+          .values({
+            policyId: existing.id,
+            revisionNumber: nextRevisionNumber,
+            title: targetRevision.title,
+            body: targetRevision.body,
+            changeSummary: `Rollback to revision ${targetRevision.revisionNumber}`,
+            createdByAgentId: actor?.agentId ?? null,
+            createdByUserId: actor?.userId ?? null,
+            createdAt: now,
+          })
+          .returning();
+
+        const [updated] = await tx
+          .update(agentPolicies)
+          .set({
+            title: targetRevision.title,
+            latestBody: targetRevision.body,
+            latestRevisionId: revision.id,
+            latestRevisionNumber: nextRevisionNumber,
+            updatedByAgentId: actor?.agentId ?? null,
+            updatedByUserId: actor?.userId ?? null,
+            updatedAt: now,
+          })
+          .where(eq(agentPolicies.id, existing.id))
+          .returning();
+
+        return rowToPolicy(updated);
+      });
+    },
+
+    getActivePoliciesForAgent: async (agentId: string): Promise<AgentPolicy[]> => {
+      const rows = await db
+        .select()
+        .from(agentPolicies)
+        .where(and(eq(agentPolicies.agentId, agentId), eq(agentPolicies.active, true)))
+        .orderBy(asc(agentPolicies.createdAt));
+      return rows.map(rowToPolicy);
+    },
+  };
+}

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -2,6 +2,7 @@ export { companyService } from "./companies.js";
 export { feedbackService } from "./feedback.js";
 export { companySkillService } from "./company-skills.js";
 export { agentService, deduplicateAgentName } from "./agents.js";
+export { agentPoliciesService, type AgentPolicy, type AgentPolicyRevision } from "./agent-policies.js";
 export { agentInstructionsService, syncInstructionsBundleConfigFromFilePath } from "./agent-instructions.js";
 export { assetService } from "./assets.js";
 export { documentService, extractLegacyPlanBody } from "./documents.js";


### PR DESCRIPTION
Rebased onto current master with migration renumbered from 0047 → 0056 to avoid conflicts with upstream migrations 0047–0055.

Original branch had 1489 commits to rebase; instead cherry-picked only the ANGA-182 commit cleanly onto master.

- `packages/db/src/migrations/0056_agent_policies.sql`
- `packages/db/src/schema/agent_policies.ts`
- `packages/db/src/schema/agent_policy_revisions.ts`
- `server/src/services/agent-policies.ts`
- `server/src/routes/agents.ts` (versioned policy endpoint)

Blocks: ANGA-183 (adapter policy wiring)