### PR TITLE
feat(heartbeat,claude-local): wire agent policies into adapter execution context

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -350,9 +350,27 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const billingType = resolveClaudeBillingType(effectiveEnv);
   const claudeSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredSkillNames = new Set(resolveClaudeDesiredSkillNames(config, claudeSkillEntries));
+
+  // Inject active agent policies from execution context into the instructions content.
+  const rawPolicies = Array.isArray(context.paperclipAgentPolicies)
+    ? (context.paperclipAgentPolicies as Array<{ key?: unknown; title?: unknown; body?: unknown }>)
+    : [];
+  const policySection =
+    rawPolicies.length > 0
+      ? "\n\n# Agent Policies\n\n" +
+        rawPolicies
+          .map((p) => {
+            const title = typeof p.title === "string" ? p.title : String(p.key ?? "");
+            const body = typeof p.body === "string" ? p.body : "";
+            return `## ${title}\n\n${body}`;
+          })
+          .join("\n\n")
+      : "";
+
   // When instructionsFilePath is configured, build a stable content-addressed
   // file that includes both the file content and the path directive, so we only
   // need --append-system-prompt-file (Claude CLI forbids using both flags together).
+  // Also appends any active agent policies from the execution context.
   let combinedInstructionsContents: string | null = null;
   if (instructionsFilePath) {
     try {
@@ -362,7 +380,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `Resolve any relative file references from ${instructionsFileDir}. ` +
         `This base directory is authoritative for sibling instruction files such as ` +
         `./HEARTBEAT.md, ./SOUL.md, and ./TOOLS.md; do not resolve those from the parent agent directory.`;
-      combinedInstructionsContents = instructionsContent + pathDirective;
+      combinedInstructionsContents = instructionsContent + pathDirective + policySection;
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       await onLog(
@@ -370,6 +388,9 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
         `[paperclip] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
       );
     }
+  } else if (policySection) {
+    // No instructions file but we have policies — use policy content as instructions.
+    combinedInstructionsContents = policySection.trimStart();
   }
   const promptBundle = await prepareClaudePromptBundle({
     companyId: agent.companyId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -78,6 +78,7 @@ import {
   skillInvocationDurationSeconds,
   isMetricsEnabled,
 } from "../observability/metrics.js";
+import { agentPoliciesService } from "./agent-policies.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 // Terminal statuses for heartbeatRuns (matches HeartbeatRunStatus from @paperclipai/shared).
@@ -3685,6 +3686,24 @@ export function heartbeatService(db: Db) {
         });
         activeRunExecutions.delete(run.id);
         return;
+      }
+      // Inject active agent policies into execution context so adapters can
+      // consume learned runtime behavior without touching adapterConfig.
+      try {
+        const activePolicies = await agentPoliciesService(db).getActivePoliciesForAgent(agent.id);
+        if (activePolicies.length > 0) {
+          context.paperclipAgentPolicies = activePolicies.map((p) => ({
+            key: p.key,
+            title: p.title,
+            format: p.format,
+            body: p.latestBody,
+          }));
+        }
+      } catch (err) {
+        logger.warn(
+          { agentId: agent.id, runId: run.id, err },
+          "failed to load agent policies; continuing without them",
+        );
       }
       let executedAdapterType = agent.adapterType;
 


### PR DESCRIPTION
Depends on #12

Closes ANGA-183

## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- ANGA-182 added the agent policies data layer
- Policies were stored but not consumed at runtime
- This PR wires them into heartbeat executeRun() and the claude_local adapter
- Agents now behave according to learned policies without touching adapterConfig

## What Changed

- heartbeat.ts: query active policies before adapter.execute(), attach as context.paperclipAgentPolicies; errors caught/logged
- execute.ts (claude-local): read from context, build policy section, append to system prompt; create policy-only file if no instructionsFilePath
- Agents with no active policies: no change in behavior

## Verification

- pnpm tsc --noEmit: no errors
- No active policies: run proceeds unchanged
- Active policy: appears in system prompt under Agent Policies heading
- Policy fetch error: logged as warning, run continues

## Risks

- Policy query failure silently caught
- Depends on ANGA-182 merging first

## Checklist

- [x] Thinking path
- [x] tsc passes
- [x] Risks documented