### PR TITLE
feat(heartbeat): add memory pre-flight gate and process-lost telemetry (ANGA-165)

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
@@ -67,6 +68,7 @@ const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";
 const DETACHED_PROCESS_ERROR_CODE = "process_detached";
+const LOW_MEMORY_THRESHOLD_BYTES = 2 * 1024 * 1024 * 1024; // 2 GB — defer spawn if free memory is below this
 const startLocksByAgent = new Map<string, Promise<void>>();
 const REPO_ONLY_CWD_SENTINEL = "/__paperclip_repo_only__";
 const MANAGED_WORKSPACE_GIT_CLONE_TIMEOUT_MS = 10 * 60 * 1000;
@@ -1929,6 +1931,8 @@ export function heartbeatService(db: Db) {
         payload: {
           ...(run.processPid ? { processPid: run.processPid } : {}),
           ...(retriedRun ? { retryRunId: retriedRun.id } : {}),
+          freeMemBytes: os.freemem(),
+          totalMemBytes: os.totalmem(),
         },
       });
 
@@ -2655,6 +2659,29 @@ export function heartbeatService(db: Db) {
           },
           "local agent jwt secret missing or invalid; running without injected PAPERCLIP_API_KEY",
         );
+      }
+      // Memory pre-flight: defer if OS free memory is below threshold to avoid OOM kills
+      const freeMemBytes = os.freemem();
+      if (freeMemBytes < LOW_MEMORY_THRESHOLD_BYTES) {
+        const freeMemMB = Math.round(freeMemBytes / (1024 * 1024));
+        const totalMemMB = Math.round(os.totalmem() / (1024 * 1024));
+        logger.warn(
+          { runId: run.id, agentId: agent.id, freeMemMB, totalMemMB },
+          "low memory: deferring run back to queued",
+        );
+        await db
+          .update(heartbeatRuns)
+          .set({ status: "queued", updatedAt: new Date() })
+          .where(eq(heartbeatRuns.id, run.id));
+        await appendRunEvent(run, await nextRunEventSeq(run.id), {
+          eventType: "lifecycle",
+          stream: "system",
+          level: "warn",
+          message: `Deferred: insufficient free memory (${freeMemMB} MB free of ${totalMemMB} MB total); will retry on next scheduler tick`,
+          payload: { freeMemBytes, totalMemBytes: os.totalmem() },
+        });
+        activeRunExecutions.delete(run.id);
+        return;
       }
       let adapterResult = await adapter.execute({
         runId: run.id,


### PR DESCRIPTION
## Summary

- Adds a memory availability pre-flight check before spawning adapter child processes in `heartbeat.ts`
- If free memory < 2 GB threshold (`LOW_MEMORY_THRESHOLD_BYTES`), defers run to `queued` state with a system event explaining the deferral — prevents Windows OOM kills on constrained systems
- Deferred runs re-enter `resumeQueuedRuns()` on the next scheduler tick automatically
- Adds `freeMemBytes` + `totalMemBytes` to the `process_lost` event payload in `reapOrphanedRuns()` for better post-mortem diagnostics

## Motivation

Root cause analysis in [ANGA-158](/ANGA/issues/ANGA-158): system has 31.9 GB RAM but only 1.8 GB free (5.7%) with 3 concurrent agent processes. Windows silently OOM-kills child processes, causing process_lost events. The single retry re-spawns under the same memory pressure and also gets killed.

## Test plan
- [ ] `heartbeat-process-recovery.test.ts`: 4/4 tests pass
- [ ] No new dependencies
- [ ] Threshold configurable via `LOW_MEMORY_THRESHOLD_BYTES` constant (default 2 GB)
- [ ] Deferred run events include deferral reason

Closes [ANGA-165](/ANGA/issues/ANGA-165)

🤖 PR opened by CTO agent on behalf of Dev Agent — Platform ([ANGA-165](/ANGA/issues/ANGA-165))