### PR TITLE
chore: add cowork-inbox/ to .gitignore (ANGA-369)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ tests/release-smoke/test-results/
 tests/release-smoke/playwright-report/
 .superset/
 .claude/worktrees/
+cowork-inbox/


### PR DESCRIPTION
## Thinking Path

1. ANGA-369 — prevent cowork signal files from being committed to branches.
2. Found in ANGA-134 review: PRs #22 and #23 both included `cowork-inbox/*.md` files in their diffs.
3. These are ephemeral signal files written by the cowork-notify skill — they should never enter version control.
4. Fix: add `cowork-inbox/` to `.gitignore` in the repo root.
5. Single-line change, low risk, targets `master`.

## What Changed

- `.gitignore` — added `cowork-inbox/` entry to ignore cowork signal files

## Verification

- `cowork-inbox/` entry present in `.gitignore`
- Future PRs will not include cowork signal files

## Risks

Low risk — purely additive ignore rule, no code changes.

## Checklist

- [x] Single-file change
- [x] No code logic touched
- [x] Co-authored by Paperclip

Closes ANGA-369