### PR TITLE
fix: retry process-lost runs on assigneeAgentId, not executorAgentId

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -345,6 +345,46 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(issue?.executionRunId).toBe(retryRun?.id ?? null);
   });
 
+  it("retries on assigneeAgentId when executor differs from assignee", async () => {
+    // Scenario: CTO (executorAgentId) created the run while the task was
+    // assigned to Dev Agent (assigneeAgentId).  Retry must wake Dev Agent.
+    const { companyId, agentId: executorAgentId, runId, issueId } = await seedRunFixture({
+      processPid: 999_999_999,
+    });
+
+    // Add a separate assignee agent and re-assign the issue to them.
+    const assigneeAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "DevAgentPlatform",
+      role: "engineer",
+      status: "paused",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db
+      .update(issues)
+      .set({ assigneeAgentId })
+      .where(eq(issues.id, issueId));
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reapOrphanedRuns();
+    expect(result.reaped).toBe(1);
+
+    // Retry run must belong to the assignee, not the executor.
+    const allRuns = await db.select().from(heartbeatRuns);
+    const retryRun = allRuns.find((r) => r.id !== runId);
+    expect(retryRun?.agentId).toBe(assigneeAgentId);
+    expect(retryRun?.agentId).not.toBe(executorAgentId);
+
+    const wakeups = await db.select().from(agentWakeupRequests);
+    const retryWakeup = wakeups.find((w) => w.runId === retryRun?.id);
+    expect(retryWakeup?.agentId).toBe(assigneeAgentId);
+  });
+
   it("does not queue a second retry after the first process-loss retry was already used", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
       processPid: 999_999_999,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2492,7 +2492,7 @@ export function heartbeatService(db: Db) {
         .insert(agentWakeupRequests)
         .values({
           companyId: run.companyId,
-          agentId: run.agentId,
+          agentId: agent.id,
           source: "automation",
           triggerDetail: "system",
           reason: "process_lost_retry",
@@ -2512,7 +2512,7 @@ export function heartbeatService(db: Db) {
         .insert(heartbeatRuns)
         .values({
           companyId: run.companyId,
-          agentId: run.agentId,
+          agentId: agent.id,
           invocationSource: "automation",
           triggerDetail: "system",
           status: "queued",
@@ -2801,7 +2801,23 @@ export function heartbeatService(db: Db) {
 
       let retriedRun: typeof heartbeatRuns.$inferSelect | null = null;
       if (shouldRetry) {
-        const agent = await getAgent(run.agentId);
+        // Prefer the issue's assigneeAgentId over the run's agentId so that
+        // a task assigned to Agent A but last executed by Agent B retries on
+        // Agent A (the true owner), not Agent B.
+        const contextSnapshot = parseObject(finalizedRun.contextSnapshot);
+        const issueId = readNonEmptyString(contextSnapshot.issueId);
+        let targetAgentId = run.agentId;
+        if (issueId) {
+          const issueRow = await db
+            .select({ assigneeAgentId: issues.assigneeAgentId })
+            .from(issues)
+            .where(eq(issues.id, issueId))
+            .then((rows) => rows[0] ?? null);
+          if (issueRow?.assigneeAgentId) {
+            targetAgentId = issueRow.assigneeAgentId;
+          }
+        }
+        const agent = await getAgent(targetAgentId);
         if (agent) {
           retriedRun = await enqueueProcessLossRetry(finalizedRun, agent, now);
         }


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Each agent run tracks which agent is executing a task via executionRunId
> - When a local process is lost, Paperclip enqueues a retry run
> - The retry resolved the target agent from run.agentId (the executor), not the task's assigneeAgentId
> - When Agent B (CTO) creates a task assigned to Agent A (Dev Agent), retries kept waking Agent B
> - Agent B always hit 409 on checkout because Agent A held the lock, creating an infinite loop
> - This PR fixes retry to prefer assigneeAgentId over run.agentId

## What Changed

- `server/src/services/heartbeat.ts` — In reapOrphanedRuns: look up the issue's assigneeAgentId and use it as the wake target if set; fall back to run.agentId for unassigned tasks.
- `server/src/services/heartbeat.ts` — enqueueProcessLossRetry now uses agent.id instead of run.agentId directly, honoring the passed agent parameter.
- `server/src/__tests__/heartbeat-process-recovery.test.ts` — New regression test: "retries on assigneeAgentId when executor differs from assignee".

## Verification

Run: pnpm vitest run server/src/__tests__/heartbeat-process-recovery.test.ts

8 tests pass (7 existing + 1 new). New test fails without the fix, passes with it.

## Risks

Low risk. Only affects the shouldRetry path in reapOrphanedRuns, fires at most once per process-loss. Fallback to run.agentId preserves behavior for unassigned tasks. No schema changes.

## Checklist

- [x] Thinking path included
- [x] Tests pass locally
- [x] New regression test added
- [x] Risks documented
- [x] Will address all reviewer comments before requesting merge