### PR TITLE
feat(issues): scaffold Objective/Scope/Verification on issue creation

### DIFF
--- a/server/src/__tests__/issue-template-scaffold-routes.test.ts
+++ b/server/src/__tests__/issue-template-scaffold-routes.test.ts
@@ -1,0 +1,235 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { issueRoutes } from "../routes/issues.js";
+import { errorHandler } from "../middleware/index.js";
+import { REQUIRED_SECTIONS } from "../issue-template-scaffold.js";
+
+const mockIssueService = vi.hoisted(() => ({
+  create: vi.fn(),
+  getById: vi.fn(),
+  getAncestors: vi.fn(),
+  findMentionedProjectIds: vi.fn(),
+  getCommentCursor: vi.fn(),
+  getComment: vi.fn(),
+}));
+
+vi.mock("../services/index.js", () => ({
+  accessService: () => ({
+    canUser: vi.fn(),
+    hasPermission: vi.fn(),
+  }),
+  agentService: () => ({
+    getById: vi.fn(),
+  }),
+  documentService: () => ({
+    getIssueDocumentPayload: vi.fn(async () => ({})),
+  }),
+  executionWorkspaceService: () => ({
+    getById: vi.fn(),
+  }),
+  goalService: () => ({
+    getById: vi.fn(),
+    getDefaultCompanyGoal: vi.fn(),
+  }),
+  heartbeatService: () => ({
+    wakeup: vi.fn(async () => undefined),
+    reportRunActivity: vi.fn(async () => undefined),
+  }),
+  issueApprovalService: () => ({}),
+  issueService: () => mockIssueService,
+  logActivity: vi.fn(async () => undefined),
+  projectService: () => ({
+    getById: vi.fn(),
+    listByIds: vi.fn(),
+  }),
+  routineService: () => ({
+    syncRunStatusForIssue: vi.fn(async () => undefined),
+  }),
+  workProductService: () => ({
+    listForIssue: vi.fn(async () => []),
+  }),
+}));
+
+vi.mock("../services/issue-assignment-wakeup.js", () => ({
+  queueIssueAssignmentWakeup: vi.fn(),
+}));
+
+function makeCreatedIssue(description: string) {
+  return {
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    companyId: "company-1",
+    identifier: "PAP-1",
+    title: "Test issue",
+    description,
+    status: "backlog",
+    priority: "medium",
+    projectId: null,
+    goalId: null,
+    parentId: null,
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    createdByAgentId: null,
+    createdByUserId: "local-board",
+    labels: [],
+    labelIds: [],
+    updatedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "board",
+      userId: "local-board",
+      companyIds: ["company-1"],
+      source: "local_implicit",
+      isInstanceAdmin: false,
+    };
+    next();
+  });
+  app.use("/api", issueRoutes({} as any, {} as any));
+  app.use(errorHandler);
+  return app;
+}
+
+const FULL_DESCRIPTION =
+  "## Objective\n\nDo something\n\n## Scope\n\n**Touch:** foo\n**Do not touch:** bar\n\n## Verification\n\n- [ ] it works";
+
+describe("POST /api/companies/:companyId/issues — scaffold mode (default)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.PAPERCLIP_SPEC_ENFORCE;
+  });
+
+  afterEach(() => {
+    delete process.env.PAPERCLIP_SPEC_ENFORCE;
+  });
+
+  it("scaffolds description when description is missing", async () => {
+    mockIssueService.create.mockImplementation((_cid: string, data: { description: string }) =>
+      Promise.resolve(makeCreatedIssue(data.description)),
+    );
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({ title: "My task" });
+
+    expect(res.status).toBe(201);
+    for (const section of REQUIRED_SECTIONS) {
+      expect(res.body.description).toContain(section);
+    }
+  });
+
+  it("scaffolds description when description is empty string", async () => {
+    mockIssueService.create.mockImplementation((_cid: string, data: { description: string }) =>
+      Promise.resolve(makeCreatedIssue(data.description)),
+    );
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({ title: "My task", description: "" });
+
+    expect(res.status).toBe(201);
+    for (const section of REQUIRED_SECTIONS) {
+      expect(res.body.description).toContain(section);
+    }
+  });
+
+  it("passes description through unchanged when all sections are present", async () => {
+    mockIssueService.create.mockImplementation((_cid: string, data: { description: string }) =>
+      Promise.resolve(makeCreatedIssue(data.description)),
+    );
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({ title: "My task", description: FULL_DESCRIPTION });
+
+    expect(res.status).toBe(201);
+    expect(res.body.description).toBe(FULL_DESCRIPTION);
+  });
+
+  it("appends only missing sections when description is partial", async () => {
+    mockIssueService.create.mockImplementation((_cid: string, data: { description: string }) =>
+      Promise.resolve(makeCreatedIssue(data.description)),
+    );
+
+    const partialDesc = "## Objective\n\nDo something important";
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({ title: "My task", description: partialDesc });
+
+    expect(res.status).toBe(201);
+    // Original objective section preserved
+    expect(res.body.description).toContain("Do something important");
+    // Missing sections appended
+    expect(res.body.description).toContain("## Scope");
+    expect(res.body.description).toContain("## Verification");
+    // Objective NOT duplicated
+    expect(res.body.description.split("## Objective").length).toBe(2);
+  });
+});
+
+describe("POST /api/companies/:companyId/issues — strict mode (PAPERCLIP_SPEC_ENFORCE=strict)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.PAPERCLIP_SPEC_ENFORCE = "strict";
+  });
+
+  afterEach(() => {
+    delete process.env.PAPERCLIP_SPEC_ENFORCE;
+  });
+
+  it("returns 400 when description is missing", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({ title: "My task" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Objective/);
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when description lacks required sections", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({ title: "My task", description: "Just some text without sections" });
+
+    expect(res.status).toBe(400);
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+
+  it("allows creation when description has all required sections", async () => {
+    mockIssueService.create.mockResolvedValue(makeCreatedIssue(FULL_DESCRIPTION));
+
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({ title: "My task", description: FULL_DESCRIPTION });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.create).toHaveBeenCalledOnce();
+  });
+
+  it("returns 400 when only Objective and Scope are present", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .post("/api/companies/company-1/issues")
+      .send({
+        title: "My task",
+        description: "## Objective\n\nDo stuff\n\n## Scope\n\nTouch: foo",
+      });
+
+    expect(res.status).toBe(400);
+    expect(mockIssueService.create).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/issue-template-scaffold.test.ts
+++ b/server/src/__tests__/issue-template-scaffold.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getSpecEnforceMode,
+  hasAllRequiredSections,
+  REQUIRED_SECTIONS,
+  scaffoldDescription,
+} from "../issue-template-scaffold.js";
+
+describe("hasAllRequiredSections", () => {
+  it("returns false for null", () => {
+    expect(hasAllRequiredSections(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(hasAllRequiredSections(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(hasAllRequiredSections("")).toBe(false);
+  });
+
+  it("returns false when only some sections are present", () => {
+    expect(hasAllRequiredSections("## Objective\n\nDo stuff")).toBe(false);
+    expect(hasAllRequiredSections("## Objective\n\nDo stuff\n\n## Scope\n\nTouch: foo")).toBe(false);
+  });
+
+  it("returns true when all three sections are present", () => {
+    const desc = "## Objective\n\nDo stuff\n\n## Scope\n\nTouch: foo\n\n## Verification\n\n- [ ] check";
+    expect(hasAllRequiredSections(desc)).toBe(true);
+  });
+
+  it("returns true even when extra sections are present", () => {
+    const desc =
+      "## Context\n\nBackground\n\n## Objective\n\nDo stuff\n\n## Scope\n\nTouch: foo\n\n## Verification\n\n- [ ] check\n\n## Notes\n\nExtra";
+    expect(hasAllRequiredSections(desc)).toBe(true);
+  });
+});
+
+describe("scaffoldDescription", () => {
+  it("returns scaffold with all three sections when description is null", () => {
+    const result = scaffoldDescription(null);
+    for (const section of REQUIRED_SECTIONS) {
+      expect(result).toContain(section);
+    }
+  });
+
+  it("returns scaffold with all three sections when description is undefined", () => {
+    const result = scaffoldDescription(undefined);
+    for (const section of REQUIRED_SECTIONS) {
+      expect(result).toContain(section);
+    }
+  });
+
+  it("returns scaffold with all three sections when description is empty string", () => {
+    const result = scaffoldDescription("");
+    for (const section of REQUIRED_SECTIONS) {
+      expect(result).toContain(section);
+    }
+  });
+
+  it("passes through unchanged when all sections are already present", () => {
+    const desc = "## Objective\n\nDo stuff\n\n## Scope\n\nTouch: foo\n\n## Verification\n\n- [ ] check";
+    expect(scaffoldDescription(desc)).toBe(desc);
+  });
+
+  it("appends only the missing sections when description is partial (Objective only)", () => {
+    const desc = "## Objective\n\nDo stuff";
+    const result = scaffoldDescription(desc);
+    expect(result).toContain("## Objective");
+    expect(result).toContain("## Scope");
+    expect(result).toContain("## Verification");
+    // Original content preserved
+    expect(result).toContain("Do stuff");
+    // Objective section NOT duplicated
+    expect(result.indexOf("## Objective")).toBe(result.lastIndexOf("## Objective"));
+  });
+
+  it("appends only the missing sections when description has Objective and Scope but not Verification", () => {
+    const desc = "## Objective\n\nDo stuff\n\n## Scope\n\nTouch: foo";
+    const result = scaffoldDescription(desc);
+    expect(result).toContain("## Verification");
+    // Objective and Scope are not duplicated
+    expect(result.split("## Objective").length).toBe(2);
+    expect(result.split("## Scope").length).toBe(2);
+  });
+});
+
+describe("getSpecEnforceMode", () => {
+  const originalEnv = process.env.PAPERCLIP_SPEC_ENFORCE;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.PAPERCLIP_SPEC_ENFORCE;
+    } else {
+      process.env.PAPERCLIP_SPEC_ENFORCE = originalEnv;
+    }
+  });
+
+  it("returns scaffold when env var is not set", () => {
+    delete process.env.PAPERCLIP_SPEC_ENFORCE;
+    expect(getSpecEnforceMode()).toBe("scaffold");
+  });
+
+  it("returns strict when env var is set to strict", () => {
+    process.env.PAPERCLIP_SPEC_ENFORCE = "strict";
+    expect(getSpecEnforceMode()).toBe("strict");
+  });
+
+  it("returns scaffold for any other value", () => {
+    process.env.PAPERCLIP_SPEC_ENFORCE = "soft";
+    expect(getSpecEnforceMode()).toBe("scaffold");
+    process.env.PAPERCLIP_SPEC_ENFORCE = "1";
+    expect(getSpecEnforceMode()).toBe("scaffold");
+  });
+});

--- a/server/src/issue-template-scaffold.ts
+++ b/server/src/issue-template-scaffold.ts
@@ -1,0 +1,47 @@
+/**
+ * Soft-scaffold and validation helpers for the Objective/Scope/Verification
+ * harness spec format enforced at issue creation time.
+ *
+ * Controlled by the PAPERCLIP_SPEC_ENFORCE environment variable:
+ *   (unset / anything other than "strict") — scaffold mode: missing sections
+ *     are appended automatically so the path of least resistance is compliance.
+ *   "strict" — hard-reject mode: a POST /api/companies/:companyId/issues
+ *     request whose description is missing any required section returns HTTP 400.
+ */
+
+export const REQUIRED_SECTIONS = ["## Objective", "## Scope", "## Verification"] as const;
+
+const SECTION_SKELETONS: Record<(typeof REQUIRED_SECTIONS)[number], string> = {
+  "## Objective": "## Objective\n\n<!-- Describe what this task achieves and why it matters. -->",
+  "## Scope":
+    "## Scope\n\n**Touch:** <!-- files, systems, or areas to modify -->\n**Do not touch:** <!-- explicit exclusions -->",
+  "## Verification": "## Verification\n\n- [ ] <!-- Concrete, machine-checkable acceptance criterion -->",
+};
+
+/** Returns true when every required section header is present in the description. */
+export function hasAllRequiredSections(description: string | null | undefined): boolean {
+  if (!description) return false;
+  return REQUIRED_SECTIONS.every((section) => description.includes(section));
+}
+
+/**
+ * Soft-scaffold: append skeleton blocks for any missing sections.
+ * If the description already contains all three sections it is returned unchanged.
+ */
+export function scaffoldDescription(description: string | null | undefined): string {
+  const base = description ?? "";
+  const missing = REQUIRED_SECTIONS.filter((section) => !base.includes(section));
+  if (missing.length === 0) return base;
+
+  const appended = missing.map((section) => SECTION_SKELETONS[section]).join("\n\n");
+  return base ? `${base}\n\n${appended}` : appended;
+}
+
+/**
+ * Returns the scaffold enforcement mode derived from the environment.
+ *   "strict"  — reject requests that are missing any required section (HTTP 400)
+ *   "scaffold" — (default) silently append missing sections
+ */
+export function getSpecEnforceMode(): "strict" | "scaffold" {
+  return process.env.PAPERCLIP_SPEC_ENFORCE === "strict" ? "strict" : "scaffold";
+}

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -38,6 +38,11 @@ import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
 import { isAllowedContentType, MAX_ATTACHMENT_BYTES } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+import {
+  getSpecEnforceMode,
+  hasAllRequiredSections,
+  scaffoldDescription,
+} from "../issue-template-scaffold.js";
 
 const MAX_ISSUE_COMMENT_LIMIT = 500;
 const updateIssueRouteSchema = updateIssueSchema.extend({
@@ -968,9 +973,20 @@ export function issueRoutes(db: Db, storage: StorageService) {
       await assertCanAssignTasks(req, companyId);
     }
 
+    const specMode = getSpecEnforceMode();
+    if (specMode === "strict" && !hasAllRequiredSections(req.body.description)) {
+      res.status(400).json({
+        error:
+          "Issue description must include ## Objective, ## Scope, and ## Verification sections (PAPERCLIP_SPEC_ENFORCE=strict)",
+      });
+      return;
+    }
+    const description = specMode === "scaffold" ? scaffoldDescription(req.body.description) : req.body.description;
+
     const actor = getActorInfo(req);
     const issue = await svc.create(companyId, {
       ...req.body,
+      description,
       createdByAgentId: actor.agentId,
       createdByUserId: actor.actorType === "user" ? actor.actorId : null,
     });


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI agents for zero-human companies
- Agents create issues by calling `POST /api/companies/:companyId/issues`
- Harness spec requires every issue to have `## Objective`, `## Scope`, and `## Verification` sections
- But agents repeatedly skip these sections (9 regressions tracked in ANGA-440) because it is instructional discipline only — nothing enforces it at the API layer
- So we need the API itself to scaffold the missing sections, making compliance automatic
- This PR injects scaffolding logic into the issue creation route: soft-scaffold mode appends missing sections; strict mode rejects non-compliant requests with HTTP 400

## What Changed

- **`server/src/issue-template-scaffold.ts`** (new) — pure helper module: `hasAllRequiredSections()`, `scaffoldDescription()`, `getSpecEnforceMode()`
- **`server/src/routes/issues.ts`** — modified `POST /api/companies/:companyId/issues` to apply scaffold/reject before `svc.create()`
- **`server/src/__tests__/issue-template-scaffold.test.ts`** (new) — unit tests for all scaffold helpers
- **`server/src/__tests__/issue-template-scaffold-routes.test.ts`** (new) — route integration tests for scaffold and strict modes

## Verification

```bash
pnpm test:run --project server "issue-template-scaffold"
```

## Risks

**Low risk.** Change only affects `POST /api/companies/:companyId/issues`. Default scaffold mode is additive. Strict mode is opt-in via `PAPERCLIP_SPEC_ENFORCE=strict`. No schema changes, no migrations, no PATCH route changes.

## Checklist

- [x] One PR = one issue (ANGA-457)
- [x] Thinking path included
- [x] Unit and integration tests added
- [x] Existing tests unaffected
- [x] No PATCH routes modified
- [x] Co-authored-by Paperclip

Closes ANGA-457