### PR TITLE
feat: admin routes for stale lock cleanup and queued run reaping

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -48,6 +48,7 @@ import { pluginRegistryService } from "./services/plugin-registry.js";
 import { createHostClientHandlers } from "@paperclipai/plugin-sdk";
 import type { BetterAuthSessionResult } from "./auth/better-auth.js";
 import { telegramRoutes } from "./routes/telegram.js";
+import { adminRoutes } from "./routes/admin.js";
 
 type UiMode = "none" | "static" | "vite-dev";
 
@@ -157,6 +158,7 @@ export async function createApp(
   api.use(sidebarBadgeRoutes(db));
   api.use(instanceSettingsRoutes(db));
   api.use(telegramRoutes(db));
+  api.use(adminRoutes(db));
   const hostServicesDisposers = new Map<string, () => void>();
   const workerManager = createPluginWorkerManager();
   const pluginRegistry = pluginRegistryService(db);

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -1,0 +1,139 @@
+import { Router, type Request } from "express";
+import { and, eq, inArray, isNotNull, isNull, or } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { agents, heartbeatRuns, issues } from "@paperclipai/db";
+import { forbidden } from "../errors.js";
+import { heartbeatService } from "../services/index.js";
+
+const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
+
+function assertBoard(req: Request) {
+  if (req.actor.type !== "board") {
+    throw forbidden("Board access required");
+  }
+}
+
+export function adminRoutes(db: Db) {
+  const router = Router();
+  const heartbeat = heartbeatService(db as any);
+
+  /**
+   * Clear stale executionRunId/executionLockedAt locks on issues where the
+   * referenced run no longer exists or is in a terminal state.
+   *
+   * Safe to call at any time; does not touch running/queued runs.
+   */
+  router.post("/admin/cleanup-stale-locks", async (req, res) => {
+    assertBoard(req);
+
+    // Reap any running runs whose processes have disappeared, releasing their
+    // issue execution locks in the process.
+    const reaped = await heartbeat.reapOrphanedRuns();
+
+    // Clear any remaining issue locks pointing at terminal or missing runs.
+    const staleIssues = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .leftJoin(heartbeatRuns, eq(issues.executionRunId, heartbeatRuns.id))
+      .where(
+        and(
+          isNotNull(issues.executionRunId),
+          or(
+            isNull(heartbeatRuns.id), // run record missing
+            inArray(heartbeatRuns.status, [...TERMINAL_RUN_STATUSES]),
+          ),
+        ),
+      );
+
+    let clearedLocks = 0;
+    if (staleIssues.length > 0) {
+      const staleIssueIds = staleIssues.map((r) => r.id);
+      const updated = await db
+        .update(issues)
+        .set({
+          executionRunId: null,
+          executionAgentNameKey: null,
+          executionLockedAt: null,
+          checkoutRunId: null,
+          updatedAt: new Date(),
+        })
+        .where(inArray(issues.id, staleIssueIds))
+        .returning({ id: issues.id });
+      clearedLocks = updated.length;
+    }
+
+    res.json({ reaped: reaped.reaped, runIds: reaped.runIds, clearedLocks });
+  });
+
+  /**
+   * Mark stuck queued runs as failed when the owning agent is paused,
+   * terminated, or pending approval. Also releases the corresponding issue
+   * execution locks so those issues can be reassigned.
+   *
+   * Optional body: { staleThresholdMs: number } — only reap runs older than
+   * this many milliseconds (default: 0, reap all matching runs immediately).
+   */
+  router.post("/admin/reap-stale-queued-runs", async (req, res) => {
+    assertBoard(req);
+
+    const staleThresholdMs =
+      typeof req.body?.staleThresholdMs === "number" ? req.body.staleThresholdMs : 0;
+
+    const now = new Date();
+
+    const queuedRuns = await db
+      .select({
+        id: heartbeatRuns.id,
+        createdAt: heartbeatRuns.createdAt,
+      })
+      .from(heartbeatRuns)
+      .innerJoin(agents, eq(heartbeatRuns.agentId, agents.id))
+      .where(
+        and(
+          eq(heartbeatRuns.status, "queued"),
+          inArray(agents.status, ["paused", "terminated", "pending_approval"]),
+        ),
+      );
+
+    const staleRuns =
+      staleThresholdMs > 0
+        ? queuedRuns.filter(
+            (r) => now.getTime() - new Date(r.createdAt).getTime() >= staleThresholdMs,
+          )
+        : queuedRuns;
+
+    if (staleRuns.length === 0) {
+      res.json({ reaped: 0, runIds: [] });
+      return;
+    }
+
+    const staleRunIds = staleRuns.map((r) => r.id);
+
+    await db
+      .update(heartbeatRuns)
+      .set({
+        status: "failed",
+        error: "Agent is paused or terminated; queued run reaped by admin",
+        errorCode: "agent_unavailable",
+        finishedAt: now,
+        updatedAt: now,
+      })
+      .where(inArray(heartbeatRuns.id, staleRunIds));
+
+    // Release any issue execution locks held by these runs.
+    await db
+      .update(issues)
+      .set({
+        executionRunId: null,
+        executionAgentNameKey: null,
+        executionLockedAt: null,
+        checkoutRunId: null,
+        updatedAt: now,
+      })
+      .where(inArray(issues.executionRunId, staleRunIds));
+
+    res.json({ reaped: staleRuns.length, runIds: staleRunIds });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Thinking Path

- Paperclip orchestrates AI-agent companies by assigning tasks (issues) to agents via heartbeat runs
- Each issue can be "locked" to a run via `executionRunId`/`executionLockedAt` while an agent works it
- Server restarts or agent termination can leave runs stuck in `running` or `queued` state, holding issue execution locks
- `reapOrphanedRuns()` handles stuck running processes on a 5-min timer, but there is no manual trigger for operators
- Queued runs for paused/terminated agents also get permanently stuck since `reapOrphanedRuns` only targets `running` state
- Operators need `POST /api/admin/cleanup-stale-locks` and `POST /api/admin/reap-stale-queued-runs` to unblock without direct DB access

## What Changed

- **`server/src/routes/admin.ts`** (new): Board-only admin routes:
  - `POST /admin/cleanup-stale-locks`: calls `reapOrphanedRuns()` for stuck running processes, then directly clears any remaining issue execution locks pointing at terminal or missing runs via LEFT JOIN query
  - `POST /admin/reap-stale-queued-runs`: finds queued runs for paused/terminated/pending-approval agents, marks them `failed`, clears corresponding issue execution locks; supports optional `staleThresholdMs` body param to filter by age
- **`server/src/app.ts`**: imports and mounts `adminRoutes(db)` on the `/api` router

## Verification

```bash
# cleanup-stale-locks — returns 200 with { reaped, runIds, clearedLocks }
curl -X POST http://localhost:3100/api/admin/cleanup-stale-locks \
  -H "Authorization: Bearer <board-token>"

# reap-stale-queued-runs — returns 200 with { reaped, runIds }
curl -X POST http://localhost:3100/api/admin/reap-stale-queued-runs \
  -H "Authorization: Bearer <board-token>" \
  -H "Content-Type: application/json" \
  -d {"staleThresholdMs": 300000}

# Board-only: non-board caller gets 403
curl -X POST http://localhost:3100/api/admin/cleanup-stale-locks \
  -H "Authorization: Bearer <agent-token>"  # 403 Forbidden
```

TypeScript typecheck: `tsc --noEmit -p server/tsconfig.json` exit 0

## Risks

Low risk. Both endpoints are idempotent, board-only, and only target clearly terminal/stuck states.

## Checklist

- [x] TypeScript typecheck passes
- [x] Board-only auth enforced on both endpoints
- [x] Both endpoints return 200 with count of affected records
- [x] No changes to heartbeat.ts internals or existing routes
- [x] Commit includes Co-Authored-By: Paperclip

Closes ANGA-525