### PR TITLE
feat(agents): add remote_trigger adapter type for CoWork-driven heartbeats (ANGA-521)

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -31,6 +31,7 @@ export const AGENT_ADAPTER_TYPES = [
   "cursor",
   "openclaw_gateway",
   "hermes_local",
+  "remote_trigger",
 ] as const;
 export type AgentAdapterType = (typeof AGENT_ADAPTER_TYPES)[number];
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4175,6 +4175,9 @@ export function heartbeatService(db: Db) {
 
       for (const agent of allAgents) {
         if (agent.status === "paused" || agent.status === "terminated" || agent.status === "pending_approval") continue;
+        // remote_trigger agents are driven by external schedulers (e.g. CoWork RemoteTriggers);
+        // skip native interval-based scheduling so they don't get double-fired.
+        if (agent.adapterType === "remote_trigger") continue;
         const policy = parseHeartbeatPolicy(agent);
         if (!policy.enabled || policy.intervalSec <= 0) continue;
 


### PR DESCRIPTION
## Thinking Path

1. **Goal:** `remote_trigger` agents must not be scheduled by Paperclip's native heartbeat timer — they are driven externally (CoWork RemoteTriggers).
2. **Entry point:** `heartbeat.ts` → `tickTimers()` → the `for (const agent of allAgents)` loop that schedules interval-based heartbeats.
3. **Change needed:** Skip agents whose `adapterType === "remote_trigger"` before scheduling, same pattern as the existing `paused`/`terminated` guard.
4. **Type registration:** `AGENT_ADAPTER_TYPES` in `shared/constants.ts` is the source of truth for all valid adapter type strings; adding `"remote_trigger"` here propagates to all Zod validators automatically — no migration needed.
5. **Scope:** 2 files, 4 lines. No DB schema change, no API contract change.

## What Changed

- `packages/shared/src/constants.ts` — added `"remote_trigger"` to `AGENT_ADAPTER_TYPES` array
- `server/src/services/heartbeat.ts` — added guard in `tickTimers()` to skip `remote_trigger` agents from native interval scheduling

## Verification

```bash
# TypeScript compile
npm run build --workspace=packages/shared
npm run build --workspace=server

# Unit tests
npm run test --workspace=server

# Manual: create an agent with adapterType = remote_trigger and confirm
# it does not appear in heartbeat timer ticks, but can still be triggered
# via POST /api/issues/:id/checkout (external trigger path).
```

## Risks

Low risk. Additive change: existing adapter types are unaffected. The new type simply opts out of native scheduling. Agents using `remote_trigger` cannot exist until the type is registered here, so no existing deployments are impacted.

## Checklist

- [x] Thinking Path traces from project root to this change (5+ steps)
- [x] What Changed is a concrete bullet list
- [x] Verification includes runnable commands
- [x] Risks explicitly acknowledged
- [x] PR is scoped to a single issue (ANGA-521)
- [x] No unrelated commits included
- [x] Co-authored-by tag present on commit

Closes ANGA-521