### PR TITLE
fix(auth): reject dev secret in authenticated deployment mode (ANGA-545)

### DIFF
--- a/server/src/__tests__/better-auth-startup-assertion.test.ts
+++ b/server/src/__tests__/better-auth-startup-assertion.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createBetterAuthInstance } from "../auth/better-auth.js";
+import type { Config } from "../config.js";
+
+const BETTER_AUTH_SECRET_ENV = "BETTER_AUTH_SECRET";
+const AGENT_JWT_SECRET_ENV = "PAPERCLIP_AGENT_JWT_SECRET";
+
+function makeConfig(deploymentMode: Config["deploymentMode"]): Config {
+  return {
+    deploymentMode,
+    authBaseUrlMode: "auto",
+    authPublicBaseUrl: undefined,
+    authDisableSignUp: false,
+    allowedHostnames: [],
+  } as unknown as Config;
+}
+
+vi.mock("better-auth", () => ({
+  betterAuth: vi.fn(() => ({ __mock: true })),
+}));
+
+vi.mock("better-auth/adapters/drizzle", () => ({
+  drizzleAdapter: vi.fn(() => ({ __mockAdapter: true })),
+}));
+
+vi.mock("@paperclipai/db", () => ({
+  authUsers: {},
+  authSessions: {},
+  authAccounts: {},
+  authVerifications: {},
+}));
+
+describe("createBetterAuthInstance — startup assertion", () => {
+  const originalBetterAuthSecret = process.env[BETTER_AUTH_SECRET_ENV];
+  const originalAgentJwtSecret = process.env[AGENT_JWT_SECRET_ENV];
+
+  beforeEach(() => {
+    delete process.env[BETTER_AUTH_SECRET_ENV];
+    delete process.env[AGENT_JWT_SECRET_ENV];
+  });
+
+  afterEach(() => {
+    if (originalBetterAuthSecret === undefined) delete process.env[BETTER_AUTH_SECRET_ENV];
+    else process.env[BETTER_AUTH_SECRET_ENV] = originalBetterAuthSecret;
+    if (originalAgentJwtSecret === undefined) delete process.env[AGENT_JWT_SECRET_ENV];
+    else process.env[AGENT_JWT_SECRET_ENV] = originalAgentJwtSecret;
+  });
+
+  it("throws when deploymentMode is authenticated and no secret is configured (falls back to dev secret)", () => {
+    expect(() => createBetterAuthInstance({} as any, makeConfig("authenticated"))).toThrow(
+      "FATAL: BETTER_AUTH_SECRET must be set in authenticated deployment mode.",
+    );
+  });
+
+  it("throws when deploymentMode is authenticated and BETTER_AUTH_SECRET equals the dev default", () => {
+    process.env[BETTER_AUTH_SECRET_ENV] = "paperclip-dev-secret";
+    expect(() => createBetterAuthInstance({} as any, makeConfig("authenticated"))).toThrow(
+      "FATAL: BETTER_AUTH_SECRET must be set in authenticated deployment mode.",
+    );
+  });
+
+  it("throws when deploymentMode is authenticated and PAPERCLIP_AGENT_JWT_SECRET equals the dev default", () => {
+    process.env[AGENT_JWT_SECRET_ENV] = "paperclip-dev-secret";
+    expect(() => createBetterAuthInstance({} as any, makeConfig("authenticated"))).toThrow(
+      "FATAL: BETTER_AUTH_SECRET must be set in authenticated deployment mode.",
+    );
+  });
+
+  it("does not throw when deploymentMode is authenticated and a real secret is configured", () => {
+    process.env[BETTER_AUTH_SECRET_ENV] = "a-real-production-secret-value";
+    expect(() => createBetterAuthInstance({} as any, makeConfig("authenticated"))).not.toThrow();
+  });
+
+  it("does not throw in local_trusted mode even without a secret configured", () => {
+    expect(() => createBetterAuthInstance({} as any, makeConfig("local_trusted"))).not.toThrow();
+  });
+
+  it("does not throw in local_trusted mode even when secret is explicitly set to dev default", () => {
+    process.env[BETTER_AUTH_SECRET_ENV] = "paperclip-dev-secret";
+    expect(() => createBetterAuthInstance({} as any, makeConfig("local_trusted"))).not.toThrow();
+  });
+});

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -65,10 +65,19 @@ export function deriveAuthTrustedOrigins(config: Config): string[] {
   return Array.from(trustedOrigins);
 }
 
+const DEV_SECRET = "paperclip-dev-secret";
+
 export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?: string[]): BetterAuthInstance {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
-  const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET ?? "paperclip-dev-secret";
+  const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET ?? DEV_SECRET;
   const effectiveTrustedOrigins = trustedOrigins ?? deriveAuthTrustedOrigins(config);
+
+  if (config.deploymentMode === "authenticated" && secret === DEV_SECRET) {
+    throw new Error(
+      "FATAL: BETTER_AUTH_SECRET must be set in authenticated deployment mode. " +
+      "The default dev secret is publicly known and must not be used in production.",
+    );
+  }
 
   const publicUrl = process.env.PAPERCLIP_PUBLIC_URL ?? baseUrl;
   const isHttpOnly = publicUrl ? publicUrl.startsWith("http://") : false;


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - It supports multiple deployment modes: `local_trusted` (development) and `authenticated` (production)
> - In `authenticated` mode, Better Auth issues session tokens using a secret key
> - The fallback secret `"paperclip-dev-secret"` is hardcoded in source and publicly known
> - If an operator forgets to set `BETTER_AUTH_SECRET` in production, the server silently uses this known secret
> - An attacker can forge valid session tokens for any user on a misconfigured instance
> - This PR adds a startup-time assertion that throws a fatal error in that scenario
> - The benefit is: a misconfigured `authenticated`-mode server crashes loudly at boot rather than running with a compromised auth layer

## What Changed

- `server/src/auth/better-auth.ts` — Extract dev secret into `DEV_SECRET` constant; add guard that throws `FATAL: BETTER_AUTH_SECRET must be set in authenticated deployment mode.` when `deploymentMode === "authenticated"` and the resolved secret equals the dev default
- `server/src/__tests__/better-auth-startup-assertion.test.ts` — New test file covering: rejection when no secret set, rejection when secret explicitly equals dev default (via `BETTER_AUTH_SECRET` or `PAPERCLIP_AGENT_JWT_SECRET`), success with a real secret, and no-throw in `local_trusted` mode regardless of secret value

## Verification

- Run: `pnpm test -- run --reporter=verbose server/src/__tests__/better-auth-startup-assertion.test.ts`
- Start server with `PAPERCLIP_DEPLOYMENT_MODE=authenticated` and no `BETTER_AUTH_SECRET` → should crash with FATAL message
- Start server with `PAPERCLIP_DEPLOYMENT_MODE=authenticated` and `BETTER_AUTH_SECRET=some-real-secret` → should start normally
- Start server with no deployment mode set (defaults to `local_trusted`) → should start normally regardless of secret

## Risks

- Low risk. The check only fires when `deploymentMode === "authenticated"` AND the resolved secret equals the hardcoded dev default — a combination that should never exist in a correctly configured production deployment. No behavior change for `local_trusted` mode or properly configured `authenticated` deployments.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] If this change affects the UI, I have included before/after screenshots (N/A — server-only change)
- [ ] I have updated relevant documentation to reflect my changes (N/A — error message is self-documenting)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes ANGA-545