### PR TITLE
feat(telegram): add recovery notification when server comes back online

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,6 +36,7 @@ import {
 } from "./services/index.js";
 import { createFeedbackTraceShareClientFromConfig } from "./services/feedback-share-client.js";
 import { startTelegramEventBridge } from "./services/telegram-event-bridge.js";
+import { telegramNotify } from "./services/telegram-notify.js";
 import { createStorageServiceFromConfig } from "./storage/index.js";
 import { printStartupBanner } from "./startup-banner.js";
 import { getBoardClaimWarningUrl, initializeBoardClaimChallenge } from "./board-claim.js";
@@ -734,8 +735,19 @@ export async function startServer(): Promise<StartedServer> {
     });
   });
   
+  // Send a recovery / "back online" Telegram notification after a short delay.
+  // The delay debounces rapid restart flapping — if the server crashes within
+  // this window the notification is never sent.
+  const startupNotifyTimer = setTimeout(() => {
+    void telegramNotify.serverOnline({
+      url: process.env.PAPERCLIP_PUBLIC_URL || undefined,
+    });
+  }, 10_000);
+  startupNotifyTimer.unref();
+
   {
     const shutdown = async (signal: "SIGINT" | "SIGTERM") => {
+      clearTimeout(startupNotifyTimer);
       const telemetryClient = getTelemetryClient();
       if (telemetryClient) {
         telemetryClient.stop();

--- a/server/src/services/telegram-notify.ts
+++ b/server/src/services/telegram-notify.ts
@@ -115,6 +115,15 @@ export const telegramNotify = {
     });
   },
 
+  /** Notify that the server has started and is online. */
+  async serverOnline(input: { url?: string; version?: string }) {
+    const ver = input.version ? ` (${input.version})` : "";
+    const link = input.url ? `\n${input.url}` : "";
+    await send({
+      text: `✅ Paperclip is back online${ver}${link}`,
+    });
+  },
+
   /** Generic notification for anything else. */
   async info(text: string) {
     await send({ text });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The Telegram notification subsystem bridges server events to a Telegram bot sidecar for board visibility
> - Currently the system notifies on heartbeat completions, issue status changes, approvals, and budget events
> - There is no notification when the Paperclip server itself comes back online after a crash or restart
> - The board only knows when things go wrong (external downtime alerts) but has no signal when service resumes
> - This PR adds a recovery notification — a "back online" Telegram message sent 10s after server startup
> - The 10s delay debounces rapid restart flapping so the board isn't spammed during crash loops
> - The timer is cancelled on graceful shutdown (SIGINT/SIGTERM) to avoid false positives during intentional restarts

## What Changed

- Added `serverOnline()` method to `telegramNotify` in `server/src/services/telegram-notify.ts` — sends a "Paperclip is back online" message with optional URL and version
- Added startup notification in `server/src/index.ts` — fires 10 seconds after the server listen promise resolves, debounced via `setTimeout` + `unref()`
- Added `clearTimeout` in the shutdown handler to cancel the notification if the server shuts down gracefully within the 10s window

## Verification

- Start the server with `TELEGRAM_NOTIFY_ENABLED=true` and a running telegram-bot sidecar → after 10s, a "Paperclip is back online" message should appear in the Telegram chat
- Start the server and immediately send SIGTERM within 10s → no recovery message should be sent
- Existing downtime alerts (external) are untouched — this PR only adds to `telegram-notify.ts` and `index.ts`
- Rapid restart scenario: if the server crashes and restarts repeatedly within 10s windows, only stable startups produce a notification

## Risks

Low risk. The notification is fire-and-forget (matches existing pattern). The timer is `unref()`'d so it won't keep the process alive. The only new code path is the `setTimeout` + `telegramNotify.serverOnline()` call after the server is already listening. No database changes, no API changes, no existing behavior modified.

## Model Used

Claude Opus 4.6 (claude-opus-4-6) via Claude Code, standard tool use mode.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass (node_modules not available in worktree — typecheck deferred to CI)
- [ ] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots (N/A — no UI changes)
- [x] I have updated relevant documentation to reflect my changes (N/A — no doc changes needed)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes ANGA-549