### PR TITLE
fix: add .gitattributes LF enforcement for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Enforce LF line endings for shell scripts to prevent CRLF breakage in Docker
+*.sh text eol=lf


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Paperclip runs inside Docker containers on Linux hosts
> - Shell scripts (`.sh`) are used for Docker entrypoints and build/release automation
> - When these scripts are checked out on Windows, git may convert LF to CRLF line endings
> - CRLF line endings cause `exec format error` / `no such file or directory` on Linux
> - This happened on 2026-04-04 when `docker-entrypoint.sh` had CRLF, breaking the Docker rebuild
> - This PR adds a `.gitattributes` file that forces `*.sh` files to always use LF endings
> - The benefit is this class of Docker failure is permanently prevented at the git level

## What Changed

- Added `.gitattributes` with `*.sh text eol=lf` rule
- Ran `git add --renormalize .` to verify all existing `.sh` files already have LF endings (no changes needed)

## Verification

- Verify `.gitattributes` contains `*.sh text eol=lf`
- On a Windows checkout with `core.autocrlf=true`, confirm `.sh` files still have LF endings:
  ```bash
  git clone <repo> && od -c scripts/release.sh | grep '\\r' # should find nothing
  ```
- Docker build should succeed without entrypoint exec errors

## Risks

Low risk. `.gitattributes` only affects line-ending normalization for `.sh` files. No behavioral change for existing LF-only files. No impact on non-shell files.

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`) — tool use mode via Claude Code CLI, running as Paperclip Dev Agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable — N/A, no testable logic
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [ ] I have updated relevant documentation to reflect my changes — N/A
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes ANGA-548