### PR TITLE
fix(issues): adopt issue when checkoutRunId is null but executionRunId is stale

### DIFF
--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1502,6 +1502,7 @@ export function issueService(db: Db) {
           status: issues.status,
           assigneeAgentId: issues.assigneeAgentId,
           checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
         })
         .from(issues)
         .where(eq(issues.id, id))
@@ -1539,11 +1540,55 @@ export function issueService(db: Db) {
         }
       }
 
+      // When checkoutRunId is null but executionRunId is stale, adopt the issue
+      // instead of throwing a conflict. This happens after process_lost_retry
+      // clears checkoutRunId but leaves executionRunId from a previous run.
+      if (
+        actorRunId &&
+        current.status === "in_progress" &&
+        current.assigneeAgentId === actorAgentId &&
+        current.checkoutRunId == null
+      ) {
+        const now = new Date();
+        const adopted = await db
+          .update(issues)
+          .set({
+            checkoutRunId: actorRunId,
+            executionRunId: actorRunId,
+            executionLockedAt: now,
+            updatedAt: now,
+          })
+          .where(
+            and(
+              eq(issues.id, id),
+              eq(issues.status, "in_progress"),
+              eq(issues.assigneeAgentId, actorAgentId),
+              isNull(issues.checkoutRunId),
+            ),
+          )
+          .returning({
+            id: issues.id,
+            status: issues.status,
+            assigneeAgentId: issues.assigneeAgentId,
+            checkoutRunId: issues.checkoutRunId,
+            executionRunId: issues.executionRunId,
+          })
+          .then((rows) => rows[0] ?? null);
+
+        if (adopted) {
+          return {
+            ...adopted,
+            adoptedFromRunId: current.executionRunId,
+          };
+        }
+      }
+
       throw conflict("Issue run ownership conflict", {
         issueId: current.id,
         status: current.status,
         assigneeAgentId: current.assigneeAgentId,
         checkoutRunId: current.checkoutRunId,
+        executionRunId: current.executionRunId,
         actorAgentId,
         actorRunId,
       });


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - Agents work on issues via a checkout lock system using `checkoutRunId` and `executionRunId`
> - When an agent comments on or updates an in-progress issue, `assertCheckoutOwner` validates ownership
> - The `process_lost_retry` mechanism can clear `checkoutRunId` (set to null) while leaving `executionRunId` from a prior run
> - In this state, `assertCheckoutOwner` fails all three checks: run-lock mismatch (null ≠ actorRunId), stale-adoption requires non-null `checkoutRunId`, and falls through to 409
> - This blocks agents from commenting on their own assigned, in-progress issues
> - This PR adds a third adoption path for the null-checkoutRunId case, mirroring the checkout method's existing logic
> - The benefit is agents can always interact with their own issues regardless of stale execution state

## What Changed

- `assertCheckoutOwner` now selects `executionRunId` alongside `checkoutRunId`
- Added adoption path: when `checkoutRunId` is null and agent is the assignee, atomically set both `checkoutRunId` and `executionRunId` to the current run (with optimistic concurrency via `isNull(checkoutRunId)` in the WHERE clause)
- Conflict error payload now includes `executionRunId` for better diagnostics

## Verification

- Reproduce: set an issue to `in_progress` with `checkoutRunId = null` and `executionRunId = <old-run-id>`, then have the assigned agent attempt to comment → should succeed (was 409 before)
- Existing checkout/adoption flow unchanged — stale run adoption with non-null `checkoutRunId` still works via `adoptStaleCheckoutRun`
- Concurrent checkout protection preserved: the WHERE clause checks `isNull(checkoutRunId)` atomically

## Risks

Low-medium risk. The new adoption path only fires when `checkoutRunId` is already null (no lock held), so it cannot override an active checkout. The atomic WHERE clause prevents race conditions. The pattern mirrors the existing checkout method (lines 1449-1466).

## Model Used

Claude Opus 4.6 (`claude-opus-4-6`) — tool use mode via Claude Code CLI, running as Paperclip Dev Agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass — pnpm store permission issue in worktree; change is type-safe and uses existing patterns
- [ ] I have added or updated tests where applicable — test for this specific state transition would be valuable as follow-up
- [ ] If this change affects the UI, I have included before/after screenshots — N/A
- [ ] I have updated relevant documentation to reflect my changes — N/A
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge

Closes ANGA-582