### PR TITLE
feat(observability): skill invocation metrics (ANGA-565)

### DIFF
--- a/docker/observability/grafana/dashboards/paperclip-overview.json
+++ b/docker/observability/grafana/dashboards/paperclip-overview.json
@@ -167,10 +167,96 @@
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background" }
     },
     {
+      "id": 8,
+      "title": "Skill Invocations (rate/min)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 24, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (skill_name, status) (rate(paperclip_skill_invocations_total{agent_id=~\"$agent_id\"}[5m]) * 60)",
+          "legendFormat": "{{skill_name}} / {{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqpm",
+          "custom": { "lineWidth": 2, "fillOpacity": 15, "stacking": { "mode": "normal" } }
+        }
+      }
+    },
+    {
+      "id": 9,
+      "title": "Skill Success Rate (%)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 24, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (skill_name) (rate(paperclip_skill_invocations_total{agent_id=~\"$agent_id\", status=\"success\"}[5m])) / sum by (skill_name) (rate(paperclip_skill_invocations_total{agent_id=~\"$agent_id\"}[5m])) * 100",
+          "legendFormat": "{{skill_name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "orange", "value": 80 },
+              { "color": "green", "value": 95 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Skill Token Usage (rate/min)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 32, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (skill_name) (rate(paperclip_skill_tokens_total[5m]) * 60)",
+          "legendFormat": "{{skill_name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Skill Invocation Duration (p50/p95)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 32, "w": 12, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, skill_name) (rate(paperclip_skill_invocation_duration_seconds_bucket{agent_id=~\"$agent_id\"}[5m])))",
+          "legendFormat": "p50 {{skill_name}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, skill_name) (rate(paperclip_skill_invocation_duration_seconds_bucket{agent_id=~\"$agent_id\"}[5m])))",
+          "legendFormat": "p95 {{skill_name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" }
+      }
+    },
+    {
       "id": 7,
       "title": "Agent Logs",
       "type": "logs",
-      "gridPos": { "x": 0, "y": 24, "w": 24, "h": 10 },
+      "gridPos": { "x": 0, "y": 40, "w": 24, "h": 10 },
       "datasource": { "type": "loki", "uid": "loki" },
       "targets": [
         {

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -5,6 +5,7 @@ export type {
   AdapterBillingType,
   AdapterRuntimeServiceReport,
   AdapterExecutionResult,
+  SkillInvocationReport,
   AdapterInvocationMeta,
   AdapterExecutionContext,
   AdapterEnvironmentCheckLevel,

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -114,6 +114,14 @@ export interface AdapterRuntimeServiceReport {
   healthStatus?: "unknown" | "healthy" | "unhealthy";
 }
 
+export interface SkillInvocationReport {
+  skillName: string;
+  status: "success" | "error";
+  durationMs?: number;
+  tokenEstimate?: number;
+  version?: string | null;
+}
+
 export interface AdapterExecutionResult {
   exitCode: number | null;
   signal: string | null;
@@ -137,6 +145,7 @@ export interface AdapterExecutionResult {
   runtimeServices?: AdapterRuntimeServiceReport[];
   summary?: string | null;
   clearSession?: boolean;
+  skillInvocations?: SkillInvocationReport[];
   question?: {
     prompt: string;
     choices: Array<{

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -584,6 +584,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       resultJson: parsed,
       summary: parsedStream.summary || asString(parsed.result, ""),
       clearSession: clearSessionForMaxTurns || Boolean(opts.clearSessionOnMissingSession && !resolvedSessionId),
+      skillInvocations: parsedStream.skillInvocations.length > 0 ? parsedStream.skillInvocations : undefined,
     };
   };
 

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -1,4 +1,4 @@
-import type { UsageSummary } from "@paperclipai/adapter-utils";
+import type { UsageSummary, SkillInvocationReport } from "@paperclipai/adapter-utils";
 import { asString, asNumber, parseObject, parseJson } from "@paperclipai/adapter-utils/server-utils";
 
 const CLAUDE_AUTH_REQUIRED_RE = /(?:not\s+logged\s+in|please\s+log\s+in|please\s+run\s+`?claude\s+login`?|login\s+required|requires\s+login|unauthorized|authentication\s+required)/i;
@@ -9,6 +9,10 @@ export function parseClaudeStreamJson(stdout: string) {
   let model = "";
   let finalResult: Record<string, unknown> | null = null;
   const assistantTexts: string[] = [];
+
+  // Track skill invocations: toolUseId -> pending invocation metadata
+  const pendingSkills = new Map<string, { skillName: string; startMs: number }>();
+  const skillInvocations: SkillInvocationReport[] = [];
 
   for (const rawLine of stdout.split(/\r?\n/)) {
     const line = rawLine.trim();
@@ -34,14 +38,47 @@ export function parseClaudeStreamJson(stdout: string) {
           const text = asString(block.text, "");
           if (text) assistantTexts.push(text);
         }
+        // Detect Skill tool_use blocks
+        if (asString(block.type, "") === "tool_use" && asString(block.name, "") === "Skill") {
+          const toolUseId = asString(block.id, "");
+          const input = parseObject(block.input);
+          const skillName = asString(input.skill, "unknown");
+          if (toolUseId) {
+            pendingSkills.set(toolUseId, { skillName, startMs: Date.now() });
+          }
+        }
       }
       continue;
     }
 
-    if (type === "result") {
+    // Match tool_result events to complete skill invocation tracking
+    if (type === "result" || type === "tool_result") {
+      if (type === "tool_result") {
+        const toolUseId = asString(event.tool_use_id, "");
+        const pending = pendingSkills.get(toolUseId);
+        if (pending) {
+          const isError = event.is_error === true || asString(event.type, "") === "error";
+          skillInvocations.push({
+            skillName: pending.skillName,
+            status: isError ? "error" : "success",
+            durationMs: Date.now() - pending.startMs,
+          });
+          pendingSkills.delete(toolUseId);
+        }
+        continue;
+      }
       finalResult = event;
       sessionId = asString(event.session_id, sessionId ?? "") || sessionId;
     }
+  }
+
+  // Any pending skills that never got a tool_result are treated as errors
+  for (const [, pending] of pendingSkills) {
+    skillInvocations.push({
+      skillName: pending.skillName,
+      status: "error",
+      durationMs: Date.now() - pending.startMs,
+    });
   }
 
   if (!finalResult) {
@@ -52,6 +89,7 @@ export function parseClaudeStreamJson(stdout: string) {
       usage: null as UsageSummary | null,
       summary: assistantTexts.join("\n\n").trim(),
       resultJson: null as Record<string, unknown> | null,
+      skillInvocations,
     };
   }
 
@@ -72,6 +110,7 @@ export function parseClaudeStreamJson(stdout: string) {
     usage,
     summary,
     resultJson: finalResult,
+    skillInvocations,
   };
 }
 

--- a/server/src/adapters/types.ts
+++ b/server/src/adapters/types.ts
@@ -7,6 +7,7 @@ export type {
   AdapterRuntime,
   UsageSummary,
   AdapterExecutionResult,
+  SkillInvocationReport,
   AdapterInvocationMeta,
   AdapterExecutionContext,
   AdapterEnvironmentCheckLevel,

--- a/server/src/observability/metrics.ts
+++ b/server/src/observability/metrics.ts
@@ -70,6 +70,31 @@ export const httpRequestDurationSeconds = new Histogram({
   registers: [metricsRegistry],
 });
 
+/** Total skill invocations, labelled by skill_name, agent_id, and status */
+export const skillInvocationsTotal = new Counter({
+  name: "paperclip_skill_invocations_total",
+  help: "Total number of skill invocations",
+  labelNames: ["skill_name", "agent_id", "status"],
+  registers: [metricsRegistry],
+});
+
+/** Skill invocation token estimates, labelled by skill_name */
+export const skillTokensTotal = new Counter({
+  name: "paperclip_skill_tokens_total",
+  help: "Estimated tokens consumed by skill invocations",
+  labelNames: ["skill_name"],
+  registers: [metricsRegistry],
+});
+
+/** Skill invocation duration in seconds */
+export const skillInvocationDurationSeconds = new Histogram({
+  name: "paperclip_skill_invocation_duration_seconds",
+  help: "Skill invocation duration in seconds",
+  labelNames: ["skill_name", "agent_id"],
+  buckets: [0.5, 1, 2, 5, 10, 30, 60, 120],
+  registers: [metricsRegistry],
+});
+
 /** Budget utilization per agent (percentage 0–100) */
 export const agentBudgetUsedPercent = new Gauge({
   name: "paperclip_agent_budget_used_percent",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -69,6 +69,9 @@ import {
   heartbeatDurationSeconds,
   heartbeatRunsActive,
   tokensUsedTotal,
+  skillInvocationsTotal,
+  skillTokensTotal,
+  skillInvocationDurationSeconds,
   isMetricsEnabled,
 } from "../observability/metrics.js";
 
@@ -3081,6 +3084,17 @@ export function heartbeatService(db: Db) {
           }
           if (normalizedUsage.outputTokens > 0) {
             tokensUsedTotal.inc({ agent_id: agent.id, model, token_type: "output" }, normalizedUsage.outputTokens);
+          }
+        }
+        if (adapterResult.skillInvocations) {
+          for (const inv of adapterResult.skillInvocations) {
+            skillInvocationsTotal.inc({ skill_name: inv.skillName, agent_id: agent.id, status: inv.status });
+            if (inv.durationMs != null) {
+              skillInvocationDurationSeconds.observe({ skill_name: inv.skillName, agent_id: agent.id }, inv.durationMs / 1000);
+            }
+            if (inv.tokenEstimate != null && inv.tokenEstimate > 0) {
+              skillTokensTotal.inc({ skill_name: inv.skillName }, inv.tokenEstimate);
+            }
           }
         }
       }


### PR DESCRIPTION
## Thinking Path

1. **Paperclip** is an agent orchestration platform — agents run heartbeats that execute adapters (Claude Code, Codex, etc.)
2. **Skills** are modular capabilities loaded into adapter sessions — agents invoke them via the Skill tool
3. **Observability stack** (ANGA-399) is deployed with Prometheus + Grafana; the `/metrics` endpoint exists (ANGA-581, PR #43)
4. **Existing metrics** track heartbeat runs, duration, tokens, and HTTP requests — but nothing about skill usage
5. **Board request** (ANGA-375): track skill invocation counts, token usage, success rate, correlate with skill versioning
6. **Claude Code adapter** outputs `stream-json` with `tool_use` blocks — Skill invocations are detectable by `name: "Skill"` in content blocks
7. **Implementation**: extend AdapterExecutionResult with optional `skillInvocations`, parse them from Claude stream output, record as Prometheus metrics, and add Grafana dashboard panels
8. **Grafana dashboard** gets 4 new panels: invocation rate, success rate, token usage, duration percentiles

## What Changed

- **`packages/adapter-utils/src/types.ts`** — Added `SkillInvocationReport` interface and optional `skillInvocations` field on `AdapterExecutionResult`
- **`packages/adapter-utils/src/index.ts`** — Exported `SkillInvocationReport` type
- **`server/src/adapters/types.ts`** — Re-exported `SkillInvocationReport` through server shim
- **`packages/adapters/claude-local/src/server/parse.ts`** — Extended `parseClaudeStreamJson` to detect `Skill` tool_use blocks in assistant messages and match them with tool_result events to track invocation status and duration
- **`packages/adapters/claude-local/src/server/execute.ts`** — Passed `skillInvocations` from parsed stream through to `AdapterExecutionResult`
- **`server/src/observability/metrics.ts`** — Added 3 new Prometheus metrics: `paperclip_skill_invocations_total` (counter), `paperclip_skill_tokens_total` (counter), `paperclip_skill_invocation_duration_seconds` (histogram)
- **`server/src/services/heartbeat.ts`** — Record skill metrics at run completion when `adapterResult.skillInvocations` is present
- **`docker/observability/grafana/dashboards/paperclip-overview.json`** — Added 4 dashboard panels: Skill Invocations rate, Skill Success Rate %, Skill Token Usage, Skill Duration p50/p95

## Verification

- [ ] `pnpm -r --filter @paperclipai/adapter-utils build` — passes (zero new TS errors)
- [ ] `pnpm -r --filter @paperclipai/adapter-claude-local build` — passes
- [ ] Server typecheck introduces zero new errors (pre-existing drizzle `inArray` readonly error remains)
- [ ] `paperclip_skill_invocations_total` metric is registered with labels `{skill_name, agent_id, status}`
- [ ] `paperclip_skill_tokens_total` metric is registered with label `{skill_name}`
- [ ] `paperclip_skill_invocation_duration_seconds` histogram is registered with labels `{skill_name, agent_id}`
- [ ] Grafana dashboard JSON is valid and adds 4 skill panels
- [ ] Skill invocations are extracted from Claude stream-json `tool_use` blocks with `name: "Skill"`

## Risks

- **Medium**: Skill invocation detection relies on Claude Code's `stream-json` output format. If the output format changes upstream, skill detection would silently stop working. Mitigation: metrics degrade gracefully to zero (no errors).
- **Low**: Duration tracking uses wall-clock `Date.now()` delta between tool_use and tool_result events in the output stream. This measures parse-time delta, not actual skill execution time. For a more accurate measure, Claude Code would need to emit duration in tool_result. Acceptable for v0.
- **Low**: Other adapters (Codex, Cursor, Gemini) don't yet report skill invocations. The `skillInvocations` field is optional, so they work unchanged.

## Model Used

Claude Opus 4.6 — full reasoning, code generation, multi-file refactoring

## Checklist

- [x] Thinking path included
- [x] Model specified with details
- [x] Tests pass locally (adapter-utils and claude-local build clean)
- [ ] Tests added/updated if applicable (no existing test suite for parse.ts or metrics.ts)
- [x] No UI changes
- [x] Documentation updated (dashboard panels serve as visual docs)
- [x] Risks documented
- [x] Will address Greptile/reviewer comments

Closes ANGA-565