### PR TITLE
fix(heartbeat): repair broken merge from PR #47

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -73,7 +73,7 @@ import {
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
 // Terminal statuses for heartbeatRuns (matches HeartbeatRunStatus from @paperclipai/shared).
 // "skipped" is a WakeupRequestStatus, not a heartbeat run status — excluded intentionally.
-const TERMINAL_RUN_STATUSES = ["succeeded", "failed", "cancelled", "timed_out"] as const;
+const TERMINAL_RUN_STATUSES: string[] = ["succeeded", "failed", "cancelled", "timed_out"];
 const HEARTBEAT_MAX_CONCURRENT_RUNS_DEFAULT = 1;
 const HEARTBEAT_MAX_CONCURRENT_RUNS_MAX = 10;
 const DEFERRED_WAKE_CONTEXT_KEY = "_paperclipWakeContext";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -60,10 +60,8 @@ import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.
 import {
   hasSessionCompactionThresholds,
   resolveSessionCompactionPolicy,
-  type AdapterFallbackEntry,
   type SessionCompactionPolicy,
 } from "@paperclipai/adapter-utils";
-import { categorizeAdapterError } from "./adapter-failure-taxonomy.js";
 import {
   heartbeatRunsTotal,
   heartbeatDurationSeconds,


### PR DESCRIPTION
## Thinking Path

> - Paperclip orchestrates AI agents for zero-human companies
> - The heartbeat service (`server/src/services/heartbeat.ts`) is the core runtime loop that drives agent execution
> - PR #47 introduced a multi-step adapter fallback chain, replacing the old single-entry fallback
> - The merge created a syntax error: the new `logger.warn` call's context lines from the old code were misaligned, leaving the warn call without a message argument and 100 lines of dead old code inside the wrong scope
> - This breaks TypeScript compilation, which blocks ALL CI (typecheck, build, tests, benchmarks)
> - This PR fixes the syntax error and removes the dead old fallback code
> - The benefit is CI goes green and the new fallback chain works as PR #47 intended

## What Changed

- Fixed `logger.warn` call at line ~3093 — added missing message argument (`"adapter.fallback.jwt_creation_failed"`) and proper call closure
- Added `continue;` statement to skip the fallback chain entry when JWT creation fails
- Removed 100 lines of dead old fallback implementation that was incorrectly nested inside the JWT guard's `if` block (was supposed to be fully replaced by PR #47's new chain loop)
- Removed unused imports (`AdapterFallbackEntry` type, `categorizeAdapterError` function)

## Verification

- CI typecheck job should pass (was previously failing with `TS1135: Argument expression expected` at heartbeat.ts:3100)
- CI build job should pass
- CI test suite should run (was blocked by build failure)
- Adapter fallback chain behavior is unchanged from PR #47's intent — the removed code was dead/unreachable old implementation

## Risks

- **Medium risk**: Removing 100 lines of old fallback code. However, this code was (a) syntactically broken and never compiled, (b) nested inside a JWT-failure guard where it logically shouldn't run, and (c) fully superseded by PR #47's new chain loop at lines 3060-3265. The old code referenced undefined variables (`failureCategory`) confirming it was dead.

## Model Used

- Claude Opus 4.6 (`claude-opus-4-6`) via Claude Code, with tool use (file reading, grep, git blame, GitHub CLI)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have run tests locally and they pass (blocked by pnpm store permissions in sandbox — relying on CI)
- [ ] I have added or updated tests where applicable (no new tests needed — this is a syntax/dead-code fix)
- [ ] If this change affects the UI, I have included before/after screenshots (N/A)
- [ ] I have updated relevant documentation to reflect my changes (N/A)
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge