### PR TITLE
docs(instructions): trim HEARTBEAT.md to role-specific content only (A4)

### DIFF
--- a/cowork/agents/cto/HEARTBEAT.md
+++ b/cowork/agents/cto/HEARTBEAT.md
@@ -1,18 +1,8 @@
 # HEARTBEAT.md — CTO Execution Checklist
 
-Run this every heartbeat alongside the `paperclip` skill (which handles identity, inbox, checkout, and exit protocol).
+Follow the `paperclip` skill for identity, inbox, approval follow-up, checkout, status updates, and exit. This file covers CTO-specific steps only.
 
-## 1. Approval Follow-Up
-
-If `PAPERCLIP_APPROVAL_ID` is set:
-- `GET /api/approvals/{approvalId}` — review and action.
-- Close resolved issues or comment on what remains open.
-
-## 2. Assignments
-
-Use `paperclip` skill for inbox and checkout. Prioritize `in_progress` → `todo`. Skip `blocked` unless you can unblock it.
-
-## 3. Triage and Delegate
+## Triage and Delegate
 
 For each task:
 1. Assess: Is this architecture/design (yours) or implementation (engineer)?
@@ -20,22 +10,13 @@ For each task:
 3. If architecture: do the work — write the ADR, make the decision, document it.
 4. If unclear: break into subtasks, assign each to the right owner.
 
-## 4. Engineer Unblocking
+## Engineer Unblocking
 
 - Check if your reports have blocked tasks.
 - Assess the blocker; resolve if you can, escalate to CEO if it requires strategy/budget.
 - Post a comment on the blocked task with your assessment.
 
-## 5. Update and Exit
-
-- PATCH status to `done` with a summary comment.
-- PATCH status to `blocked` with a clear blocker description if stuck.
-- Always comment before exiting on in-progress work.
-
 ## Rules
 
-- Always include `X-Paperclip-Run-Id` header on mutating API calls.
-- Comment in concise markdown: status line + bullets + links.
-- Never look for unassigned work.
 - Never cancel cross-team tasks — reassign with a comment.
 - Escalate to CEO when blocked on strategy, budget, or org decisions.

--- a/server/src/onboarding-assets/ceo/HEARTBEAT.md
+++ b/server/src/onboarding-assets/ceo/HEARTBEAT.md
@@ -1,8 +1,8 @@
 # HEARTBEAT.md — CEO Heartbeat Checklist
 
-Run this alongside the `paperclip` skill (which handles identity, assignments, checkout, delegation API calls, and exit protocol).
+Follow the `paperclip` skill for identity, inbox, approval follow-up, checkout, status updates, and exit. This file covers CEO-specific steps only.
 
-## 1. Local Planning Check
+## Daily Plan Review
 
 1. Read today's plan from `./memory/YYYY-MM-DD.md` under "## Today's Plan".
 2. Review each planned item: completed, blocked, or up next.
@@ -10,24 +10,9 @@ Run this alongside the `paperclip` skill (which handles identity, assignments, c
 4. If ahead, start the next highest priority.
 5. Record progress in daily notes.
 
-## 2. Approval Follow-Up
-
-If `PAPERCLIP_APPROVAL_ID` is set:
-- Review the approval and its linked issues.
-- Close resolved issues or comment on what remains open.
-
-## 3. Assignments
-
-Use the `paperclip` skill for inbox, checkout, and work. Prioritize `in_progress` → `todo`. Skip `blocked` unless you can unblock it.
-
-## 4. Fact Extraction
+## Fact Extraction
 
 1. Check for new conversations since last extraction.
 2. Extract durable facts to `./life/` (PARA entities).
 3. Update `./memory/YYYY-MM-DD.md` with timeline entries.
 4. Update access metadata (timestamp, access_count) for referenced facts.
-
-## 5. Exit
-
-- Comment on any in-progress work before exiting.
-- If nothing assigned and no valid mention-handoff, exit cleanly.


### PR DESCRIPTION
## Summary

The `paperclip` skill already covers identity, inbox, approval follow-up, checkout, status updates, run-id headers, comment format, and exit protocol. HEARTBEAT.md was duplicating this content, adding ~274 tokens of overhead per heartbeat with no additional signal.

**Token savings:**
| File | Before | After | Saved |
|------|--------|-------|-------|
| CTO HEARTBEAT.md | ~395 tokens | ~231 tokens | **-164 tokens** |
| CEO HEARTBEAT.md | ~297 tokens | ~187 tokens | **-110 tokens** |
| **Total** | **~692 tokens** | **~418 tokens** | **-274 tokens/run** |

**Kept** (role-specific, not covered by skill):
- CTO: Triage & Delegate logic, Engineer Unblocking, cross-team task rules
- CEO: Daily Plan Review (memory files), Fact Extraction (PARA entities)

**Removed** (already in `paperclip` skill):
- Approval follow-up procedure
- Assignments/inbox/checkout reminders
- Update & exit procedure
- `X-Paperclip-Run-Id` header rule (skill line 34)
- Comment format rule (skill line 293-296)
- "Never look for unassigned work" (skill line 276)

## Test plan

- [ ] CI passes (no tests touch HEARTBEAT.md content)
- [ ] Verify trimmed CTO file still covers all CTO-specific behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)