### PR TITLE
feat(costs): add per-issue cost breakdown endpoint (B3)

### DIFF
--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -49,6 +49,7 @@ const mockCostService = vi.hoisted(() => ({
   byProvider: vi.fn().mockResolvedValue([]),
   byBiller: vi.fn().mockResolvedValue([]),
   windowSpend: vi.fn().mockResolvedValue([]),
+  byIssue: vi.fn().mockResolvedValue([]),
   byProject: vi.fn().mockResolvedValue([]),
 }));
 const mockFinanceService = vi.hoisted(() => ({
@@ -162,6 +163,15 @@ describe("cost routes", () => {
   it("returns 400 for an invalid 'to' date string", async () => {
     const { parseCostDateRange } = await loadCostParsers();
     expect(() => parseCostDateRange({ to: "banana" })).toThrow(/invalid 'to' date/i);
+  });
+
+  it("returns cost rows by issue for valid requests", async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get("/api/companies/company-1/costs/by-issue")
+      .query({ from: "2026-02-01T00:00:00.000Z", to: "2026-02-28T23:59:59.999Z" });
+    expect(res.status).toBe(200);
+    expect(mockCostService.byIssue).toHaveBeenCalled();
   });
 
   it("returns finance summary rows for valid requests", async () => {

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -128,6 +128,14 @@ export function costRoutes(db: Db) {
     res.json(rows);
   });
 
+  router.get("/companies/:companyId/costs/by-issue", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    const range = parseCostDateRange(req.query);
+    const rows = await costs.byIssue(companyId, range);
+    res.json(rows);
+  });
+
   router.get("/companies/:companyId/costs/by-agent-model", async (req, res) => {
     const companyId = req.params.companyId as string;
     assertCompanyAccess(req, companyId);

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -311,6 +311,33 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         .orderBy(costEvents.provider, costEvents.biller, costEvents.billingType, costEvents.model);
     },
 
+    byIssue: async (companyId: string, range?: CostDateRange) => {
+      const conditions: ReturnType<typeof eq>[] = [
+        eq(costEvents.companyId, companyId),
+        isNotNull(costEvents.issueId),
+      ];
+      if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
+      if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
+
+      return db
+        .select({
+          issueId: costEvents.issueId,
+          issueIdentifier: issues.identifier,
+          issueTitle: issues.title,
+          issueStatus: issues.status,
+          costCents: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::int`,
+          inputTokens: sql<number>`coalesce(sum(${costEvents.inputTokens}), 0)::int`,
+          cachedInputTokens: sql<number>`coalesce(sum(${costEvents.cachedInputTokens}), 0)::int`,
+          outputTokens: sql<number>`coalesce(sum(${costEvents.outputTokens}), 0)::int`,
+          runCount: sql<number>`count(distinct ${costEvents.heartbeatRunId})::int`,
+        })
+        .from(costEvents)
+        .leftJoin(issues, eq(costEvents.issueId, issues.id))
+        .where(and(...conditions))
+        .groupBy(costEvents.issueId, issues.identifier, issues.title, issues.status)
+        .orderBy(desc(sql`coalesce(sum(${costEvents.costCents}), 0)::int`));
+    },
+
     byProject: async (companyId: string, range?: CostDateRange) => {
       const issueIdAsText = sql<string>`${issues.id}::text`;
       const runProjectLinks = db


### PR DESCRIPTION
## Summary

Adds `GET /companies/:companyId/costs/by-issue` — returns token and cost totals grouped by issue, enabling the tokens-per-task view from the B3 token usage dashboard objective.

The `costEvents` table already has `issueId`, `inputTokens`, `cachedInputTokens`, `outputTokens`, `costCents`, and `heartbeatRunId`. This endpoint surfaces them with issue metadata joined from `issues`.

**Response shape per row:**
```json
{
  "issueId": "uuid",
  "issueIdentifier": "PAP-4",
  "issueTitle": "A3: Skill scoping",
  "issueStatus": "done",
  "costCents": 142,
  "inputTokens": 48230,
  "cachedInputTokens": 31100,
  "outputTokens": 4811,
  "runCount": 7
}
```

Supports `?from=` and `?to=` date range params (same as other cost endpoints). Sorted by `costCents` descending.

## Test plan

- [ ] CI passes (typecheck, build, unit)
- [ ] `GET /companies/:companyId/costs/by-issue` returns 200 with empty array when no cost events with issueId exist
- [ ] Rows with null `issueId` are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)