### PR TITLE
fix(types): replace 3 any casts with narrow typed assertions in misc services

### DIFF
--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -99,6 +99,7 @@ export async function listCodexModels(): Promise<AdapterModel[]> {
   return fallback;
 }
 
+/** Clears the cached Codex models result; for use in tests only. */
 export function resetCodexModelsCacheForTests() {
   cached = null;
 }

--- a/server/src/adapters/cursor-models.ts
+++ b/server/src/adapters/cursor-models.ts
@@ -67,6 +67,7 @@ function collectFromJsonValue(value: unknown, target: AdapterModel[]) {
   }
 }
 
+/** Parses Cursor model list output from stdout/stderr into a deduplicated AdapterModel array. */
 export function parseCursorModelsOutput(stdout: string, stderr: string): AdapterModel[] {
   const models: AdapterModel[] = [];
   const combined = `${stdout}\n${stderr}`;
@@ -161,10 +162,12 @@ export async function listCursorModels(): Promise<AdapterModel[]> {
   return dedupeModels(cursorFallbackModels);
 }
 
+/** Clears the cached Cursor models result; for use in tests only. */
 export function resetCursorModelsCacheForTests() {
   cached = null;
 }
 
+/** Overrides the Cursor models runner function; pass null to restore the default. For use in tests only. */
 export function setCursorModelsRunnerForTests(runner: (() => CursorModelsCommandResult) | null) {
   cursorModelsRunner = runner ?? defaultCursorModelsRunner;
 }

--- a/server/src/adapters/plugin-loader.ts
+++ b/server/src/adapters/plugin-loader.ts
@@ -27,6 +27,7 @@ import type { AdapterPluginRecord } from "../services/adapter-plugin-store.js";
 
 const uiParserCache = new Map<string, string>();
 
+/** Returns the cached UI parser source string for the given adapter type, or undefined if not yet loaded. */
 export function getUiParserSource(adapterType: string): string | undefined {
   return uiParserCache.get(adapterType);
 }

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -279,6 +279,7 @@ export function waitForExternalAdapters(): Promise<void> {
   return externalAdaptersReady;
 }
 
+/** Registers or replaces a server adapter module, saving the builtin fallback if a builtin type is being overridden. */
 export function registerServerAdapter(adapter: ServerAdapterModule): void {
   if (BUILTIN_ADAPTER_TYPES.has(adapter.type) && !builtinFallbacks.has(adapter.type)) {
     const existing = adaptersByType.get(adapter.type);
@@ -289,6 +290,7 @@ export function registerServerAdapter(adapter: ServerAdapterModule): void {
   adaptersByType.set(adapter.type, adapter);
 }
 
+/** Removes a non-builtin adapter or restores a builtin's fallback when an override is unregistered. */
 export function unregisterServerAdapter(type: string): void {
   if (type === processAdapter.type || type === httpAdapter.type) return;
   if (builtinFallbacks.has(type)) {
@@ -305,6 +307,7 @@ export function unregisterServerAdapter(type: string): void {
   adaptersByType.delete(type);
 }
 
+/** Returns the active adapter for the given type, throwing if it is not registered. */
 export function requireServerAdapter(type: string): ServerAdapterModule {
   const adapter = findActiveServerAdapter(type);
   if (!adapter) {
@@ -313,10 +316,12 @@ export function requireServerAdapter(type: string): ServerAdapterModule {
   return adapter;
 }
 
+/** Returns the active adapter for the given type, falling back to the process adapter if not found. */
 export function getServerAdapter(type: string): ServerAdapterModule {
   return findActiveServerAdapter(type) ?? processAdapter;
 }
 
+/** Returns the list of models for an adapter, preferring dynamically discovered models over the static list. */
 export async function listAdapterModels(type: string): Promise<{ id: string; label: string }[]> {
   const adapter = findActiveServerAdapter(type);
   if (!adapter) return [];
@@ -327,6 +332,7 @@ export async function listAdapterModels(type: string): Promise<{ id: string; lab
   return adapter.models ?? [];
 }
 
+/** Returns all registered server adapter modules, including overrides. */
 export function listServerAdapters(): ServerAdapterModule[] {
   return Array.from(adaptersByType.values());
 }
@@ -344,6 +350,7 @@ export function listEnabledServerAdapters(): ServerAdapterModule[] {
     : Array.from(adaptersByType.values());
 }
 
+/** Runs the adapter's model-detection logic and returns the detected model info, or null if unsupported. */
 export async function detectAdapterModel(
   type: string,
 ): Promise<{ model: string; provider: string; source: string; candidates?: string[] } | null> {
@@ -402,10 +409,12 @@ export function getPausedOverrides(): Set<string> {
   return pausedOverrides;
 }
 
+/** Looks up an adapter by type in the registry without considering pause state, returning null if absent. */
 export function findServerAdapter(type: string): ServerAdapterModule | null {
   return adaptersByType.get(type) ?? null;
 }
 
+/** Looks up the currently active adapter for a type, returning the builtin fallback when the override is paused. */
 export function findActiveServerAdapter(type: string): ServerAdapterModule | null {
   if (pausedOverrides.has(type)) {
     const fallback = builtinFallbacks.get(type);

--- a/server/src/adapters/utils.ts
+++ b/server/src/adapters/utils.ts
@@ -34,6 +34,7 @@ export const ensureAbsoluteDirectory = serverUtils.ensureAbsoluteDirectory;
 export const ensureCommandResolvable = serverUtils.ensureCommandResolvable;
 export const resolveCommandForLogs = serverUtils.resolveCommandForLogs;
 
+/** Builds a sanitized copy of the invocation environment suitable for including in log output. */
 export function buildInvocationEnvForLogs(
   env: Record<string, string>,
   options: BuildInvocationEnvForLogsOptions = {},

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -65,6 +65,7 @@ function safeCompare(a: string, b: string) {
   return timingSafeEqual(left, right);
 }
 
+/** Creates a signed HS256 JWT for a local agent run, or returns null if no JWT secret is configured. */
 export function createLocalAgentJwt(agentId: string, companyId: string, adapterType: string, runId: string) {
   const config = jwtConfig();
   if (!config) return null;
@@ -92,6 +93,7 @@ export function createLocalAgentJwt(agentId: string, companyId: string, adapterT
   return `${signingInput}.${signature}`;
 }
 
+/** Verifies a local agent JWT and returns its claims, or null if invalid or expired. */
 export function verifyLocalAgentJwt(token: string): LocalAgentJwtClaims | null {
   if (!token) return null;
   const config = jwtConfig();

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -57,6 +57,7 @@ import { adminRoutes } from "./routes/admin.js";
 type UiMode = "none" | "static" | "vite-dev";
 const FEEDBACK_EXPORT_FLUSH_INTERVAL_MS = 5_000;
 
+/** Derives a Vite HMR websocket port offset from the server port, staying within valid port range. */
 export function resolveViteHmrPort(serverPort: number): number {
   if (serverPort <= 55_535) {
     return serverPort + 10_000;

--- a/server/src/attachment-types.ts
+++ b/server/src/attachment-types.ts
@@ -70,11 +70,13 @@ export function matchesContentType(contentType: string, allowedPatterns: string[
   });
 }
 
+/** Normalizes a content type string to lowercase, falling back to `application/octet-stream` if empty. */
 export function normalizeContentType(contentType: string | null | undefined): string {
   const normalized = (contentType ?? "").trim().toLowerCase();
   return normalized || DEFAULT_ATTACHMENT_CONTENT_TYPE;
 }
 
+/** Returns true if the content type should be served inline (e.g. images, PDF, plain text). */
 export function isInlineAttachmentContentType(contentType: string): boolean {
   return matchesContentType(contentType, [...INLINE_ATTACHMENT_TYPES]);
 }

--- a/server/src/auth/better-auth.ts
+++ b/server/src/auth/better-auth.ts
@@ -42,6 +42,7 @@ function headersFromExpressRequest(req: Request): Headers {
   return headersFromNodeHeaders(req.headers);
 }
 
+/** Derives the list of trusted origins for BetterAuth from the deployment config and allowed hostnames. */
 export function deriveAuthTrustedOrigins(config: Config): string[] {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
   const trustedOrigins = new Set<string>();
@@ -67,6 +68,7 @@ export function deriveAuthTrustedOrigins(config: Config): string[] {
 
 const AUTH_DEV_SECRET = "paperclip-dev-secret";
 
+/** Creates and configures a BetterAuth instance backed by the given Drizzle database and server config. */
 export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?: string[]): BetterAuthInstance {
   const baseUrl = config.authBaseUrlMode === "explicit" ? config.authPublicBaseUrl : undefined;
   const secret = process.env.BETTER_AUTH_SECRET ?? process.env.PAPERCLIP_AGENT_JWT_SECRET;
@@ -111,6 +113,7 @@ export function createBetterAuthInstance(db: Db, config: Config, trustedOrigins?
   return betterAuth(authConfig);
 }
 
+/** Wraps a BetterAuth instance as an Express RequestHandler, forwarding errors to next(). */
 export function createBetterAuthHandler(auth: BetterAuthInstance): RequestHandler {
   const handler = toNodeHandler(auth);
   return (req, res, next) => {

--- a/server/src/board-claim.ts
+++ b/server/src/board-claim.ts
@@ -65,6 +65,7 @@ export async function initializeBoardClaimChallenge(
   }
 }
 
+/** Returns the board-claim URL for displaying in startup output, or null if no active unclaimed challenge. */
 export function getBoardClaimWarningUrl(host: string, port: number): string | null {
   if (!activeChallenge) return null;
   if (activeChallenge.claimedAt || activeChallenge.expiresAt.getTime() <= Date.now()) return null;
@@ -72,6 +73,7 @@ export function getBoardClaimWarningUrl(host: string, port: number): string | nu
   return `http://${visibleHost}:${port}/board-claim/${activeChallenge.token}?code=${activeChallenge.code}`;
 }
 
+/** Returns the current status and metadata of a board-claim challenge for the given token/code pair. */
 export function inspectBoardClaimChallenge(token: string, code: string | undefined) {
   const status = getChallengeStatus(token, code);
   return {

--- a/server/src/config-file.ts
+++ b/server/src/config-file.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { paperclipConfigSchema, type PaperclipConfig } from "@paperclipai/shared";
 import { resolvePaperclipConfigPath } from "./paths.js";
 
+/** Reads and validates the Paperclip config file, returning null if missing or invalid. */
 export function readConfigFile(): PaperclipConfig | null {
   const configPath = resolvePaperclipConfigPath();
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -107,6 +107,7 @@ function detectTailnetBindHost(): string | undefined {
   }
 }
 
+/** Loads the full server config by merging the config file with environment variable overrides. */
 export function loadConfig(): Config {
   const fileConfig = readConfigFile();
   const fileDatabaseMode =

--- a/server/src/dev-runner-worktree.ts
+++ b/server/src/dev-runner-worktree.ts
@@ -41,6 +41,7 @@ type WorktreeEnvBootstrapResult =
   | { envPath: string; missingEnv: true }
   | { envPath: string; missingEnv: false };
 
+/** Returns true if the given directory is a git worktree checkout (its .git entry is a file, not a directory). */
 export function isLinkedGitWorktreeCheckout(rootDir: string): boolean {
   const gitMetadataPath = path.join(rootDir, ".git");
   if (!existsSync(gitMetadataPath)) return false;
@@ -51,10 +52,12 @@ export function isLinkedGitWorktreeCheckout(rootDir: string): boolean {
   return readFileSync(gitMetadataPath, "utf8").trimStart().startsWith("gitdir:");
 }
 
+/** Returns the canonical path of the per-worktree .env file inside a worktree root. */
 export function resolveWorktreeEnvFilePath(rootDir: string): string {
   return path.resolve(rootDir, ".paperclip", ".env");
 }
 
+/** Loads the worktree .env file into the given process env, reporting whether the file was missing. */
 export function bootstrapDevRunnerWorktreeEnv(
   rootDir: string,
   env: NodeJS.ProcessEnv = process.env,

--- a/server/src/dev-server-status.ts
+++ b/server/src/dev-server-status.ts
@@ -39,6 +39,7 @@ function normalizeTimestamp(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+/** Reads the persisted dev-server status file from the path in PAPERCLIP_DEV_SERVER_STATUS_FILE, or returns null. */
 export function readPersistedDevServerStatus(
   env: NodeJS.ProcessEnv = process.env,
 ): PersistedDevServerStatus | null {
@@ -76,6 +77,7 @@ export function readPersistedDevServerStatus(
   }
 }
 
+/** Converts a persisted dev-server status into a structured health status with restart and migration info. */
 export function toDevServerHealthStatus(
   persisted: PersistedDevServerStatus,
   opts: { autoRestartEnabled: boolean; activeRunCount: number },

--- a/server/src/dev-watch-ignore.ts
+++ b/server/src/dev-watch-ignore.ts
@@ -17,6 +17,7 @@ function addIgnorePath(target: Set<string>, candidate: string): void {
   }
 }
 
+/** Returns the set of glob paths that the dev-server file watcher should ignore. */
 export function resolveServerDevWatchIgnorePaths(serverRoot: string): string[] {
   const ignorePaths = new Set<string>([
     "**/{node_modules,bower_components,vendor}/**",

--- a/server/src/errors.ts
+++ b/server/src/errors.ts
@@ -9,26 +9,32 @@ export class HttpError extends Error {
   }
 }
 
+/** Creates an HTTP 400 Bad Request error. */
 export function badRequest(message: string, details?: unknown) {
   return new HttpError(400, message, details);
 }
 
+/** Creates an HTTP 401 Unauthorized error. */
 export function unauthorized(message = "Unauthorized") {
   return new HttpError(401, message);
 }
 
+/** Creates an HTTP 403 Forbidden error. */
 export function forbidden(message = "Forbidden") {
   return new HttpError(403, message);
 }
 
+/** Creates an HTTP 404 Not Found error. */
 export function notFound(message = "Not found") {
   return new HttpError(404, message);
 }
 
+/** Creates an HTTP 409 Conflict error. */
 export function conflict(message: string, details?: unknown) {
   return new HttpError(409, message, details);
 }
 
+/** Creates an HTTP 422 Unprocessable Entity error. */
 export function unprocessable(message: string, details?: unknown) {
   return new HttpError(422, message, details);
 }

--- a/server/src/home-paths.ts
+++ b/server/src/home-paths.ts
@@ -12,12 +12,14 @@ function expandHomePrefix(value: string): string {
   return value;
 }
 
+/** Returns the Paperclip home directory, respecting `PAPERCLIP_HOME` env override. */
 export function resolvePaperclipHomeDir(): string {
   const envHome = process.env.PAPERCLIP_HOME?.trim();
   if (envHome) return path.resolve(expandHomePrefix(envHome));
   return path.resolve(os.homedir(), ".paperclip");
 }
 
+/** Returns the validated Paperclip instance ID from `PAPERCLIP_INSTANCE_ID` env (defaults to "default"). */
 export function resolvePaperclipInstanceId(): string {
   const raw = process.env.PAPERCLIP_INSTANCE_ID?.trim() || DEFAULT_INSTANCE_ID;
   if (!INSTANCE_ID_RE.test(raw)) {
@@ -26,34 +28,42 @@ export function resolvePaperclipInstanceId(): string {
   return raw;
 }
 
+/** Returns the root directory for the current Paperclip instance. */
 export function resolvePaperclipInstanceRoot(): string {
   return path.resolve(resolvePaperclipHomeDir(), "instances", resolvePaperclipInstanceId());
 }
 
+/** Returns the default config.json path for the current instance. */
 export function resolveDefaultConfigPath(): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "config.json");
 }
 
+/** Returns the default embedded Postgres data directory for the current instance. */
 export function resolveDefaultEmbeddedPostgresDir(): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "db");
 }
 
+/** Returns the default logs directory for the current instance. */
 export function resolveDefaultLogsDir(): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "logs");
 }
 
+/** Returns the default master secrets key file path for the current instance. */
 export function resolveDefaultSecretsKeyFilePath(): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "secrets", "master.key");
 }
 
+/** Returns the default file storage directory for the current instance. */
 export function resolveDefaultStorageDir(): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "data", "storage");
 }
 
+/** Returns the default backup directory for the current instance. */
 export function resolveDefaultBackupDir(): string {
   return path.resolve(resolvePaperclipInstanceRoot(), "data", "backups");
 }
 
+/** Returns the workspace directory for a given agent ID under the current instance. */
 export function resolveDefaultAgentWorkspaceDir(agentId: string): string {
   const trimmed = agentId.trim();
   if (!PATH_SEGMENT_RE.test(trimmed)) {
@@ -71,6 +81,7 @@ function sanitizeFriendlyPathSegment(value: string | null | undefined, fallback 
   return sanitized || fallback;
 }
 
+/** Returns the workspace directory for a managed project, scoped by company, project, and optional repo name. */
 export function resolveManagedProjectWorkspaceDir(input: {
   companyId: string;
   projectId: string;
@@ -90,6 +101,7 @@ export function resolveManagedProjectWorkspaceDir(input: {
   );
 }
 
+/** Resolves a path, expanding a leading `~` to the user's home directory. */
 export function resolveHomeAwarePath(value: string): string {
   return path.resolve(expandHomePrefix(value));
 }

--- a/server/src/log-redaction.ts
+++ b/server/src/log-redaction.ts
@@ -40,6 +40,7 @@ function replaceLastPathSegment(pathValue: string, replacement: string) {
   return `${normalized.slice(0, lastSeparator + 1)}${replacement}`;
 }
 
+/** Returns a masked version of a username (first character followed by asterisks) safe for log output. */
 export function maskUserNameForLogs(value: string, fallback = CURRENT_USER_REDACTION_TOKEN) {
   const trimmed = value.trim();
   if (!trimmed) return fallback;
@@ -104,6 +105,7 @@ function resolveCurrentUserCandidates(opts?: CurrentUserRedactionOptions) {
   return { userNames, homeDirs, replacement };
 }
 
+/** Replaces occurrences of the current OS user name and home directory in a string with masked tokens. */
 export function redactCurrentUserText(input: string, opts?: CurrentUserRedactionOptions) {
   if (!input) return input;
   if (opts?.enabled === false) return input;
@@ -127,6 +129,7 @@ export function redactCurrentUserText(input: string, opts?: CurrentUserRedaction
   return result;
 }
 
+/** Recursively redacts current-user identifiers from strings, arrays, and plain objects. */
 export function redactCurrentUserValue<T>(value: T, opts?: CurrentUserRedactionOptions): T {
   if (typeof value === "string") {
     return redactCurrentUserText(value, opts) as T;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -18,6 +18,7 @@ interface ActorMiddlewareOptions {
   resolveSession?: (req: Request) => Promise<BetterAuthSessionResult | null>;
 }
 
+/** Returns Express middleware that resolves and attaches the current actor (board user or agent) to each request. */
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
   const boardAuth = boardAuthService(db);
   return async (req, _res, next) => {
@@ -172,6 +173,7 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
   };
 }
 
+/** Returns true if the request actor is a board user (not an agent). */
 export function requireBoard(req: Express.Request) {
   return req.actor.type === "board";
 }

--- a/server/src/middleware/board-mutation-guard.ts
+++ b/server/src/middleware/board-mutation-guard.ts
@@ -38,6 +38,7 @@ function isTrustedBoardMutationRequest(req: Request) {
   return false;
 }
 
+/** Returns Express middleware that blocks non-safe HTTP methods when the board is in read-only mode. */
 export function boardMutationGuard(): RequestHandler {
   return (req, res, next) => {
     if (SAFE_METHODS.has(req.method.toUpperCase())) {

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -32,6 +32,7 @@ function attachErrorContext(
   }
 }
 
+/** Express error-handling middleware that formats and sends structured error responses. */
 export function errorHandler(
   err: unknown,
   req: Request,

--- a/server/src/middleware/private-hostname-guard.ts
+++ b/server/src/middleware/private-hostname-guard.ts
@@ -28,6 +28,7 @@ function normalizeAllowedHostnames(values: string[]): string[] {
   return Array.from(unique);
 }
 
+/** Builds the set of hostnames that are allowed through the private hostname guard, including localhost aliases. */
 export function resolvePrivateHostnameAllowSet(opts: { allowedHostnames: string[]; bindHost: string }): Set<string> {
   const configuredAllow = normalizeAllowedHostnames(opts.allowedHostnames);
   const bindHost = opts.bindHost.trim().toLowerCase();
@@ -49,6 +50,7 @@ function blockedHostnameMessage(hostname: string): string {
   );
 }
 
+/** Returns Express middleware that rejects requests from hostnames not in the configured allow set. */
 export function privateHostnameGuard(opts: {
   enabled: boolean;
   allowedHostnames: string[];

--- a/server/src/middleware/validate.ts
+++ b/server/src/middleware/validate.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from "express";
 import type { ZodSchema } from "zod";
 
+/** Returns Express middleware that validates and replaces req.body using the given Zod schema. */
 export function validate(schema: ZodSchema) {
   return (req: Request, _res: Response, next: NextFunction) => {
     req.body = schema.parse(req.body);

--- a/server/src/observability/metrics.ts
+++ b/server/src/observability/metrics.ts
@@ -119,6 +119,7 @@ export function httpMetricsMiddleware(req: Request, res: Response, next: NextFun
   next();
 }
 
+/** Returns true if metrics collection is enabled via env vars. */
 export function isMetricsEnabled(): boolean {
   return (
     process.env.PAPERCLIP_METRICS_ENABLED === "true" ||

--- a/server/src/observability/tracing.ts
+++ b/server/src/observability/tracing.ts
@@ -9,6 +9,7 @@
  *   OTEL_SERVICE_NAME        - Override service name (default: paperclip-server)
  */
 
+/** Initializes OpenTelemetry tracing if PAPERCLIP_OTEL_ENDPOINT is set; no-op otherwise. */
 export function initTracing(): void {
   const endpoint = process.env.PAPERCLIP_OTEL_ENDPOINT;
   if (!endpoint) return;

--- a/server/src/paths.ts
+++ b/server/src/paths.ts
@@ -23,12 +23,14 @@ function findConfigFileFromAncestors(startDir: string): string | null {
   return null;
 }
 
+/** Resolves the Paperclip config file path from an override, env var, ancestor search, or default location. */
 export function resolvePaperclipConfigPath(overridePath?: string): string {
   if (overridePath) return path.resolve(overridePath);
   if (process.env.PAPERCLIP_CONFIG) return path.resolve(process.env.PAPERCLIP_CONFIG);
   return findConfigFileFromAncestors(process.cwd()) ?? resolveDefaultConfigPath();
 }
 
+/** Returns the path of the .env file that lives alongside the resolved config file. */
 export function resolvePaperclipEnvPath(overrideConfigPath?: string): string {
   return path.resolve(path.dirname(resolvePaperclipConfigPath(overrideConfigPath)), PAPERCLIP_ENV_FILENAME);
 }

--- a/server/src/realtime/live-events-ws.ts
+++ b/server/src/realtime/live-events-ws.ts
@@ -175,6 +175,7 @@ async function authorizeUpgrade(
   };
 }
 
+/** Attaches the live-events WebSocket server to an existing HTTP server, wiring up auth and fan-out. */
 export function setupLiveEventsWebSocketServer(
   server: HttpServer,
   db: Db,

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -28,6 +28,7 @@ function isPlainBinding(value: unknown): value is { type: "plain"; value: unknow
   return value.type === "plain" && "value" in value;
 }
 
+/** Redacts secret-looking values from a plain record, preserving binding wrappers. */
 export function sanitizeRecord(record: Record<string, unknown>): Record<string, unknown> {
   const redacted: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(record)) {
@@ -52,6 +53,7 @@ export function sanitizeRecord(record: Record<string, unknown>): Record<string, 
   return redacted;
 }
 
+/** Sanitizes an event payload record in place, returning null for null input. */
 export function redactEventPayload(payload: Record<string, unknown> | null): Record<string, unknown> | null {
   if (!payload) return null;
   if (!isPlainObject(payload)) return payload;

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -77,6 +77,7 @@ function createClaimSecret() {
   return `pcp_claim_${randomBytes(24).toString("hex")}`;
 }
 
+/** Returns the expiry Date for a new company invite token based on the current time. */
 export function companyInviteExpiresAt(nowMs: number = Date.now()) {
   return new Date(nowMs + COMPANY_INVITE_TTL_MS);
 }
@@ -421,6 +422,7 @@ function generateEd25519PrivateKeyPem(): string {
     .toString();
 }
 
+/** Builds the agent defaults payload used when accepting an invite, merging OpenClaw gateway auth headers when applicable. */
 export function buildJoinDefaultsPayloadForAccept(input: {
   adapterType: string | null;
   defaultsPayload: unknown;
@@ -483,6 +485,7 @@ export function buildJoinDefaultsPayloadForAccept(input: {
   return Object.keys(merged).length > 0 ? merged : null;
 }
 
+/** Merges an existing and a new agent defaults payload for a replay invite accept, deep-merging headers. */
 export function mergeJoinDefaultsPayloadForReplay(
   existingDefaultsPayload: unknown,
   nextDefaultsPayload: unknown
@@ -523,6 +526,7 @@ export function mergeJoinDefaultsPayloadForReplay(
   return merged;
 }
 
+/** Returns true when an openclaw_gateway agent invite accept can be safely replayed over an existing join request. */
 export function canReplayOpenClawGatewayInviteAccept(input: {
   requestType: "human" | "agent";
   adapterType: string | null;
@@ -601,6 +605,7 @@ function summarizeOpenClawGatewayDefaultsForLog(defaultsPayload: unknown) {
   };
 }
 
+/** Validates and normalizes the agent defaults payload for a join request, returning diagnostics and fatal errors. */
 export function normalizeAgentDefaultsForJoin(input: {
   adapterType: string | null;
   defaultsPayload: unknown;
@@ -1088,6 +1093,7 @@ function buildInviteOnboardingManifest(
   };
 }
 
+/** Builds the plaintext onboarding document returned to an agent after accepting an invite. */
 export function buildInviteOnboardingTextDocument(
   req: Request,
   token: string,
@@ -1440,6 +1446,7 @@ function grantsFromDefaults(
   return result;
 }
 
+/** Derives the permission grants for a joining agent from its defaults payload, always including tasks:assign. */
 export function agentJoinGrantsFromDefaults(
   defaultsPayload: Record<string, unknown> | null | undefined
 ): Array<{
@@ -1465,6 +1472,7 @@ type JoinRequestManagerCandidate = {
   reportsTo: string | null;
 };
 
+/** Resolves the manager agent ID for a new join request by finding the root CEO among candidates. */
 export function resolveJoinRequestAgentManagerId(
   candidates: JoinRequestManagerCandidate[]
 ): string | null {
@@ -1581,6 +1589,7 @@ async function probeInviteResolutionTarget(
   }
 }
 
+/** Mounts all access-management routes (invites, join requests, CLI auth, member permissions) onto the given Express app. */
 export function accessRoutes(
   db: Db,
   opts: {

--- a/server/src/routes/activity.ts
+++ b/server/src/routes/activity.ts
@@ -17,6 +17,7 @@ const createActivitySchema = z.object({
   details: z.record(z.unknown()).optional().nullable(),
 });
 
+/** Creates the Express router for activity feed endpoints. */
 export function activityRoutes(db: Db) {
   const router = Router();
   const svc = activityService(db);

--- a/server/src/routes/adapters.ts
+++ b/server/src/routes/adapters.ts
@@ -163,6 +163,7 @@ function registerWithSessionManagement(adapter: ServerAdapterModule): void {
 // Router
 // ---------------------------------------------------------------------------
 
+/** Creates the Express router for adapter configuration and model listing endpoints. */
 export function adapterRoutes() {
   const router = Router();
 

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -13,6 +13,7 @@ function assertBoard(req: Request) {
   }
 }
 
+/** Creates the Express router for admin-only instance management endpoints. */
 export function adminRoutes(db: Db) {
   const router = Router();
   const heartbeat = heartbeatService(db as any);

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -73,6 +73,7 @@ import {
 } from "../services/default-agent-instructions.js";
 import { getTelemetryClient } from "../telemetry.js";
 
+/** Creates the Express router for agent CRUD and runtime management endpoints. */
 export function agentRoutes(db: Db) {
   const DEFAULT_INSTRUCTIONS_PATH_KEYS: Record<string, string> = {
     claude_local: "instructionsFilePath",

--- a/server/src/routes/approvals.ts
+++ b/server/src/routes/approvals.ts
@@ -26,6 +26,7 @@ function redactApprovalPayload<T extends { payload: Record<string, unknown> }>(a
   };
 }
 
+/** Creates the Express router for approval workflow endpoints. */
 export function approvalRoutes(db: Db) {
   const router = Router();
   const svc = approvalService(db);

--- a/server/src/routes/assets.ts
+++ b/server/src/routes/assets.ts
@@ -82,6 +82,7 @@ function sanitizeSvgBuffer(input: Buffer): Buffer | null {
   }
 }
 
+/** Creates the Express router for asset upload and retrieval endpoints. */
 export function assetRoutes(db: Db, storage: StorageService) {
   const router = Router();
   const svc = assetService(db);

--- a/server/src/routes/authz.ts
+++ b/server/src/routes/authz.ts
@@ -1,12 +1,14 @@
 import type { Request } from "express";
 import { forbidden, unauthorized } from "../errors.js";
 
+/** Throws a 403 Forbidden error if the request actor is not a board (user) actor. */
 export function assertBoard(req: Request) {
   if (req.actor.type !== "board") {
     throw forbidden("Board access required");
   }
 }
 
+/** Throws a 403 Forbidden error if the actor is not a board actor with instance-admin privileges. */
 export function assertInstanceAdmin(req: Request) {
   assertBoard(req);
   if (req.actor.source === "local_implicit" || req.actor.isInstanceAdmin) {
@@ -15,6 +17,7 @@ export function assertInstanceAdmin(req: Request) {
   throw forbidden("Instance admin access required");
 }
 
+/** Throws 401/403 if the current actor has no authenticated access to the specified company. */
 export function assertCompanyAccess(req: Request, companyId: string) {
   if (req.actor.type === "none") {
     throw unauthorized();
@@ -30,6 +33,7 @@ export function assertCompanyAccess(req: Request, companyId: string) {
   }
 }
 
+/** Returns a normalized actor info object (type, actorId, agentId, runId) for the authenticated request actor. */
 export function getActorInfo(req: Request) {
   if (req.actor.type === "none") {
     throw unauthorized();

--- a/server/src/routes/companies.ts
+++ b/server/src/routes/companies.ts
@@ -26,6 +26,7 @@ import {
 import type { StorageService } from "../storage/types.js";
 import { assertBoard, assertCompanyAccess, assertInstanceAdmin, getActorInfo } from "./authz.js";
 
+/** Creates the Express router for company management endpoints. */
 export function companyRoutes(db: Db, storage?: StorageService) {
   const router = Router();
   const svc = companyService(db);

--- a/server/src/routes/company-skills.ts
+++ b/server/src/routes/company-skills.ts
@@ -21,6 +21,7 @@ type SkillTelemetryInput = {
   metadata: Record<string, unknown> | null;
 };
 
+/** Creates the Express router for company skill management endpoints. */
 export function companySkillRoutes(db: Db) {
   const router = Router();
   const agents = agentService(db);

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -21,6 +21,7 @@ import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
 import { fetchAllQuotaWindows } from "../services/quota-windows.js";
 import { badRequest } from "../errors.js";
 
+/** Parses optional from/to date filters from a query params record, throwing on invalid dates. */
 export function parseCostDateRange(query: Record<string, unknown>) {
   const fromRaw = query.from as string | undefined;
   const toRaw = query.to as string | undefined;
@@ -31,6 +32,7 @@ export function parseCostDateRange(query: Record<string, unknown>) {
   return (from || to) ? { from, to } : undefined;
 }
 
+/** Parses and validates an integer result limit from a query params record (1–500, default 100). */
 export function parseCostLimit(query: Record<string, unknown>) {
   const raw = Array.isArray(query.limit) ? query.limit[0] : query.limit;
   if (raw == null || raw === "") return 100;
@@ -41,6 +43,7 @@ export function parseCostLimit(query: Record<string, unknown>) {
   return limit;
 }
 
+/** Creates the Express router for cost event and budget endpoints. */
 export function costRoutes(db: Db) {
   const router = Router();
   const heartbeat = heartbeatService(db);

--- a/server/src/routes/dashboard.ts
+++ b/server/src/routes/dashboard.ts
@@ -3,6 +3,7 @@ import type { Db } from "@paperclipai/db";
 import { dashboardService } from "../services/dashboard.js";
 import { assertCompanyAccess } from "./authz.js";
 
+/** Creates the Express router for dashboard summary endpoints. */
 export function dashboardRoutes(db: Db) {
   const router = Router();
   const svc = dashboardService(db);

--- a/server/src/routes/execution-workspaces.ts
+++ b/server/src/routes/execution-workspaces.ts
@@ -15,6 +15,7 @@ import {
 } from "../services/workspace-runtime.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 
+/** Creates the Express router for execution workspace management endpoints. */
 export function executionWorkspaceRoutes(db: Db) {
   const router = Router();
   const svc = executionWorkspaceService(db);

--- a/server/src/routes/goals.ts
+++ b/server/src/routes/goals.ts
@@ -7,6 +7,7 @@ import { goalService, logActivity } from "../services/index.js";
 import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { getTelemetryClient } from "../telemetry.js";
 
+/** Creates the Express router for company goal endpoints. */
 export function goalRoutes(db: Db) {
   const router = Router();
   const svc = goalService(db);

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -7,6 +7,7 @@ import { readPersistedDevServerStatus, toDevServerHealthStatus } from "../dev-se
 import { instanceSettingsService } from "../services/instance-settings.js";
 import { serverVersion } from "../version.js";
 
+/** Creates the Express router for health check and status endpoints. */
 export function healthRoutes(
   db?: Db,
   opts: {

--- a/server/src/routes/inbox-dismissals.ts
+++ b/server/src/routes/inbox-dismissals.ts
@@ -9,6 +9,7 @@ const inboxDismissalSchema = z.object({
   itemKey: z.string().trim().min(1).regex(/^(approval|join|run):.+$/, "Unsupported inbox item key"),
 });
 
+/** Creates the Express router for inbox dismissal state endpoints. */
 export function inboxDismissalRoutes(db: Db) {
   const router = Router();
   const svc = inboxDismissalService(db);

--- a/server/src/routes/instance-settings.ts
+++ b/server/src/routes/instance-settings.ts
@@ -16,6 +16,7 @@ function assertCanManageInstanceSettings(req: Request) {
   throw forbidden("Instance admin access required");
 }
 
+/** Creates the Express router for instance settings read/write endpoints. */
 export function instanceSettingsRoutes(db: Db) {
   const router = Router();
   const svc = instanceSettingsService(db);

--- a/server/src/routes/issues-checkout-wakeup.ts
+++ b/server/src/routes/issues-checkout-wakeup.ts
@@ -5,6 +5,7 @@ type CheckoutWakeInput = {
   checkoutRunId: string | null;
 };
 
+/** Returns true if the issue assignee should be woken when a checkout occurs (false if the agent checked out its own run). */
 export function shouldWakeAssigneeOnCheckout(input: CheckoutWakeInput): boolean {
   if (input.actorType !== "agent") return true;
   if (!input.actorAgentId) return true;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -267,6 +267,7 @@ function buildExecutionStageWakeup(input: {
   return null;
 }
 
+/** Creates the Express router for issue CRUD and workflow endpoints. */
 export function issueRoutes(
   db: Db,
   storage: StorageService,

--- a/server/src/routes/llms.ts
+++ b/server/src/routes/llms.ts
@@ -10,6 +10,7 @@ function hasCreatePermission(agent: { role: string; permissions: Record<string, 
   return Boolean((agent.permissions as Record<string, unknown>).canCreateAgents);
 }
 
+/** Creates the Express router for LLM adapter listing endpoints. */
 export function llmRoutes(db: Db) {
   const router = Router();
   const agentsSvc = agentService(db);

--- a/server/src/routes/org-chart-svg.ts
+++ b/server/src/routes/org-chart-svg.ts
@@ -700,6 +700,7 @@ function smartCollapseTree(roots: OrgNode[]): OrgNode[] {
   return tree;
 }
 
+/** Renders a company org chart as an SVG string from a tree of OrgNodes, with optional style and overlay. */
 export function renderOrgChartSvg(orgTree: OrgNode[], style: OrgChartStyle = "warmth", overlay?: OrgChartOverlay): string {
   const theme = THEMES[style] || THEMES.warmth;
 

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -15,6 +15,7 @@ import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { startRuntimeServicesForWorkspaceControl, stopRuntimeServicesForProjectWorkspace } from "../services/workspace-runtime.js";
 import { getTelemetryClient } from "../telemetry.js";
 
+/** Creates the Express router for project and workspace management endpoints. */
 export function projectRoutes(db: Db) {
   const router = Router();
   const svc = projectService(db);

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -15,6 +15,7 @@ import { assertCompanyAccess, getActorInfo } from "./authz.js";
 import { forbidden, unauthorized } from "../errors.js";
 import { getTelemetryClient } from "../telemetry.js";
 
+/** Creates the Express router for scheduled routine management endpoints. */
 export function routineRoutes(db: Db) {
   const router = Router();
   const svc = routineService(db);

--- a/server/src/routes/secrets.ts
+++ b/server/src/routes/secrets.ts
@@ -11,6 +11,7 @@ import { validate } from "../middleware/validate.js";
 import { assertBoard, assertCompanyAccess } from "./authz.js";
 import { logActivity, secretService } from "../services/index.js";
 
+/** Creates the Express router for secret management endpoints. */
 export function secretRoutes(db: Db) {
   const router = Router();
   const svc = secretService(db);

--- a/server/src/routes/sidebar-badges.ts
+++ b/server/src/routes/sidebar-badges.ts
@@ -15,6 +15,7 @@ function buildDismissedAtByKey(
   );
 }
 
+/** Creates the Express router for sidebar unread badge count endpoints. */
 export function sidebarBadgeRoutes(db: Db) {
   const router = Router();
   const svc = sidebarBadgeService(db);

--- a/server/src/routes/telegram.ts
+++ b/server/src/routes/telegram.ts
@@ -36,6 +36,7 @@ interface IngestBody {
   username?: string;
 }
 
+/** Creates the Express router for Telegram webhook and notification endpoints. */
 export function telegramRoutes(db: Db) {
   const router = Router();
   const svc = issueService(db);

--- a/server/src/secrets/provider-registry.ts
+++ b/server/src/secrets/provider-registry.ts
@@ -19,12 +19,14 @@ const providerById = new Map<SecretProvider, SecretProviderModule>(
   providers.map((provider) => [provider.id, provider]),
 );
 
+/** Returns the secret provider module for the given provider ID, throwing if unsupported. */
 export function getSecretProvider(id: SecretProvider): SecretProviderModule {
   const provider = providerById.get(id);
   if (!provider) throw unprocessable(`Unsupported secret provider: ${id}`);
   return provider;
 }
 
+/** Returns descriptors for all registered secret providers. */
 export function listSecretProviders(): SecretProviderDescriptor[] {
   return providers.map((provider) => provider.descriptor);
 }

--- a/server/src/services/access.ts
+++ b/server/src/services/access.ts
@@ -13,6 +13,7 @@ type GrantInput = {
   scope?: Record<string, unknown> | null;
 };
 
+/** Creates the access control service for checking instance admin roles and permissions. */
 export function accessService(db: Db) {
   async function isInstanceAdmin(userId: string | null | undefined): Promise<boolean> {
     if (!userId) return false;

--- a/server/src/services/activity.ts
+++ b/server/src/services/activity.ts
@@ -9,6 +9,7 @@ export interface ActivityFilters {
   entityId?: string;
 }
 
+/** Creates the activity service for querying recent issue and comment activity. */
 export function activityService(db: Db) {
   const issueIdAsText = sql<string>`${issues.id}::text`;
   return {

--- a/server/src/services/adapter-plugin-store.ts
+++ b/server/src/services/adapter-plugin-store.ts
@@ -114,10 +114,12 @@ function writeSettings(settings: AdapterSettings): void {
 // Public API
 // ---------------------------------------------------------------------------
 
+/** Returns all registered adapter plugin records from the store. */
 export function listAdapterPlugins(): AdapterPluginRecord[] {
   return readStore();
 }
 
+/** Adds or replaces an adapter plugin record in the store (keyed by `type`). */
 export function addAdapterPlugin(record: AdapterPluginRecord): void {
   const store = [...readStore()];
   const idx = store.findIndex((r) => r.type === record.type);
@@ -129,6 +131,7 @@ export function addAdapterPlugin(record: AdapterPluginRecord): void {
   writeStore(store);
 }
 
+/** Removes the adapter plugin with the given type from the store. Returns true if it was found and removed. */
 export function removeAdapterPlugin(type: string): boolean {
   const store = [...readStore()];
   const idx = store.findIndex((r) => r.type === type);
@@ -138,10 +141,12 @@ export function removeAdapterPlugin(type: string): boolean {
   return true;
 }
 
+/** Returns the adapter plugin record matching the given type, or undefined if not found. */
 export function getAdapterPluginByType(type: string): AdapterPluginRecord | undefined {
   return readStore().find((r) => r.type === type);
 }
 
+/** Returns the path to the managed adapter plugins directory, creating it if needed. */
 export function getAdapterPluginsDir(): string {
   ensureDirs();
   return ADAPTER_PLUGINS_DIR;
@@ -151,14 +156,17 @@ export function getAdapterPluginsDir(): string {
 // Adapter enable/disable (settings)
 // ---------------------------------------------------------------------------
 
+/** Returns the list of adapter type identifiers that are currently disabled. */
 export function getDisabledAdapterTypes(): string[] {
   return readSettings().disabledTypes;
 }
 
+/** Returns true if the given adapter type is currently disabled. */
 export function isAdapterDisabled(type: string): boolean {
   return readSettings().disabledTypes.includes(type);
 }
 
+/** Enables or disables an adapter type. Returns true if the settings were changed. */
 export function setAdapterDisabled(type: string, disabled: boolean): boolean {
   const settings = { ...readSettings(), disabledTypes: [...readSettings().disabledTypes] };
   const idx = settings.disabledTypes.indexOf(type);

--- a/server/src/services/agent-instructions.ts
+++ b/server/src/services/agent-instructions.ts
@@ -429,6 +429,7 @@ async function writeBundleFiles(
   }
 }
 
+/** Synchronizes a bundle config in an adapter config object from a file path, inferring mode, root, and entry. */
 export function syncInstructionsBundleConfigFromFilePath(
   agent: AgentLike,
   adapterConfig: Record<string, unknown>,
@@ -451,6 +452,7 @@ export function syncInstructionsBundleConfigFromFilePath(
   return applyBundleConfig(next, { mode, rootPath, entryFile });
 }
 
+/** Creates the agent instructions service for reading, writing, and managing instruction bundles. */
 export function agentInstructionsService() {
   async function getBundle(agent: AgentLike): Promise<AgentInstructionsBundle> {
     const state = await recoverManagedBundleState(agent, deriveBundleState(agent));

--- a/server/src/services/agent-permissions.ts
+++ b/server/src/services/agent-permissions.ts
@@ -2,12 +2,14 @@ export type NormalizedAgentPermissions = Record<string, unknown> & {
   canCreateAgents: boolean;
 };
 
+/** Returns the default agent permissions for the given role (e.g. ceo gets canCreateAgents). */
 export function defaultPermissionsForRole(role: string): NormalizedAgentPermissions {
   return {
     canCreateAgents: role === "ceo",
   };
 }
 
+/** Merges an agent's stored permissions with role-based defaults, ensuring required fields are present. */
 export function normalizeAgentPermissions(
   permissions: unknown,
   role: string,

--- a/server/src/services/agent-policies.ts
+++ b/server/src/services/agent-policies.ts
@@ -73,6 +73,7 @@ function rowToRevision(row: typeof agentPolicyRevisions.$inferSelect): AgentPoli
   };
 }
 
+/** Creates the agent policies service for managing rate-limit and spending policy rules. */
 export function agentPoliciesService(db: Db) {
   return {
     listPolicies: async (

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -155,6 +155,7 @@ function configPatchFromSnapshot(snapshot: unknown): Partial<typeof agents.$infe
   };
 }
 
+/** Returns true if the candidate agent name normalizes to the same URL key as any active existing agent. */
 export function hasAgentShortnameCollision(
   candidateName: string,
   existingAgents: AgentShortnameRow[],
@@ -170,6 +171,7 @@ export function hasAgentShortnameCollision(
   });
 }
 
+/** Returns a unique agent name by appending a numeric suffix if the candidate name collides with existing agents. */
 export function deduplicateAgentName(
   candidateName: string,
   existingAgents: AgentShortnameRow[],
@@ -186,6 +188,7 @@ export function deduplicateAgentName(
   return `${candidateName} ${Date.now()}`;
 }
 
+/** Creates the agent service for managing agent records, runtime state, and lifecycle. */
 export function agentService(db: Db) {
   function currentUtcMonthWindow(now = new Date()) {
     const year = now.getUTCFullYear();

--- a/server/src/services/approvals.ts
+++ b/server/src/services/approvals.ts
@@ -8,6 +8,7 @@ import { budgetService } from "./budgets.js";
 import { notifyHireApproved } from "./hire-hook.js";
 import { instanceSettingsService } from "./instance-settings.js";
 
+/** Creates the approval service for managing agent hire and execution approval workflows. */
 export function approvalService(db: Db) {
   const agentsSvc = agentService(db);
   const budgets = budgetService(db);

--- a/server/src/services/assets.ts
+++ b/server/src/services/assets.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { assets } from "@paperclipai/db";
 
+/** Creates the asset service for storing and retrieving company file assets. */
 export function assetService(db: Db) {
   return {
     create: (companyId: string, data: Omit<typeof assets.$inferInsert, "companyId">) =>

--- a/server/src/services/board-auth.ts
+++ b/server/src/services/board-auth.ts
@@ -16,28 +16,34 @@ export const CLI_AUTH_CHALLENGE_TTL_MS = 10 * 60 * 1000;
 
 export type CliAuthChallengeStatus = "pending" | "approved" | "cancelled" | "expired";
 
+/** Hashes a bearer token string with SHA-256 and returns the hex digest. */
 export function hashBearerToken(token: string) {
   return createHash("sha256").update(token).digest("hex");
 }
 
+/** Compares two token hash strings using a timing-safe equality check. */
 export function tokenHashesMatch(left: string, right: string) {
   const leftBytes = Buffer.from(left, "utf8");
   const rightBytes = Buffer.from(right, "utf8");
   return leftBytes.length === rightBytes.length && timingSafeEqual(leftBytes, rightBytes);
 }
 
+/** Generates a new random board API token with a `pcp_board_` prefix. */
 export function createBoardApiToken() {
   return `pcp_board_${randomBytes(24).toString("hex")}`;
 }
 
+/** Generates a new random CLI auth challenge secret with a `pcp_cli_auth_` prefix. */
 export function createCliAuthSecret() {
   return `pcp_cli_auth_${randomBytes(24).toString("hex")}`;
 }
 
+/** Returns the expiry Date for a new board API key (30 days from `nowMs`). */
 export function boardApiKeyExpiresAt(nowMs: number = Date.now()) {
   return new Date(nowMs + BOARD_API_KEY_TTL_MS);
 }
 
+/** Returns the expiry Date for a new CLI auth challenge (10 minutes from `nowMs`). */
 export function cliAuthChallengeExpiresAt(nowMs: number = Date.now()) {
   return new Date(nowMs + CLI_AUTH_CHALLENGE_TTL_MS);
 }
@@ -49,6 +55,7 @@ function challengeStatusForRow(row: typeof cliAuthChallenges.$inferSelect): CliA
   return "pending";
 }
 
+/** Creates the board authentication service for resolving user access and session validation. */
 export function boardAuthService(db: Db) {
   async function resolveBoardAccess(userId: string) {
     const [user, memberships, adminRole] = await Promise.all([

--- a/server/src/services/budgets.ts
+++ b/server/src/services/budgets.ts
@@ -209,6 +209,7 @@ async function markApprovalStatus(
     .where(eq(approvals.id, approvalId));
 }
 
+/** Creates the budget service for enforcing agent and project spending limits. */
 export function budgetService(db: Db, hooks: BudgetServiceHooks = {}) {
   async function pauseScopeForBudget(policy: PolicyRow) {
     const now = new Date();

--- a/server/src/services/companies.ts
+++ b/server/src/services/companies.ts
@@ -30,6 +30,7 @@ import {
 } from "@paperclipai/db";
 import { notFound, unprocessable } from "../errors.js";
 
+/** Creates the company service for managing company records, members, and settings. */
 export function companyService(db: Db) {
   const ISSUE_PREFIX_FALLBACK = "CMP";
 

--- a/server/src/services/company-portability.ts
+++ b/server/src/services/company-portability.ts
@@ -2687,6 +2687,7 @@ function normalizeGitHubSourcePath(value: string | null | undefined) {
   return value.trim().replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
 }
 
+/** Parses a GitHub source URL into its hostname, owner, repo, ref, and path components. */
 export function parseGitHubSourceUrl(rawUrl: string) {
   const url = new URL(rawUrl);
   if (url.protocol !== "https:") {
@@ -2738,6 +2739,7 @@ export function parseGitHubSourceUrl(rawUrl: string) {
 }
 
 
+/** Creates the company portability service for importing and exporting company data bundles. */
 export function companyPortabilityService(db: Db, storage?: StorageService) {
   const companies = companyService(db);
   const agents = agentService(db);

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -192,6 +192,7 @@ function normalizeSkillKey(value: string | null | undefined) {
   return segments.length > 0 ? segments.join("/") : null;
 }
 
+/** Normalizes a GitHub skill directory path to a portable slash-separated form, falling back to the given default. */
 export function normalizeGitHubSkillDirectory(
   value: string | null | undefined,
   fallback: string,
@@ -590,6 +591,7 @@ function extractCommandTokens(raw: string) {
   return matches.map((token) => token.replace(/^['"]|['"]$/g, ""));
 }
 
+/** Parses a raw skill import source string into a structured ParsedSkillImportSource, throwing if invalid. */
 export function parseSkillImportSourceInput(rawInput: string): ParsedSkillImportSource {
   const trimmed = rawInput.trim();
   if (!trimmed) {
@@ -1484,6 +1486,7 @@ function toCompanySkillListItem(skill: CompanySkill, attachedAgentCount: number)
   };
 }
 
+/** Creates the company skill service for managing, syncing, and invoking agent skills. */
 export function companySkillService(db: Db) {
   const agents = agentService(db);
   const projects = projectService(db);

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -43,6 +43,7 @@ async function getMonthlySpendTotal(
   return Number(row?.total ?? 0);
 }
 
+/** Creates the cost service for recording and querying agent usage cost events. */
 export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
   const budgets = budgetService(db, budgetHooks);
   return {

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -4,6 +4,7 @@ import { agents, approvals, companies, costEvents, issues } from "@paperclipai/d
 import { notFound } from "../errors.js";
 import { budgetService } from "./budgets.js";
 
+/** Creates the dashboard service for generating company-level summary data. */
 export function dashboardService(db: Db) {
   const budgets = budgetService(db);
   return {

--- a/server/src/services/default-agent-instructions.ts
+++ b/server/src/services/default-agent-instructions.ts
@@ -22,6 +22,7 @@ export async function loadDefaultAgentInstructionsBundle(role: DefaultAgentBundl
   return Object.fromEntries(entries);
 }
 
+/** Maps an agent role string to the appropriate default-instructions bundle role (ceo or default). */
 export function resolveDefaultAgentInstructionsBundleRole(role: string): DefaultAgentBundleRole {
   return role === "ceo" ? "ceo" : "default";
 }

--- a/server/src/services/documents.ts
+++ b/server/src/services/documents.ts
@@ -17,6 +17,7 @@ function isUniqueViolation(error: unknown): boolean {
   return !!error && typeof error === "object" && "code" in error && (error as { code?: string }).code === "23505";
 }
 
+/** Extracts the text content of a legacy <plan>...</plan> block from an issue description. */
 export function extractLegacyPlanBody(description: string | null | undefined) {
   if (!description) return null;
   const match = /<plan>\s*([\s\S]*?)\s*<\/plan>/i.exec(description);
@@ -82,6 +83,7 @@ const issueDocumentSelect = {
   updatedAt: documents.updatedAt,
 };
 
+/** Creates the document service for managing issue plan documents and summaries. */
 export function documentService(db: Db) {
   return {
     getIssueDocumentPayload: async (issue: { id: string; description: string | null }) => {

--- a/server/src/services/execution-workspace-policy.ts
+++ b/server/src/services/execution-workspace-policy.ts
@@ -30,6 +30,7 @@ function parseExecutionWorkspaceStrategy(raw: unknown): ExecutionWorkspaceStrate
   };
 }
 
+/** Parses and validates a raw value into a ProjectExecutionWorkspacePolicy, returning null if empty or invalid. */
 export function parseProjectExecutionWorkspacePolicy(raw: unknown): ProjectExecutionWorkspacePolicy | null {
   const parsed = parseObject(raw);
   if (Object.keys(parsed).length === 0) return null;
@@ -77,6 +78,7 @@ export function parseProjectExecutionWorkspacePolicy(raw: unknown): ProjectExecu
   };
 }
 
+/** Returns the project workspace policy only when isolated workspaces are enabled; otherwise returns null. */
 export function gateProjectExecutionWorkspacePolicy(
   projectPolicy: ProjectExecutionWorkspacePolicy | null,
   isolatedWorkspacesEnabled: boolean,
@@ -85,6 +87,7 @@ export function gateProjectExecutionWorkspacePolicy(
   return projectPolicy;
 }
 
+/** Parses a raw value into IssueExecutionWorkspaceSettings, normalizing legacy mode names. */
 export function parseIssueExecutionWorkspaceSettings(raw: unknown): IssueExecutionWorkspaceSettings | null {
   const parsed = parseObject(raw);
   if (Object.keys(parsed).length === 0) return null;
@@ -116,6 +119,7 @@ export function parseIssueExecutionWorkspaceSettings(raw: unknown): IssueExecuti
   };
 }
 
+/** Derives the default issue workspace settings from the project policy, or null if the policy is disabled. */
 export function defaultIssueExecutionWorkspaceSettingsForProject(
   projectPolicy: ProjectExecutionWorkspacePolicy | null,
 ): IssueExecutionWorkspaceSettings | null {
@@ -132,6 +136,7 @@ export function defaultIssueExecutionWorkspaceSettingsForProject(
   };
 }
 
+/** Maps a persisted workspace mode string to a typed IssueExecutionWorkspaceSettings mode, defaulting to agent_default. */
 export function issueExecutionWorkspaceModeForPersistedWorkspace(
   mode: string | null | undefined,
 ): IssueExecutionWorkspaceSettings["mode"] {
@@ -147,6 +152,7 @@ export function issueExecutionWorkspaceModeForPersistedWorkspace(
   return "shared_workspace";
 }
 
+/** Resolves the effective execution workspace mode by combining issue settings, project policy, and legacy flags. */
 export function resolveExecutionWorkspaceMode(input: {
   projectPolicy: ProjectExecutionWorkspacePolicy | null;
   issueSettings: IssueExecutionWorkspaceSettings | null;
@@ -168,6 +174,7 @@ export function resolveExecutionWorkspaceMode(input: {
   return "shared_workspace";
 }
 
+/** Builds the adapter config record with workspace strategy and runtime fields applied according to the resolved mode. */
 export function buildExecutionWorkspaceAdapterConfig(input: {
   agentConfig: Record<string, unknown>;
   projectPolicy: ProjectExecutionWorkspacePolicy | null;

--- a/server/src/services/execution-workspaces.ts
+++ b/server/src/services/execution-workspaces.ts
@@ -182,6 +182,7 @@ async function inspectGitCloseReadiness(workspace: ExecutionWorkspace): Promise<
   };
 }
 
+/** Parses and returns the ExecutionWorkspaceConfig stored in a workspace metadata record, or null if absent. */
 export function readExecutionWorkspaceConfig(metadata: Record<string, unknown> | null | undefined): ExecutionWorkspaceConfig | null {
   const raw = isRecord(metadata?.config) ? metadata.config : null;
   if (!raw) return null;
@@ -203,6 +204,7 @@ export function readExecutionWorkspaceConfig(metadata: Record<string, unknown> |
   return hasConfig ? config : null;
 }
 
+/** Applies a partial ExecutionWorkspaceConfig patch to a metadata record, returning the updated metadata. */
 export function mergeExecutionWorkspaceConfig(
   metadata: Record<string, unknown> | null | undefined,
   patch: Partial<ExecutionWorkspaceConfig> | null,
@@ -356,6 +358,7 @@ async function loadEffectiveRuntimeServicesByExecutionWorkspace(
   );
 }
 
+/** Creates the execution workspace service for managing isolated agent workspace lifecycle. */
 export function executionWorkspaceService(db: Db) {
   return {
     list: async (companyId: string, filters?: {

--- a/server/src/services/feedback-redaction.ts
+++ b/server/src/services/feedback-redaction.ts
@@ -94,6 +94,7 @@ function applyPattern(input: string, pattern: RedactionPattern) {
   return { output, matches };
 }
 
+/** Creates a fresh, empty redaction state to track field sanitization across a feedback payload. */
 export function createFeedbackRedactionState(): FeedbackRedactionState {
   return {
     redactedFields: new Set<string>(),
@@ -104,6 +105,7 @@ export function createFeedbackRedactionState(): FeedbackRedactionState {
   };
 }
 
+/** Redacts secrets, PII, and sensitive patterns from a text string, truncating to `maxLength`. */
 export function sanitizeFeedbackText(
   input: string,
   state: FeedbackRedactionState,
@@ -133,6 +135,7 @@ export function sanitizeFeedbackText(
   return output;
 }
 
+/** Recursively sanitizes a feedback value (string, array, or object), redacting secrets and PII. */
 export function sanitizeFeedbackValue(
   value: unknown,
   state: FeedbackRedactionState,
@@ -163,6 +166,7 @@ export function sanitizeFeedbackValue(
   return output;
 }
 
+/** Converts a redaction state into a serializable summary object for audit logging. */
 export function finalizeFeedbackRedactionSummary(state: FeedbackRedactionState) {
   return {
     strategy: "deterministic_feedback_v2",
@@ -174,6 +178,7 @@ export function finalizeFeedbackRedactionSummary(state: FeedbackRedactionState) 
   } satisfies Record<string, unknown>;
 }
 
+/** Serializes a value to JSON with object keys sorted, producing a stable canonical string. */
 export function stableStringify(value: unknown): string {
   if (value === null || typeof value !== "object") {
     return JSON.stringify(value);
@@ -188,6 +193,7 @@ export function stableStringify(value: unknown): string {
   return `{${entries.join(",")}}`;
 }
 
+/** Returns the SHA-256 hex digest of the stable JSON serialization of `value`. */
 export function sha256Digest(value: unknown) {
   return createHash("sha256").update(stableStringify(value)).digest("hex");
 }

--- a/server/src/services/feedback-share-client.ts
+++ b/server/src/services/feedback-share-client.ts
@@ -15,6 +15,7 @@ export interface FeedbackTraceShareClient {
   uploadTraceBundle(bundle: FeedbackTraceBundle): Promise<{ objectKey: string }>;
 }
 
+/** Creates a feedback trace share client configured from the given backend URL and auth token. */
 export function createFeedbackTraceShareClientFromConfig(
   config: Pick<Config, "feedbackExportBackendUrl" | "feedbackExportBackendToken">,
 ): FeedbackTraceShareClient {

--- a/server/src/services/feedback.ts
+++ b/server/src/services/feedback.ts
@@ -1669,6 +1669,7 @@ async function buildFeedbackTraceBundleFromRow(
   return bundle;
 }
 
+/** Creates the feedback service for managing issue votes, comments, and trace bundles. */
 export function feedbackService(db: Db, options: FeedbackServiceOptions = {}) {
   return {
     listIssueVotesForUser: async (issueId: string, authorUserId: string) =>

--- a/server/src/services/finance.ts
+++ b/server/src/services/finance.ts
@@ -34,6 +34,7 @@ function rangeConditions(companyId: string, range?: FinanceDateRange) {
   return conditions;
 }
 
+/** Creates the finance service for querying debit/credit summaries and balance reports. */
 export function financeService(db: Db) {
   const debitExpr = sql<number>`coalesce(sum(case when ${financeEvents.direction} = 'debit' then ${financeEvents.amountCents} else 0 end), 0)::int`;
   const creditExpr = sql<number>`coalesce(sum(case when ${financeEvents.direction} = 'credit' then ${financeEvents.amountCents} else 0 end), 0)::int`;

--- a/server/src/services/github-fetch.ts
+++ b/server/src/services/github-fetch.ts
@@ -5,10 +5,12 @@ function isGitHubDotCom(hostname: string) {
   return h === "github.com" || h === "www.github.com";
 }
 
+/** Returns the GitHub REST API base URL for the given hostname (supports GitHub.com and GHE). */
 export function gitHubApiBase(hostname: string) {
   return isGitHubDotCom(hostname) ? "https://api.github.com" : `https://${hostname}/api/v3`;
 }
 
+/** Returns the raw file URL for a given GitHub repo, ref, and file path (supports GitHub.com and GHE). */
 export function resolveRawGitHubUrl(hostname: string, owner: string, repo: string, ref: string, filePath: string) {
   const p = filePath.replace(/^\/+/, "");
   return isGitHubDotCom(hostname)

--- a/server/src/services/goals.ts
+++ b/server/src/services/goals.ts
@@ -42,6 +42,7 @@ export async function getDefaultCompanyGoal(db: GoalReader, companyId: string) {
     .then((rows) => rows[0] ?? null);
 }
 
+/** Creates the goal service for managing company-level goals and their assignments. */
 export function goalService(db: Db) {
   return {
     list: (companyId: string) => db.select().from(goals).where(eq(goals.companyId, companyId)),

--- a/server/src/services/heartbeat-run-summary.ts
+++ b/server/src/services/heartbeat-run-summary.ts
@@ -13,6 +13,7 @@ function readCommentText(value: unknown) {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+/** Merges a summary string into a run result JSON object, injecting it only if no summary field already exists. */
 export function mergeHeartbeatRunResultJson(
   resultJson: Record<string, unknown> | null | undefined,
   summary: string | null | undefined,
@@ -41,6 +42,7 @@ export function mergeHeartbeatRunResultJson(
   };
 }
 
+/** Extracts a compact summary object from a run result JSON, keeping only text and cost fields. */
 export function summarizeHeartbeatRunResultJson(
   resultJson: Record<string, unknown> | null | undefined,
 ): Record<string, unknown> | null {
@@ -68,6 +70,7 @@ export function summarizeHeartbeatRunResultJson(
   return Object.keys(summary).length > 0 ? summary : null;
 }
 
+/** Extracts the best human-readable comment text from a run result JSON, or returns null. */
 export function buildHeartbeatRunIssueComment(
   resultJson: Record<string, unknown> | null | undefined,
 ): string | null {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -159,6 +159,7 @@ export async function resolveExecutionRunAdapterConfig(input: {
   return { resolvedConfig, secretKeys };
 }
 
+/** Merges persisted execution workspace config overrides (runtime, strategy) into a base run config. */
 export function applyPersistedExecutionWorkspaceConfig(input: {
   config: Record<string, unknown>;
   workspaceConfig: ExecutionWorkspaceConfig | null;
@@ -186,12 +187,14 @@ export function applyPersistedExecutionWorkspaceConfig(input: {
   return nextConfig;
 }
 
+/** Returns a copy of the run config with the workspaceRuntime field removed. */
 export function stripWorkspaceRuntimeFromExecutionRunConfig(config: Record<string, unknown>) {
   const nextConfig = { ...config };
   delete nextConfig.workspaceRuntime;
   return nextConfig;
 }
 
+/** Constructs a RealizedExecutionWorkspace from a persisted workspace row, or null if the cwd cannot be resolved. */
 export function buildRealizedExecutionWorkspaceFromPersisted(input: {
   base: ExecutionWorkspaceInput;
   workspace: ExecutionWorkspace;
@@ -454,6 +457,7 @@ type ProjectWorkspaceCandidate = {
   id: string;
 };
 
+/** Reorders workspace candidates to place the preferred workspace first. */
 export function prioritizeProjectWorkspaceCandidatesForRun<T extends ProjectWorkspaceCandidate>(
   rows: T[],
   preferredWorkspaceId: string | null | undefined,
@@ -535,6 +539,7 @@ type ResumeSessionRow = {
   lastRunId: string | null;
 };
 
+/** Builds a session override that explicitly resumes a prior run's session when allowed. */
 export function buildExplicitResumeSessionOverride(input: {
   resumeFromRunId: string;
   resumeRunSessionIdBefore: string | null;
@@ -642,10 +647,12 @@ function formatCount(value: number | null | undefined) {
   return value.toLocaleString("en-US");
 }
 
+/** Reads the session compaction policy from an agent's adapter type and runtime config. */
 export function parseSessionCompactionPolicy(agent: typeof agents.$inferSelect): SessionCompactionPolicy {
   return resolveSessionCompactionPolicy(agent.adapterType, agent.runtimeConfig).policy;
 }
 
+/** Migrates session params to point at a newly available project workspace cwd when the previous cwd was a fallback. */
 export function resolveRuntimeSessionParamsForWorkspace(input: {
   agentId: string;
   previousSessionParams: Record<string, unknown> | null;
@@ -777,6 +784,7 @@ export function deriveTaskKeyWithHeartbeatFallback(
   return null;
 }
 
+/** Returns true when the wake context demands a fresh session rather than resuming the previous one. */
 export function shouldResetTaskSessionForWake(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ) {
@@ -806,6 +814,7 @@ function shouldRequireIssueCommentForWake(
   );
 }
 
+/** Wraps a workspace warning string in a stdout log chunk prefixed with [paperclip]. */
 export function formatRuntimeWorkspaceWarningLog(warning: string) {
   return {
     stream: "stdout" as const,
@@ -921,6 +930,7 @@ export function isRateLimitError(
   );
 }
 
+/** Returns true if the adapter result (timed out or non-zero exit) warrants trying the next fallback in the chain. */
 export function shouldContinueFallbackChain(
   result: Pick<AdapterExecutionResult, "timedOut" | "exitCode">,
 ): boolean {
@@ -946,6 +956,7 @@ export function shouldUseRateLimitFallback(
   return isRateLimitError(result);
 }
 
+/** Returns a copy of an adapter result with all session fields cleared. */
 export function stripAdapterSessionState(result: AdapterExecutionResult): AdapterExecutionResult {
   return {
     ...result,
@@ -956,6 +967,7 @@ export function stripAdapterSessionState(result: AdapterExecutionResult): Adapte
   };
 }
 
+/** Builds the runtime config to use for a fallback adapter, merging portable keys from the primary config. */
 export function buildFallbackConfig(
   primaryRuntimeConfig: Record<string, unknown>,
   fallback: AdapterFallbackChainEntry,
@@ -1059,6 +1071,7 @@ function deriveCommentId(
   );
 }
 
+/** Extracts the deduplicated list of wake comment IDs from a context snapshot. */
 export function extractWakeCommentIds(
   contextSnapshot: Record<string, unknown> | null | undefined,
 ): string[] {
@@ -1184,6 +1197,7 @@ function enrichWakeContextSnapshot(input: {
   };
 }
 
+/** Deep-merges two coalesced context snapshots, deduplicating wake and processed comment ID lists. */
 export function mergeCoalescedContextSnapshot(
   existingRaw: unknown,
   incoming: Record<string, unknown>,
@@ -1519,6 +1533,7 @@ function resolveNextSessionState(input: {
   };
 }
 
+/** Creates the heartbeat service instance for managing agent run scheduling and execution. */
 export function heartbeatService(db: Db) {
   const instanceSettings = instanceSettingsService(db);
   const getCurrentUserRedactionOptions = async () => ({

--- a/server/src/services/inbox-dismissals.ts
+++ b/server/src/services/inbox-dismissals.ts
@@ -2,6 +2,7 @@ import { and, desc, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { inboxDismissals } from "@paperclipai/db";
 
+/** Creates the inbox dismissal service for managing per-user item dismissal state. */
 export function inboxDismissalService(db: Db) {
   return {
     list: async (companyId: string, userId: string) =>

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -58,6 +58,7 @@ function toInstanceSettings(row: typeof instanceSettings.$inferSelect): Instance
   };
 }
 
+/** Creates the instance settings service for reading and updating global instance configuration. */
 export function instanceSettingsService(db: Db) {
   async function getOrCreateRow() {
     const existing = await db

--- a/server/src/services/issue-approvals.ts
+++ b/server/src/services/issue-approvals.ts
@@ -9,6 +9,7 @@ interface LinkActor {
   userId?: string | null;
 }
 
+/** Creates the issue approval service for managing execution approval workflows. */
 export function issueApprovalService(db: Db) {
   async function getIssue(issueId: string) {
     return db

--- a/server/src/services/issue-assignment-wakeup.ts
+++ b/server/src/services/issue-assignment-wakeup.ts
@@ -18,6 +18,7 @@ export interface IssueAssignmentWakeupDeps {
   ) => Promise<unknown>;
 }
 
+/** Enqueues a wakeup for the agent assigned to an issue using the given reason. */
 export function queueIssueAssignmentWakeup(input: {
   heartbeat: IssueAssignmentWakeupDeps;
   issue: { id: string; assigneeAgentId: string | null; status: string };

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -43,6 +43,7 @@ const COMPLETED_STATUS: IssueExecutionState["status"] = "completed";
 const PENDING_STATUS: IssueExecutionState["status"] = "pending";
 const CHANGES_REQUESTED_STATUS: IssueExecutionState["status"] = "changes_requested";
 
+/** Parses, validates, and deduplicates an issue execution policy input, returning null if empty or invalid. */
 export function normalizeIssueExecutionPolicy(input: unknown): IssueExecutionPolicy | null {
   if (input == null) return null;
   const parsed = issueExecutionPolicySchema.safeParse(input);
@@ -89,6 +90,7 @@ export function normalizeIssueExecutionPolicy(input: unknown): IssueExecutionPol
   };
 }
 
+/** Parses a raw value into a typed IssueExecutionState, returning null if the input is absent or invalid. */
 export function parseIssueExecutionState(input: unknown): IssueExecutionState | null {
   if (input == null) return null;
   const parsed = issueExecutionStateSchema.safeParse(input);
@@ -96,6 +98,7 @@ export function parseIssueExecutionState(input: unknown): IssueExecutionState | 
   return parsed.data;
 }
 
+/** Derives an IssueExecutionStagePrincipal from an assignee-like object, returning null if no assignee is set. */
 export function assigneePrincipal(input: AssigneeLike): IssueExecutionStagePrincipal | null {
   if (input.assigneeAgentId) {
     return { type: "agent", agentId: input.assigneeAgentId, userId: null };
@@ -236,6 +239,7 @@ function clearExecutionStatePatch(input: {
   }
 }
 
+/** Computes the issue field patch required to advance or enforce an execution-policy workflow stage transition. */
 export function applyIssueExecutionPolicyTransition(input: TransitionInput): TransitionResult {
   const patch: Record<string, unknown> = {};
   const existingState = parseIssueExecutionState(input.issue.executionState);

--- a/server/src/services/issue-goal-fallback.ts
+++ b/server/src/services/issue-goal-fallback.ts
@@ -1,5 +1,6 @@
 type MaybeId = string | null | undefined;
 
+/** Resolves the goal ID for an issue, preferring explicit goal > project goal > default goal. */
 export function resolveIssueGoalId(input: {
   projectId: MaybeId;
   goalId: MaybeId;
@@ -11,6 +12,7 @@ export function resolveIssueGoalId(input: {
   return input.defaultGoalId ?? null;
 }
 
+/** Computes the goal ID that an issue should have after a project or goal change, preserving explicit overrides. */
 export function resolveNextIssueGoalId(input: {
   currentProjectId: MaybeId;
   currentGoalId: MaybeId;

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -402,6 +402,7 @@ export function normalizeAgentMentionToken(raw: string): string {
   return s.trim();
 }
 
+/** Derives per-user context for an issue (unread state, last comment, etc.) for the given user ID. */
 export function deriveIssueUserContext(
   issue: IssueUserContextInput,
   userId: string,
@@ -536,6 +537,7 @@ function withActiveRuns(
   }));
 }
 
+/** Creates the issue service for managing issue CRUD, assignment, and activity. */
 export function issueService(db: Db) {
   const instanceSettings = instanceSettingsService(db);
 

--- a/server/src/services/live-events.ts
+++ b/server/src/services/live-events.ts
@@ -24,6 +24,7 @@ function toLiveEvent(input: {
   };
 }
 
+/** Emits a live event scoped to a specific company and returns the constructed event object. */
 export function publishLiveEvent(input: {
   companyId: string;
   type: LiveEventType;
@@ -34,6 +35,7 @@ export function publishLiveEvent(input: {
   return event;
 }
 
+/** Emits a global live event (not scoped to any company) and returns the constructed event object. */
 export function publishGlobalLiveEvent(input: {
   type: LiveEventType;
   payload?: LiveEventPayload;
@@ -43,11 +45,13 @@ export function publishGlobalLiveEvent(input: {
   return event;
 }
 
+/** Subscribes to live events for a specific company and returns an unsubscribe function. */
 export function subscribeCompanyLiveEvents(companyId: string, listener: LiveEventListener) {
   emitter.on(companyId, listener);
   return () => emitter.off(companyId, listener);
 }
 
+/** Subscribes to all global live events and returns an unsubscribe function. */
 export function subscribeGlobalLiveEvents(listener: LiveEventListener) {
   emitter.on("*", listener);
   return () => emitter.off("*", listener);

--- a/server/src/services/local-service-supervisor.ts
+++ b/server/src/services/local-service-supervisor.ts
@@ -116,6 +116,7 @@ async function safeReadRegistryRecord(filePath: string) {
   }
 }
 
+/** Derives a deterministic registry key from a local service's identity input by hashing its canonical fields. */
 export function createLocalServiceKey(input: LocalServiceIdentityInput) {
   const digest = createHash("sha256")
     .update(
@@ -211,6 +212,7 @@ export async function findLocalServiceRegistryRecordByRuntimeServiceId(input: {
   return candidate;
 }
 
+/** Returns true if the given PID belongs to a live process (uses signal 0 probe). */
 export function isPidAlive(pid: number) {
   if (!Number.isInteger(pid) || pid <= 0) return false;
   try {
@@ -221,6 +223,7 @@ export function isPidAlive(pid: number) {
   }
 }
 
+/** Returns true if the given process group ID is alive (sends signal 0 to the negative PGID). */
 export function isProcessGroupAlive(processGroupId: number | null | undefined) {
   if (process.platform === "win32") return false;
   if (typeof processGroupId !== "number" || !Number.isInteger(processGroupId) || processGroupId <= 0) return false;

--- a/server/src/services/plugin-config-validator.ts
+++ b/server/src/services/plugin-config-validator.ts
@@ -28,11 +28,11 @@ export function validateInstanceConfig(
   configJson: Record<string, unknown>,
   schema: JsonSchema,
 ): ConfigValidationResult {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const AjvCtor = (Ajv as any).default ?? Ajv;
+  // ESM/CJS interop: Ajv and ajv-formats may wrap their export under `.default`
+  const AjvCtor = (Ajv as typeof Ajv & { default?: typeof Ajv }).default ?? Ajv;
   const ajv = new AjvCtor({ allErrors: true });
   // ajv-formats v3 default export is a FormatsPlugin object; call it as a plugin.
-  const applyFormats = (addFormats as any).default ?? addFormats;
+  const applyFormats = (addFormats as typeof addFormats & { default?: typeof addFormats }).default ?? addFormats;
   applyFormats(ajv);
   // Register the secret-ref format used by plugin manifests to mark fields that
   // hold a Paperclip secret UUID rather than a raw value. The format is a UI

--- a/server/src/services/plugin-dev-watcher.ts
+++ b/server/src/services/plugin-dev-watcher.ts
@@ -72,6 +72,7 @@ function shouldIgnorePath(filename: string | null | undefined): boolean {
   );
 }
 
+/** Resolves the list of file/directory targets to watch for a plugin package's dev build. */
 export function resolvePluginWatchTargets(
   packagePath: string,
   fsDeps?: Pick<PluginDevWatcherFsDeps, "existsSync" | "readFileSync" | "readdirSync" | "statSync">,

--- a/server/src/services/plugin-host-service-cleanup.ts
+++ b/server/src/services/plugin-host-service-cleanup.ts
@@ -13,6 +13,7 @@ export interface PluginHostServiceCleanupController {
   teardown(): void;
 }
 
+/** Creates a cleanup controller that disposes plugin host service subscriptions on teardown. */
 export function createPluginHostServiceCleanup(
   lifecycle: LifecycleLike,
   disposers: Map<string, () => void>,

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -438,6 +438,7 @@ if (_logFlushInterval.unref) _logFlushInterval.unref();
 /** Maximum time (ms) to keep a session event subscription alive before forcing cleanup. */
 const SESSION_EVENT_SUBSCRIPTION_TIMEOUT_MS = 30 * 60 * 1_000; // 30 minutes
 
+/** Constructs the host services object exposed to a plugin worker, scoped to the given plugin and key. */
 export function buildHostServices(
   db: Db,
   pluginId: string,

--- a/server/src/services/plugin-runtime-sandbox.ts
+++ b/server/src/services/plugin-runtime-sandbox.ts
@@ -53,6 +53,7 @@ const DEFAULT_GLOBALS: Record<string, unknown> = {
   AbortSignal,
 };
 
+/** Creates an invoker that enforces capability permissions declared in the plugin manifest before each call. */
 export function createCapabilityScopedInvoker(
   manifest: PaperclipPluginManifestV1,
   validator: PluginCapabilityValidator,

--- a/server/src/services/plugin-secrets-handler.ts
+++ b/server/src/services/plugin-secrets-handler.ts
@@ -244,6 +244,7 @@ function createRateLimiter(maxAttempts: number, windowMs: number) {
   };
 }
 
+/** Creates a plugin secrets handler that resolves and validates secrets declared in a plugin manifest. */
 export function createPluginSecretsHandler(
   options: PluginSecretsHandlerOptions,
 ): PluginSecretsService {

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -137,6 +137,7 @@ export interface WorkerHandleEvents {
 
 type WorkerHandleEventName = keyof WorkerHandleEvents;
 
+/** Appends a stderr chunk to an existing excerpt, truncating from the start if the total exceeds the max length. */
 export function appendStderrExcerpt(current: string, chunk: string): string {
   const next = current ? `${current}\n${chunk}` : chunk;
   return next.length <= MAX_STDERR_EXCERPT_CHARS
@@ -144,6 +145,7 @@ export function appendStderrExcerpt(current: string, chunk: string): string {
     : next.slice(-MAX_STDERR_EXCERPT_CHARS);
 }
 
+/** Combines a failure message with a trimmed stderr excerpt, avoiding duplication if already included. */
 export function formatWorkerFailureMessage(message: string, stderrExcerpt: string): string {
   const excerpt = stderrExcerpt.trim();
   if (!excerpt) return message;

--- a/server/src/services/plugin-worker-manager.ts
+++ b/server/src/services/plugin-worker-manager.ts
@@ -37,6 +37,7 @@ import {
   isJsonRpcSuccessResponse,
   JsonRpcParseError,
   JsonRpcCallError,
+  type JsonRpcMessage,
 } from "@paperclipai/plugin-sdk";
 import type {
   JsonRpcId,
@@ -446,7 +447,7 @@ export function createPluginWorkerHandle(
     if (!childProcess?.stdin?.writable) {
       throw new Error(`Worker process for plugin "${pluginId}" is not writable`);
     }
-    const serialized = serializeMessage(message as any);
+    const serialized = serializeMessage(message as JsonRpcMessage);
     childProcess.stdin.write(serialized);
   }
 

--- a/server/src/services/project-workspace-runtime-config.ts
+++ b/server/src/services/project-workspace-runtime-config.ts
@@ -12,6 +12,7 @@ function readDesiredState(value: unknown): ProjectWorkspaceRuntimeConfig["desire
   return value === "running" || value === "stopped" ? value : null;
 }
 
+/** Parses a ProjectWorkspaceRuntimeConfig from a workspace metadata record, returning null if no config is present. */
 export function readProjectWorkspaceRuntimeConfig(
   metadata: Record<string, unknown> | null | undefined,
 ): ProjectWorkspaceRuntimeConfig | null {
@@ -27,6 +28,7 @@ export function readProjectWorkspaceRuntimeConfig(
   return hasConfig ? config : null;
 }
 
+/** Applies a partial ProjectWorkspaceRuntimeConfig patch to a metadata record, returning the updated metadata. */
 export function mergeProjectWorkspaceRuntimeConfig(
   metadata: Record<string, unknown> | null | undefined,
   patch: Partial<ProjectWorkspaceRuntimeConfig> | null,

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -337,6 +337,7 @@ function deriveWorkspaceName(input: {
   return "Workspace";
 }
 
+/** Resolves a unique URL-safe project shortname, appending a numeric suffix if the requested name collides. */
 export function resolveProjectNameForUniqueShortname(
   requestedName: string,
   existingProjects: ProjectShortnameRow[],
@@ -397,6 +398,7 @@ async function ensureSinglePrimaryWorkspace(
     );
 }
 
+/** Creates the project service for managing projects, workspaces, and associated resources. */
 export function projectService(db: Db) {
   return {
     list: async (companyId: string): Promise<ProjectWithGoals[]> => {

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -309,6 +309,7 @@ function mergeRoutineRunPayload(
   };
 }
 
+/** Creates the routine service for managing scheduled agent task routines. */
 export function routineService(db: Db, deps: { heartbeat?: IssueAssignmentWakeupDeps } = {}) {
   const issueSvc = issueService(db);
   const secretsSvc = secretService(db);

--- a/server/src/services/run-log-store.ts
+++ b/server/src/services/run-log-store.ts
@@ -147,6 +147,7 @@ function createLocalFileRunLogStore(basePath: string): RunLogStore {
 
 let cachedStore: RunLogStore | null = null;
 
+/** Returns the singleton RunLogStore, creating it on first call using the configured base path. */
 export function getRunLogStore() {
   if (cachedStore) return cachedStore;
   const basePath = process.env.RUN_LOG_BASE_PATH ?? path.resolve(resolvePaperclipInstanceRoot(), "data", "run-logs");

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -38,6 +38,7 @@ function canonicalizeBinding(binding: EnvBinding): CanonicalEnvBinding {
   };
 }
 
+/** Creates the secret service for storing, resolving, and managing company secrets. */
 export function secretService(db: Db) {
   type NormalizeEnvOptions = {
     strictMode?: boolean;

--- a/server/src/services/sidebar-badges.ts
+++ b/server/src/services/sidebar-badges.ts
@@ -22,6 +22,7 @@ function isDismissed(
   return dismissedAt >= normalizeTimestamp(activityAt);
 }
 
+/** Creates the sidebar badge service for computing unread counts and notification indicators. */
 export function sidebarBadgeService(db: Db) {
   return {
     get: async (

--- a/server/src/services/telegram-event-bridge.ts
+++ b/server/src/services/telegram-event-bridge.ts
@@ -96,6 +96,7 @@ function handleEvent(event: LiveEvent): void {
 
 let _unsubscribe: (() => void) | null = null;
 
+/** Starts listening to global live events and forwarding relevant ones to Telegram. */
 export function startTelegramEventBridge(): void {
   if (_unsubscribe) {
     logger.warn("telegram-event-bridge: already started, skipping");
@@ -112,6 +113,7 @@ export function startTelegramEventBridge(): void {
   logger.info("telegram-event-bridge: listening for live events");
 }
 
+/** Stops the Telegram event bridge and cleans up its live-event subscription. */
 export function stopTelegramEventBridge(): void {
   if (_unsubscribe) {
     _unsubscribe();

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -30,6 +30,7 @@ function toIssueWorkProduct(row: IssueWorkProductRow): IssueWorkProduct {
   };
 }
 
+/** Creates the work-product service for listing and managing agent-produced artifacts. */
 export function workProductService(db: Db) {
   return {
     listForIssue: async (issueId: string) => {

--- a/server/src/services/workspace-operation-log-store.ts
+++ b/server/src/services/workspace-operation-log-store.ts
@@ -147,6 +147,7 @@ function createLocalFileWorkspaceOperationLogStore(basePath: string): WorkspaceO
 
 let cachedStore: WorkspaceOperationLogStore | null = null;
 
+/** Returns the singleton WorkspaceOperationLogStore, creating it on first call. */
 export function getWorkspaceOperationLogStore() {
   if (cachedStore) return cachedStore;
   const basePath = process.env.WORKSPACE_OPERATION_LOG_BASE_PATH

--- a/server/src/services/workspace-operations.ts
+++ b/server/src/services/workspace-operations.ts
@@ -69,6 +69,7 @@ export interface WorkspaceOperationRecorder {
   }): Promise<WorkspaceOperation>;
 }
 
+/** Creates the workspace operation service for tracking and streaming long-running workspace lifecycle operations. */
 export function workspaceOperationService(db: Db) {
   const instanceSettings = instanceSettingsService(db);
   const logStore = getWorkspaceOperationLogStore();

--- a/server/src/services/workspace-runtime-read-model.ts
+++ b/server/src/services/workspace-runtime-read-model.ts
@@ -17,6 +17,7 @@ function runtimeServiceIdentityKey(row: WorkspaceRuntimeServiceRow) {
   ].join(":");
 }
 
+/** Filters a list of runtime service rows to keep only the most recent row per unique service identity. */
 export function selectCurrentRuntimeServiceRows(rows: WorkspaceRuntimeServiceRow[]) {
   const current = new Map<string, WorkspaceRuntimeServiceRow>();
   for (const row of rows) {

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -25,6 +25,7 @@ import type { WorkspaceOperationRecorder } from "./workspace-operations.js";
 import { readExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { readProjectWorkspaceRuntimeConfig } from "./project-workspace-runtime-config.js";
 
+/** Returns the user's preferred shell from SHELL env var, falling back to /bin/sh (or sh on Windows). */
 export function resolveShell(): string {
   return process.env.SHELL?.trim() || (process.platform === "win32" ? "sh" : "/bin/sh");
 }
@@ -268,6 +269,7 @@ export async function ensureServerWorkspaceLinksCurrent(
   );
 }
 
+/** Strips PAPERCLIP_* keys and sensitive database/npm vars from a base environment before passing it to a runtime service. */
 export function sanitizeRuntimeServiceBaseEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
   for (const key of Object.keys(env)) {
@@ -1514,6 +1516,7 @@ function clearIdleTimer(record: RuntimeServiceRecord) {
   record.idleTimer = null;
 }
 
+/** Reconciles adapter-reported runtime service states with the in-memory registry, starting or stopping services as needed. */
 export function normalizeAdapterManagedRuntimeServices(input: {
   adapterType: string;
   runId: string;
@@ -2460,6 +2463,7 @@ export async function persistAdapterManagedRuntimeServices(input: {
   return refs;
 }
 
+/** Builds a markdown workspace-ready comment listing the strategy, branch, cwd, and active runtime services. */
 export function buildWorkspaceReadyComment(input: {
   workspace: RealizedExecutionWorkspace;
   runtimeServices: RuntimeServiceRef[];

--- a/server/src/startup-banner.ts
+++ b/server/src/startup-banner.ts
@@ -97,6 +97,7 @@ function resolveAgentJwtSecretStatus(
   };
 }
 
+/** Prints the server startup banner with URLs, version, and configuration summary to stdout. */
 export function printStartupBanner(opts: StartupBannerOptions): void {
   const baseHost = opts.host === "0.0.0.0" ? "localhost" : opts.host;
   const baseUrl = `http://${baseHost}:${opts.listenPort}`;

--- a/server/src/storage/index.ts
+++ b/server/src/storage/index.ts
@@ -18,10 +18,12 @@ function signatureForConfig(config: Config): string {
   });
 }
 
+/** Creates a StorageService from a Config object, selecting the appropriate provider. */
 export function createStorageServiceFromConfig(config: Config): StorageService {
   return createStorageService(createStorageProviderFromConfig(config));
 }
 
+/** Returns the cached singleton StorageService, recreating it if the config has changed. */
 export function getStorageService(): StorageService {
   const config = loadConfig();
   const signature = signatureForConfig(config);

--- a/server/src/storage/local-disk-provider.ts
+++ b/server/src/storage/local-disk-provider.ts
@@ -35,6 +35,7 @@ async function statOrNull(filePath: string) {
   }
 }
 
+/** Creates a local-disk storage provider rooted at the given base directory. */
 export function createLocalDiskStorageProvider(baseDir: string): StorageProvider {
   const root = path.resolve(baseDir);
 

--- a/server/src/storage/provider-registry.ts
+++ b/server/src/storage/provider-registry.ts
@@ -3,6 +3,7 @@ import type { StorageProvider } from "./types.js";
 import { createLocalDiskStorageProvider } from "./local-disk-provider.js";
 import { createS3StorageProvider } from "./s3-provider.js";
 
+/** Instantiates the storage provider (local disk or S3) specified in the given config. */
 export function createStorageProviderFromConfig(config: Config): StorageProvider {
   if (config.storageProvider === "local_disk") {
     return createLocalDiskStorageProvider(config.storageLocalDiskBaseDir);

--- a/server/src/storage/s3-provider.ts
+++ b/server/src/storage/s3-provider.ts
@@ -63,6 +63,7 @@ function toDate(value: Date | undefined): Date | undefined {
   return value instanceof Date ? value : undefined;
 }
 
+/** Creates an S3-backed storage provider from the given config, validating required fields. */
 export function createS3StorageProvider(config: S3ProviderConfig): StorageProvider {
   const bucket = config.bucket.trim();
   const region = config.region.trim();

--- a/server/src/storage/service.ts
+++ b/server/src/storage/service.ts
@@ -87,6 +87,7 @@ function assertPutFileInput(input: PutFileInput): void {
   }
 }
 
+/** Wraps a storage provider with validation and a unified StorageService interface. */
 export function createStorageService(provider: StorageProvider): StorageService {
   return {
     provider: provider.id,

--- a/server/src/telemetry.ts
+++ b/server/src/telemetry.ts
@@ -9,6 +9,7 @@ import { serverVersion } from "./version.js";
 
 let client: TelemetryClient | null = null;
 
+/** Initializes the singleton telemetry client with the resolved config, or returns null if telemetry is disabled. */
 export function initTelemetry(fileConfig?: { enabled?: boolean }): TelemetryClient | null {
   if (client) return client;
 
@@ -25,6 +26,7 @@ export function initTelemetry(fileConfig?: { enabled?: boolean }): TelemetryClie
   return client;
 }
 
+/** Returns the initialized telemetry client singleton, or null if telemetry was not initialized. */
 export function getTelemetryClient(): TelemetryClient | null {
   return client;
 }

--- a/server/src/ui-branding.ts
+++ b/server/src/ui-branding.ts
@@ -140,10 +140,12 @@ function createFaviconDataUrl(background: string, foreground: string): string {
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
+/** Returns true if worktree UI branding is enabled via the `PAPERCLIP_IN_WORKTREE` env variable. */
 export function isWorktreeUiBrandingEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return isTruthyEnvValue(env.PAPERCLIP_IN_WORKTREE);
 }
 
+/** Reads worktree branding config from env vars and derives colors and favicon data URL. */
 export function getWorktreeUiBranding(env: NodeJS.ProcessEnv = process.env): WorktreeUiBranding {
   if (!isWorktreeUiBrandingEnabled(env)) {
     return {
@@ -168,6 +170,7 @@ export function getWorktreeUiBranding(env: NodeJS.ProcessEnv = process.env): Wor
   };
 }
 
+/** Renders HTML `<link>` tags for the favicon, using the worktree branded favicon when enabled. */
 export function renderFaviconLinks(branding: WorktreeUiBranding): string {
   if (!branding.enabled || !branding.faviconHref) return DEFAULT_FAVICON_LINKS;
 
@@ -178,6 +181,7 @@ export function renderFaviconLinks(branding: WorktreeUiBranding): string {
   ].join("\n");
 }
 
+/** Renders HTML `<meta>` tags embedding worktree name and colors for runtime UI consumption. */
 export function renderRuntimeBrandingMeta(branding: WorktreeUiBranding): string {
   if (!branding.enabled || !branding.name || !branding.color || !branding.textColor) return "";
 
@@ -205,6 +209,7 @@ function replaceMarkedBlock(html: string, startMarker: string, endMarker: string
   return `${before}${indentedContent}${after}`;
 }
 
+/** Injects favicon and runtime branding meta tags into an HTML string at the designated marker blocks. */
 export function applyUiBranding(html: string, env: NodeJS.ProcessEnv = process.env): string {
   const branding = getWorktreeUiBranding(env);
   const withFavicon = replaceMarkedBlock(html, FAVICON_BLOCK_START, FAVICON_BLOCK_END, renderFaviconLinks(branding));

--- a/server/src/worktree-config.ts
+++ b/server/src/worktree-config.ts
@@ -307,6 +307,7 @@ function needsWorktreeConfigRepair(
   return false;
 }
 
+/** Applies runtime-selected server and database ports to a config object, returning whether anything changed. */
 export function applyRuntimePortSelectionToConfig(
   config: PaperclipConfig,
   input: {
@@ -363,6 +364,7 @@ export function applyRuntimePortSelectionToConfig(
   return { config: nextConfig, changed };
 }
 
+/** Detects and repairs stale worktree config and .env files, resolving port conflicts with sibling worktrees. */
 export function maybeRepairLegacyWorktreeConfigAndEnvFiles(): {
   repairedConfig: boolean;
   repairedEnv: boolean;
@@ -440,6 +442,7 @@ export function maybeRepairLegacyWorktreeConfigAndEnvFiles(): {
   return { repairedConfig, repairedEnv };
 }
 
+/** Persists the runtime-chosen server/database ports back to the worktree config file, if they differ. */
 export function maybePersistWorktreeRuntimePorts(input: {
   serverPort: number;
   databasePort?: number | null;


### PR DESCRIPTION
## Summary

- **`plugin-worker-manager.ts`**: `message as any` → `message as JsonRpcMessage`. `serializeMessage` expects `JsonRpcMessage`; the `sendMessage(message: unknown)` wrapper needs to narrow before calling it. Imports `JsonRpcMessage` from `@paperclipai/plugin-sdk`.
- **`plugin-config-validator.ts`** (2×): Ajv and ajv-formats ESM/CJS interop `as any` casts replaced with explicit typed intersections (`typeof Ajv & { default?: typeof Ajv }`) that accurately describe the runtime behaviour.

**Impact**: reduces `anyCount` from 62 → 59 on this branch.

Also includes JSDoc cherry-pick to maintain `docs` score at 100%.

## Test plan

- [ ] `typecheck` CI passes — assertions are valid narrowings, not widening
- [ ] `score` CI shows codeHealth improvement (anyCount ≤ 59)
- [ ] Functional behaviour unchanged — no logic modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)