### PR TITLE
fix: resolve buildInvocationEnvForLogs TODO in adapters/utils.ts

### DIFF
--- a/server/src/adapters/utils.ts
+++ b/server/src/adapters/utils.ts
@@ -6,13 +6,6 @@ import { logger } from "../middleware/logger.js";
 import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
 export type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 
-type BuildInvocationEnvForLogsOptions = {
-  runtimeEnv?: NodeJS.ProcessEnv | Record<string, string>;
-  includeRuntimeKeys?: string[];
-  resolvedCommand?: string | null;
-  resolvedCommandEnvKey?: string;
-};
-
 export const runningProcesses: Map<string, { child: ChildProcess; graceSec: number; processGroupId: number | null }> =
   serverUtils.runningProcesses;
 export const MAX_CAPTURE_BYTES = serverUtils.MAX_CAPTURE_BYTES;
@@ -33,46 +26,9 @@ export const ensurePathInEnv = serverUtils.ensurePathInEnv;
 export const ensureAbsoluteDirectory = serverUtils.ensureAbsoluteDirectory;
 export const ensureCommandResolvable = serverUtils.ensureCommandResolvable;
 export const resolveCommandForLogs = serverUtils.resolveCommandForLogs;
-
-/** Builds a sanitized copy of the invocation environment suitable for including in log output. */
-export function buildInvocationEnvForLogs(
-  env: Record<string, string>,
-  options: BuildInvocationEnvForLogsOptions = {},
-): Record<string, string> {
-  // TODO: Remove this fallback once @paperclipai/adapter-utils exports buildInvocationEnvForLogs everywhere we consume it.
-  const maybeBuildInvocationEnvForLogs = (
-    serverUtils as typeof serverUtils & {
-      buildInvocationEnvForLogs?: (
-        env: Record<string, string>,
-        options?: BuildInvocationEnvForLogsOptions,
-      ) => Record<string, string>;
-    }
-  ).buildInvocationEnvForLogs;
-
-  if (typeof maybeBuildInvocationEnvForLogs === "function") {
-    return maybeBuildInvocationEnvForLogs(env, options);
-  }
-
-  const merged: Record<string, string> = { ...env };
-  const runtimeEnv = options.runtimeEnv ?? {};
-
-  for (const key of options.includeRuntimeKeys ?? []) {
-    if (key in merged) continue;
-    const value = runtimeEnv[key];
-    if (typeof value !== "string" || value.length === 0) continue;
-    merged[key] = value;
-  }
-
-  const resolvedCommand = options.resolvedCommand?.trim();
-  if (resolvedCommand) {
-    merged[options.resolvedCommandEnvKey ?? "PAPERCLIP_RESOLVED_COMMAND"] = resolvedCommand;
-  }
-
-  return redactEnvForLogs(merged);
-}
+export const buildInvocationEnvForLogs = serverUtils.buildInvocationEnvForLogs;
 
 // Re-export runChildProcess with the server's pino logger wired in.
-import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
 const _runChildProcess = serverUtils.runChildProcess;
 
 export async function runChildProcess(

--- a/server/src/adapters/utils.ts
+++ b/server/src/adapters/utils.ts
@@ -4,7 +4,8 @@
 import type { ChildProcess } from "node:child_process";
 import { logger } from "../middleware/logger.js";
 import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
-export type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
+import type { RunProcessResult } from "@paperclipai/adapter-utils/server-utils";
+export type { RunProcessResult };
 
 export const runningProcesses: Map<string, { child: ChildProcess; graceSec: number; processGroupId: number | null }> =
   serverUtils.runningProcesses;


### PR DESCRIPTION
## Summary

- Removes the local `BuildInvocationEnvForLogsOptions` type and the 40-line fallback implementation of `buildInvocationEnvForLogs` from `server/src/adapters/utils.ts`
- Replaces with a simple re-export shim (`export const buildInvocationEnvForLogs = serverUtils.buildInvocationEnvForLogs`) consistent with every other export in that file
- The TODO comment stated "Remove this fallback once `@paperclipai/adapter-utils` exports `buildInvocationEnvForLogs` everywhere we consume it" — that export now exists at `packages/adapter-utils/src/server-utils.ts`

**Impact:** removes one tracked TODO/FIXME, reduces file size, eliminates dead branching code.

## Test plan

- [ ] `pnpm tsc --noEmit -p server/tsconfig.json` — no new errors in `adapters/utils.ts`
- [ ] All callers of `buildInvocationEnvForLogs` continue to import from `../adapters/utils.js` — no import changes needed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)