### PR TITLE
feat(observability): add skill version tracking to metrics (ANGA-565)

### DIFF
--- a/docker/observability/grafana/dashboards/paperclip-overview.json
+++ b/docker/observability/grafana/dashboards/paperclip-overview.json
@@ -18,6 +18,16 @@
         "includeAll": true,
         "current": { "text": "All", "value": "$__all" },
         "refresh": 2
+      },
+      {
+        "name": "skill_name",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": "label_values(paperclip_skill_invocations_total, skill_name)",
+        "multi": true,
+        "includeAll": true,
+        "current": { "text": "All", "value": "$__all" },
+        "refresh": 2
       }
     ]
   },
@@ -174,7 +184,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum by (skill_name, status) (rate(paperclip_skill_invocations_total{agent_id=~\"$agent_id\"}[5m]) * 60)",
+          "expr": "sum by (skill_name, status) (rate(paperclip_skill_invocations_total{agent_id=~\"$agent_id\", skill_name=~\"$skill_name\"}[5m]) * 60)",
           "legendFormat": "{{skill_name}} / {{status}}"
         }
       ],
@@ -193,7 +203,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum by (skill_name) (rate(paperclip_skill_invocations_total{agent_id=~\"$agent_id\", status=\"success\"}[5m])) / sum by (skill_name) (rate(paperclip_skill_invocations_total{agent_id=~\"$agent_id\"}[5m])) * 100",
+          "expr": "sum by (skill_name) (rate(paperclip_skill_invocations_total{agent_id=~\"$agent_id\", skill_name=~\"$skill_name\", status=\"success\"}[5m])) / sum by (skill_name) (rate(paperclip_skill_invocations_total{agent_id=~\"$agent_id\", skill_name=~\"$skill_name\"}[5m])) * 100",
           "legendFormat": "{{skill_name}}"
         }
       ],
@@ -221,7 +231,7 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "sum by (skill_name) (rate(paperclip_skill_tokens_total[5m]) * 60)",
+          "expr": "sum by (skill_name) (rate(paperclip_skill_tokens_total{skill_name=~\"$skill_name\"}[5m]) * 60)",
           "legendFormat": "{{skill_name}}"
         }
       ],
@@ -240,11 +250,11 @@
       "datasource": { "type": "prometheus", "uid": "prometheus" },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le, skill_name) (rate(paperclip_skill_invocation_duration_seconds_bucket{agent_id=~\"$agent_id\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le, skill_name) (rate(paperclip_skill_invocation_duration_seconds_bucket{agent_id=~\"$agent_id\", skill_name=~\"$skill_name\"}[5m])))",
           "legendFormat": "p50 {{skill_name}}"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le, skill_name) (rate(paperclip_skill_invocation_duration_seconds_bucket{agent_id=~\"$agent_id\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le, skill_name) (rate(paperclip_skill_invocation_duration_seconds_bucket{agent_id=~\"$agent_id\", skill_name=~\"$skill_name\"}[5m])))",
           "legendFormat": "p95 {{skill_name}}"
         }
       ],
@@ -253,10 +263,33 @@
       }
     },
     {
+      "id": 12,
+      "title": "Skill Invocations by Version",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 40, "w": 24, "h": 8 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum by (skill_name, version) (rate(paperclip_skill_invocations_total{agent_id=~\"$agent_id\", skill_name=~\"$skill_name\"}[5m]) * 60)",
+          "legendFormat": "{{skill_name}} v{{version}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqpm",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 }
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull", "max"] }
+      }
+    },
+    {
       "id": 7,
       "title": "Agent Logs",
       "type": "logs",
-      "gridPos": { "x": 0, "y": 40, "w": 24, "h": 10 },
+      "gridPos": { "x": 0, "y": 48, "w": 24, "h": 10 },
       "datasource": { "type": "loki", "uid": "loki" },
       "targets": [
         {

--- a/server/src/observability/metrics.ts
+++ b/server/src/observability/metrics.ts
@@ -70,19 +70,19 @@ export const httpRequestDurationSeconds = new Histogram({
   registers: [metricsRegistry],
 });
 
-/** Total skill invocations, labelled by skill_name, agent_id, and status */
+/** Total skill invocations, labelled by skill_name, agent_id, status, and version */
 export const skillInvocationsTotal = new Counter({
   name: "paperclip_skill_invocations_total",
   help: "Total number of skill invocations",
-  labelNames: ["skill_name", "agent_id", "status"],
+  labelNames: ["skill_name", "agent_id", "status", "version"],
   registers: [metricsRegistry],
 });
 
-/** Skill invocation token estimates, labelled by skill_name */
+/** Skill invocation token estimates, labelled by skill_name and version */
 export const skillTokensTotal = new Counter({
   name: "paperclip_skill_tokens_total",
   help: "Estimated tokens consumed by skill invocations",
-  labelNames: ["skill_name"],
+  labelNames: ["skill_name", "version"],
   registers: [metricsRegistry],
 });
 
@@ -90,7 +90,7 @@ export const skillTokensTotal = new Counter({
 export const skillInvocationDurationSeconds = new Histogram({
   name: "paperclip_skill_invocation_duration_seconds",
   help: "Skill invocation duration in seconds",
-  labelNames: ["skill_name", "agent_id"],
+  labelNames: ["skill_name", "agent_id", "version"],
   buckets: [0.5, 1, 2, 5, 10, 30, 60, 120],
   registers: [metricsRegistry],
 });

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4651,12 +4651,13 @@ export function heartbeatService(db: Db) {
         }
         if (adapterResult.skillInvocations) {
           for (const inv of adapterResult.skillInvocations) {
-            skillInvocationsTotal.inc({ skill_name: inv.skillName, agent_id: agent.id, status: inv.status });
+            const version = inv.version ?? "unknown";
+            skillInvocationsTotal.inc({ skill_name: inv.skillName, agent_id: agent.id, status: inv.status, version });
             if (inv.durationMs != null) {
-              skillInvocationDurationSeconds.observe({ skill_name: inv.skillName, agent_id: agent.id }, inv.durationMs / 1000);
+              skillInvocationDurationSeconds.observe({ skill_name: inv.skillName, agent_id: agent.id, version }, inv.durationMs / 1000);
             }
             if (inv.tokenEstimate != null && inv.tokenEstimate > 0) {
-              skillTokensTotal.inc({ skill_name: inv.skillName }, inv.tokenEstimate);
+              skillTokensTotal.inc({ skill_name: inv.skillName, version }, inv.tokenEstimate);
             }
           }
         }


### PR DESCRIPTION
## Summary
Implements skill invocation metrics with version tracking for [ANGA-565](https://github.com/anhermon/paperclip/issues/ANGA-565).

**What changed:**
- Added `version` label to skill metrics (invocations, tokens, duration)
- Updated heartbeat service to record skill version from `SkillInvocationReport`
- Added Grafana dashboard variable for `skill_name` filtering
- Added new "Skill Invocations by Version" panel for correlation tracking
- Updated all existing skill panels to support skill filtering

**Metrics now include:**
- `paperclip_skill_invocations_total{skill_name, agent_id, status, version}`
- `paperclip_skill_tokens_total{skill_name, version}`
- `paperclip_skill_invocation_duration_seconds{skill_name, agent_id, version}`

## Verification
- [x] TypeScript compilation passes (`npm run build` in server/)
- [x] Grafana dashboard JSON validated
- [x] All skill metrics include version label (defaults to "unknown" if not provided)
- [x] Dashboard panels filter by skill_name and display version trends

## Test plan
- [ ] Deploy observability stack: `docker compose -f docker-compose.observability.yml up`
- [ ] Trigger skill invocations via agent heartbeat runs
- [ ] Verify metrics appear in Prometheus at `/metrics` endpoint
- [ ] Check Grafana dashboard shows skill metrics with version labels
- [ ] Confirm "Skill Invocations by Version" panel displays version correlation

🤖 Generated with [Claude Code](https://claude.com/claude-code)