### PR TITLE
feat(templates): Add GitHub issue templates with upstream conflict check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,42 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior in the Paperclip Fork
+title: '[BUG] '
+labels: ['bug']
+assignees: ''
+---
+
+## Description
+<!-- Clear, concise description of the bug -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What should happen? -->
+
+## Actual Behavior
+<!-- What actually happens? -->
+
+## Environment
+- OS: <!-- e.g., Ubuntu 22.04, macOS 14.1 -->
+- Paperclip Version: <!-- e.g., commit hash or tag -->
+- Relevant Configuration: <!-- any custom settings or environment variables -->
+
+## Upstream Conflict Check
+*Required for issues touching: error taxonomy, schemas, agent config, platform abstractions*
+- [ ] Searched upstream tracker (paperclipai/paperclip) — no parallel implementation found
+- [ ] Prior Art Link: <!-- link here if upstream work exists -->
+- [ ] Reconciliation Scope: <!-- supersede / align with upstream / deliberate fork divergence -->
+
+## Logs/Screenshots
+<!-- Include relevant error messages, logs, or screenshots -->
+
+```
+<!-- Paste logs here -->
+```
+
+## Additional Context
+<!-- Any other information that might help diagnose the issue -->

--- a/.github/ISSUE_TEMPLATE/fork-feature.md
+++ b/.github/ISSUE_TEMPLATE/fork-feature.md
@@ -1,0 +1,33 @@
+---
+name: Fork Feature Request
+about: Propose a new feature or enhancement for the Paperclip Fork
+title: '[FEATURE] '
+labels: ['enhancement']
+assignees: ''
+---
+
+## Description
+<!-- Clear, concise description of the feature or enhancement -->
+
+## Motivation
+<!-- Why is this feature needed? What problem does it solve? -->
+
+## Proposed Solution
+<!-- How should this feature be implemented? Include technical details if applicable -->
+
+## Alternatives Considered
+<!-- What other approaches were considered? Why was this solution preferred? -->
+
+## Upstream Conflict Check
+*Required for issues touching: error taxonomy, schemas, agent config, platform abstractions*
+- [ ] Searched upstream tracker (paperclipai/paperclip) — no parallel implementation found
+- [ ] Prior Art Link: <!-- link here if upstream work exists -->
+- [ ] Reconciliation Scope: <!-- supersede / align with upstream / deliberate fork divergence -->
+
+## Acceptance Criteria
+<!-- Checklist of requirements that must be met for this feature to be considered complete -->
+- [ ] 
+- [ ] 
+
+## Additional Context
+<!-- Screenshots, mockups, related issues, or any other relevant information -->

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -225,6 +225,11 @@ describe("heartbeat comment wake batching", () => {
   }, 45_000);
 
   afterAll(async () => {
+    // End the db connection pool before stopping the embedded postgres instance.
+    // Without this, postgres.js has pending socket writes queued in Immediates
+    // that fire after the instance stops, producing an unhandled
+    // "Cannot read properties of null (reading 'write')" error.
+    await db.$client.end({ timeout: 5 });
     await instance?.stop();
     if (dataDir) {
       fs.rmSync(dataDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Add feature request and bug report templates to `.github/ISSUE_TEMPLATE/`
- Both templates include the upstream conflict check section per ANGA-556 triage gate requirements

## Changes
- **fork-feature.md**: Feature request template with upstream conflict check
- **bug-report.md**: Bug report template with upstream conflict check

## Upstream Conflict Check
The checklist ensures fork issues touching error taxonomy, schemas, agent config, or platform abstractions are screened against upstream tracker (paperclipai/paperclip) to prevent duplicate/conflicting implementations.

## Test plan
- [x] Templates created with proper YAML frontmatter
- [x] Upstream conflict check section included in both templates
- [ ] Verify templates appear in GitHub issue creation UI after merge

Related: [ANGA-895](https://app.paperclip.ing/ANGA/issues/ANGA-895) | Parent: [ANGA-556](https://app.paperclip.ing/ANGA/issues/ANGA-556)

🤖 Generated with [Claude Code](https://claude.com/claude-code)