### PR TITLE
test(server): add 319 unit tests for 16 pure-function service modules

### DIFF
--- a/packages/adapter-utils/src/heartbeat-context.test.ts
+++ b/packages/adapter-utils/src/heartbeat-context.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import { assembleHeartbeatInvocation } from "./heartbeat-context.js";
+
+// ============================================================================
+// assembleHeartbeatInvocation
+// ============================================================================
+
+describe("assembleHeartbeatInvocation", () => {
+  it("returns empty prompt and no layers for empty input", () => {
+    const result = assembleHeartbeatInvocation({});
+    expect(result.prompt).toBe("");
+    expect(result.heartbeatLayers).toEqual([]);
+    expect(result.promptMetrics.promptChars).toBe(0);
+  });
+
+  it("assembles a single text fragment into the prompt", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [
+        { key: "ctx", title: "Context", text: "You are a helpful agent." },
+      ],
+    });
+    expect(result.prompt).toBe("You are a helpful agent.");
+  });
+
+  it("joins multiple fragments with double newlines", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [
+        { key: "a", title: "A", text: "First." },
+        { key: "b", title: "B", text: "Second." },
+      ],
+    });
+    expect(result.prompt).toBe("First.\n\nSecond.");
+  });
+
+  it("trims whitespace from fragment text", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [
+        { key: "x", title: "X", text: "  trimmed  " },
+      ],
+    });
+    expect(result.prompt).toBe("trimmed");
+  });
+
+  it("excludes fragments with null or undefined text from the prompt", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [
+        { key: "a", title: "A", text: "included" },
+        { key: "b", title: "B", text: null },
+      ],
+    });
+    expect(result.prompt).toBe("included");
+  });
+
+  it("marks included fragments in heartbeatLayers", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [
+        { key: "a", title: "A", text: "content" },
+        { key: "b", title: "B", text: "" },
+      ],
+    });
+    const layerA = result.heartbeatLayers.find((l) => l.key === "a");
+    const layerB = result.heartbeatLayers.find((l) => l.key === "b");
+    expect(layerA?.includedInPrompt).toBe(true);
+    expect(layerB?.includedInPrompt).toBe(false);
+  });
+
+  it("records promptMetrics with promptChars", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [{ key: "x", title: "X", text: "hello" }],
+    });
+    expect(result.promptMetrics.promptChars).toBe(5);
+  });
+
+  it("records a custom metricKey in promptMetrics", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [
+        { key: "x", title: "X", text: "12345", metricKey: "myMetric" },
+      ],
+    });
+    expect(result.promptMetrics.myMetric).toBe(5);
+  });
+
+  it("ignores fragments with empty/blank metricKey", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [
+        { key: "x", title: "X", text: "abc", metricKey: "  " },
+      ],
+    });
+    expect(result.promptMetrics["  "]).toBeUndefined();
+  });
+
+  it("adds adapter layers to heartbeatLayers with kind=adapter", () => {
+    const result = assembleHeartbeatInvocation({
+      adapterLayers: [
+        { key: "adapter-ctx", title: "Adapter Context", chars: 100, includedInPrompt: true },
+      ],
+    });
+    const layer = result.heartbeatLayers[0];
+    expect(layer?.kind).toBe("adapter");
+    expect(layer?.key).toBe("adapter-ctx");
+    expect(layer?.chars).toBe(100);
+  });
+
+  it("uses the fragment summary if provided", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [
+        { key: "a", title: "A", text: "content", summary: "custom summary" },
+      ],
+    });
+    const layer = result.heartbeatLayers.find((l) => l.key === "a");
+    expect(layer?.summary).toBe("custom summary");
+  });
+
+  it("generates a default summary based on title and chars when no summary provided", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [{ key: "a", title: "Instructions", text: "hello" }],
+    });
+    const layer = result.heartbeatLayers.find((l) => l.key === "a");
+    expect(layer?.summary).toContain("Instructions");
+    expect(layer?.summary).toContain("5 chars");
+  });
+
+  it("generates 'skipped' default summary for empty text", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [{ key: "a", title: "Instructions", text: "" }],
+    });
+    const layer = result.heartbeatLayers.find((l) => l.key === "a");
+    expect(layer?.summary).toContain("skipped");
+  });
+
+  it("propagates memoryClass from fragment to layer", () => {
+    const result = assembleHeartbeatInvocation({
+      promptFragments: [
+        { key: "ep", title: "Episodic", text: "memory", memoryClass: "episodic" },
+      ],
+    });
+    const layer = result.heartbeatLayers.find((l) => l.key === "ep");
+    expect(layer?.memoryClass).toBe("episodic");
+  });
+
+  it("reads context layers from paperclipHeartbeatContext", () => {
+    const result = assembleHeartbeatInvocation({
+      context: {
+        paperclipHeartbeatContext: {
+          layers: [
+            {
+              key: "ctx-layer",
+              title: "Ctx Layer",
+              kind: "context",
+              summary: "from context",
+              chars: 0,
+              includedInPrompt: false,
+            },
+          ],
+        },
+      },
+    });
+    const layer = result.heartbeatLayers.find((l) => l.key === "ctx-layer");
+    expect(layer).toBeDefined();
+    expect(layer?.title).toBe("Ctx Layer");
+  });
+});

--- a/packages/adapter-utils/src/session-compaction.test.ts
+++ b/packages/adapter-utils/src/session-compaction.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import {
+  getAdapterSessionManagement,
+  readSessionCompactionOverride,
+  resolveSessionCompactionPolicy,
+  hasSessionCompactionThresholds,
+  LEGACY_SESSIONED_ADAPTER_TYPES,
+} from "./session-compaction.js";
+
+// ============================================================================
+// getAdapterSessionManagement
+// ============================================================================
+
+describe("getAdapterSessionManagement", () => {
+  it("returns null for null input", () => {
+    expect(getAdapterSessionManagement(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(getAdapterSessionManagement(undefined)).toBeNull();
+  });
+
+  it("returns null for unknown adapter types", () => {
+    expect(getAdapterSessionManagement("unknown_adapter")).toBeNull();
+  });
+
+  it("returns session management for 'claude_local'", () => {
+    const result = getAdapterSessionManagement("claude_local");
+    expect(result).not.toBeNull();
+    expect(result?.supportsSessionResume).toBe(true);
+    expect(result?.nativeContextManagement).toBe("confirmed");
+  });
+
+  it("returns session management for 'codex_local'", () => {
+    const result = getAdapterSessionManagement("codex_local");
+    expect(result).not.toBeNull();
+    expect(result?.supportsSessionResume).toBe(true);
+  });
+});
+
+// ============================================================================
+// LEGACY_SESSIONED_ADAPTER_TYPES
+// ============================================================================
+
+describe("LEGACY_SESSIONED_ADAPTER_TYPES", () => {
+  it("includes claude_local", () => {
+    expect(LEGACY_SESSIONED_ADAPTER_TYPES.has("claude_local")).toBe(true);
+  });
+
+  it("includes codex_local", () => {
+    expect(LEGACY_SESSIONED_ADAPTER_TYPES.has("codex_local")).toBe(true);
+  });
+
+  it("does not include unknown types", () => {
+    expect(LEGACY_SESSIONED_ADAPTER_TYPES.has("unknown")).toBe(false);
+  });
+});
+
+// ============================================================================
+// readSessionCompactionOverride
+// ============================================================================
+
+describe("readSessionCompactionOverride", () => {
+  it("returns empty object for null runtimeConfig", () => {
+    expect(readSessionCompactionOverride(null)).toEqual({});
+  });
+
+  it("returns empty object for missing compaction config", () => {
+    expect(readSessionCompactionOverride({ other: "value" })).toEqual({});
+  });
+
+  it("reads enabled from heartbeat.sessionCompaction", () => {
+    const result = readSessionCompactionOverride({
+      heartbeat: { sessionCompaction: { enabled: "true" } },
+    });
+    expect(result.enabled).toBe(true);
+  });
+
+  it("reads enabled=false from string 'false'", () => {
+    const result = readSessionCompactionOverride({
+      heartbeat: { sessionCompaction: { enabled: "false" } },
+    });
+    expect(result.enabled).toBe(false);
+  });
+
+  it("reads enabled=false from string '0'", () => {
+    const result = readSessionCompactionOverride({
+      heartbeat: { sessionCompaction: { enabled: "0" } },
+    });
+    expect(result.enabled).toBe(false);
+  });
+
+  it("reads maxSessionRuns from numeric value", () => {
+    const result = readSessionCompactionOverride({
+      heartbeat: { sessionCompaction: { maxSessionRuns: 50 } },
+    });
+    expect(result.maxSessionRuns).toBe(50);
+  });
+
+  it("reads maxSessionRuns from string '50'", () => {
+    const result = readSessionCompactionOverride({
+      heartbeat: { sessionCompaction: { maxSessionRuns: "50" } },
+    });
+    expect(result.maxSessionRuns).toBe(50);
+  });
+
+  it("clamps negative maxSessionRuns to 0", () => {
+    const result = readSessionCompactionOverride({
+      heartbeat: { sessionCompaction: { maxSessionRuns: -5 } },
+    });
+    expect(result.maxSessionRuns).toBe(0);
+  });
+
+  it("reads from legacy heartbeat.sessionRotation key", () => {
+    const result = readSessionCompactionOverride({
+      heartbeat: { sessionRotation: { enabled: true } },
+    });
+    expect(result.enabled).toBe(true);
+  });
+
+  it("reads from top-level sessionCompaction key as fallback", () => {
+    const result = readSessionCompactionOverride({
+      sessionCompaction: { maxRawInputTokens: 1000000 },
+    });
+    expect(result.maxRawInputTokens).toBe(1000000);
+  });
+
+  it("floors fractional maxSessionRuns", () => {
+    const result = readSessionCompactionOverride({
+      heartbeat: { sessionCompaction: { maxSessionRuns: 7.9 } },
+    });
+    expect(result.maxSessionRuns).toBe(7);
+  });
+
+  it("ignores non-numeric non-string maxSessionRuns values", () => {
+    const result = readSessionCompactionOverride({
+      heartbeat: { sessionCompaction: { maxSessionRuns: {} } },
+    });
+    expect(result.maxSessionRuns).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// resolveSessionCompactionPolicy
+// ============================================================================
+
+describe("resolveSessionCompactionPolicy", () => {
+  it("uses adapter_default source for known adapters without override", () => {
+    const result = resolveSessionCompactionPolicy("claude_local", null);
+    expect(result.source).toBe("adapter_default");
+    expect(result.adapterSessionManagement).not.toBeNull();
+    expect(result.explicitOverride).toEqual({});
+  });
+
+  it("uses agent_override source when explicit overrides are present", () => {
+    const result = resolveSessionCompactionPolicy("claude_local", {
+      heartbeat: { sessionCompaction: { maxSessionRuns: 10 } },
+    });
+    expect(result.source).toBe("agent_override");
+    expect(result.policy.maxSessionRuns).toBe(10);
+  });
+
+  it("uses legacy_fallback for unknown adapters with no override", () => {
+    const result = resolveSessionCompactionPolicy("custom_adapter", null);
+    expect(result.source).toBe("legacy_fallback");
+    expect(result.adapterSessionManagement).toBeNull();
+  });
+
+  it("enables compaction for legacy sessioned adapter types", () => {
+    const result = resolveSessionCompactionPolicy("claude_local", null);
+    expect(result.policy.enabled).toBe(true);
+  });
+
+  it("disables compaction for unknown adapters (not in legacy set)", () => {
+    const result = resolveSessionCompactionPolicy("non_legacy_adapter", null);
+    expect(result.policy.enabled).toBe(false);
+  });
+
+  it("explicit override takes precedence over adapter default", () => {
+    const result = resolveSessionCompactionPolicy("claude_local", {
+      heartbeat: { sessionCompaction: { enabled: false } },
+    });
+    expect(result.policy.enabled).toBe(false);
+  });
+
+  it("returns null adapterSessionManagement for null adapter type", () => {
+    const result = resolveSessionCompactionPolicy(null, null);
+    expect(result.adapterSessionManagement).toBeNull();
+  });
+});
+
+// ============================================================================
+// hasSessionCompactionThresholds
+// ============================================================================
+
+describe("hasSessionCompactionThresholds", () => {
+  it("returns false when all thresholds are 0", () => {
+    expect(
+      hasSessionCompactionThresholds({ maxSessionRuns: 0, maxRawInputTokens: 0, maxSessionAgeHours: 0 }),
+    ).toBe(false);
+  });
+
+  it("returns true when maxSessionRuns is positive", () => {
+    expect(
+      hasSessionCompactionThresholds({ maxSessionRuns: 10, maxRawInputTokens: 0, maxSessionAgeHours: 0 }),
+    ).toBe(true);
+  });
+
+  it("returns true when maxRawInputTokens is positive", () => {
+    expect(
+      hasSessionCompactionThresholds({ maxSessionRuns: 0, maxRawInputTokens: 1000000, maxSessionAgeHours: 0 }),
+    ).toBe(true);
+  });
+
+  it("returns true when maxSessionAgeHours is positive", () => {
+    expect(
+      hasSessionCompactionThresholds({ maxSessionRuns: 0, maxRawInputTokens: 0, maxSessionAgeHours: 24 }),
+    ).toBe(true);
+  });
+});

--- a/packages/mcp-server/src/format-config.test.ts
+++ b/packages/mcp-server/src/format-config.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import { formatTextResponse, formatErrorResponse } from "./format.js";
+import { normalizeApiUrl, readConfigFromEnv } from "./config.js";
+import { PaperclipApiError } from "./client.js";
+
+// ============================================================================
+// format.ts — formatTextResponse
+// ============================================================================
+
+describe("formatTextResponse", () => {
+  it("wraps a string value in MCP text content", () => {
+    const result = formatTextResponse("hello");
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0]?.type).toBe("text");
+    expect(result.content[0]?.text).toBe("hello");
+  });
+
+  it("JSON-serializes a non-string value", () => {
+    const result = formatTextResponse({ key: "value" });
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual({ key: "value" });
+  });
+
+  it("JSON-serializes an array", () => {
+    const result = formatTextResponse([1, 2, 3]);
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed).toEqual([1, 2, 3]);
+  });
+
+  it("JSON-serializes null", () => {
+    const result = formatTextResponse(null);
+    expect(result.content[0]?.text).toBe("null");
+  });
+
+  it("JSON-serializes a number", () => {
+    const result = formatTextResponse(42);
+    expect(result.content[0]?.text).toBe("42");
+  });
+});
+
+// ============================================================================
+// format.ts — formatErrorResponse
+// ============================================================================
+
+describe("formatErrorResponse", () => {
+  it("formats a generic Error by message", () => {
+    const result = formatErrorResponse(new Error("something failed"));
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.error).toBe("something failed");
+  });
+
+  it("formats a PaperclipApiError with full details", () => {
+    const err = new PaperclipApiError({
+      message: "Not Found",
+      status: 404,
+      method: "GET",
+      path: "/issues/999",
+      body: null,
+    });
+    const result = formatErrorResponse(err);
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.error).toBe("Not Found");
+    expect(parsed.status).toBe(404);
+    expect(parsed.method).toBe("GET");
+    expect(parsed.path).toBe("/issues/999");
+  });
+
+  it("formats a non-Error value via String()", () => {
+    const result = formatErrorResponse("raw string error");
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.error).toBe("raw string error");
+  });
+});
+
+// ============================================================================
+// config.ts — normalizeApiUrl
+// ============================================================================
+
+describe("normalizeApiUrl", () => {
+  it("appends /api when not present", () => {
+    expect(normalizeApiUrl("http://localhost:3000")).toBe("http://localhost:3000/api");
+  });
+
+  it("does not double-append /api when already present", () => {
+    expect(normalizeApiUrl("http://localhost:3000/api")).toBe("http://localhost:3000/api");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(normalizeApiUrl("http://localhost:3000/")).toBe("http://localhost:3000/api");
+    expect(normalizeApiUrl("http://localhost:3000///")).toBe("http://localhost:3000/api");
+  });
+
+  it("strips trailing slashes from a URL that already has /api/", () => {
+    expect(normalizeApiUrl("http://localhost:3000/api/")).toBe("http://localhost:3000/api");
+  });
+
+  it("trims leading/trailing whitespace from the URL", () => {
+    expect(normalizeApiUrl("  http://localhost:3000  ")).toBe("http://localhost:3000/api");
+  });
+});
+
+// ============================================================================
+// config.ts — readConfigFromEnv
+// ============================================================================
+
+describe("readConfigFromEnv", () => {
+  const baseEnv = {
+    PAPERCLIP_API_URL: "http://localhost:3000",
+    PAPERCLIP_API_KEY: "token-abc",
+  } as NodeJS.ProcessEnv;
+
+  it("reads required fields from environment", () => {
+    const config = readConfigFromEnv(baseEnv);
+    expect(config.apiUrl).toBe("http://localhost:3000/api");
+    expect(config.apiKey).toBe("token-abc");
+  });
+
+  it("returns null for optional fields when not set", () => {
+    const config = readConfigFromEnv(baseEnv);
+    expect(config.companyId).toBeNull();
+    expect(config.agentId).toBeNull();
+    expect(config.runId).toBeNull();
+  });
+
+  it("reads optional fields when provided", () => {
+    const config = readConfigFromEnv({
+      ...baseEnv,
+      PAPERCLIP_COMPANY_ID: "co-1",
+      PAPERCLIP_AGENT_ID: "agent-1",
+      PAPERCLIP_RUN_ID: "run-1",
+    } as NodeJS.ProcessEnv);
+    expect(config.companyId).toBe("co-1");
+    expect(config.agentId).toBe("agent-1");
+    expect(config.runId).toBe("run-1");
+  });
+
+  it("throws when PAPERCLIP_API_URL is missing", () => {
+    expect(() =>
+      readConfigFromEnv({ PAPERCLIP_API_KEY: "key" } as NodeJS.ProcessEnv)
+    ).toThrow(/PAPERCLIP_API_URL/);
+  });
+
+  it("throws when PAPERCLIP_API_KEY is missing", () => {
+    expect(() =>
+      readConfigFromEnv({ PAPERCLIP_API_URL: "http://x" } as NodeJS.ProcessEnv)
+    ).toThrow(/PAPERCLIP_API_KEY/);
+  });
+
+  it("treats whitespace-only values as missing", () => {
+    expect(() =>
+      readConfigFromEnv({
+        PAPERCLIP_API_URL: "   ",
+        PAPERCLIP_API_KEY: "key",
+      } as NodeJS.ProcessEnv)
+    ).toThrow(/PAPERCLIP_API_URL/);
+  });
+});

--- a/packages/shared/src/execution-workspace-guards.test.ts
+++ b/packages/shared/src/execution-workspace-guards.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  isClosedIsolatedExecutionWorkspace,
+  getClosedIsolatedExecutionWorkspaceMessage,
+} from "./execution-workspace-guards.js";
+
+// ============================================================================
+// isClosedIsolatedExecutionWorkspace
+// ============================================================================
+
+describe("isClosedIsolatedExecutionWorkspace", () => {
+  const base = {
+    mode: "isolated_workspace" as const,
+    status: "active" as const,
+    closedAt: null,
+  };
+
+  it("returns false for null", () => {
+    expect(isClosedIsolatedExecutionWorkspace(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isClosedIsolatedExecutionWorkspace(undefined)).toBe(false);
+  });
+
+  it("returns false when mode is not isolated_workspace", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({ ...base, mode: "shared_workspace" })
+    ).toBe(false);
+  });
+
+  it("returns false when mode is operator_branch", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({ ...base, mode: "operator_branch" })
+    ).toBe(false);
+  });
+
+  it("returns false when isolated and status is active with no closedAt", () => {
+    expect(isClosedIsolatedExecutionWorkspace(base)).toBe(false);
+  });
+
+  it("returns false when isolated and status is idle with no closedAt", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({ ...base, status: "idle" })
+    ).toBe(false);
+  });
+
+  it("returns false when isolated and status is in_review with no closedAt", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({ ...base, status: "in_review" })
+    ).toBe(false);
+  });
+
+  it("returns true when isolated and status is archived", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({ ...base, status: "archived" })
+    ).toBe(true);
+  });
+
+  it("returns true when isolated and status is cleanup_failed", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({ ...base, status: "cleanup_failed" })
+    ).toBe(true);
+  });
+
+  it("returns true when isolated and closedAt is a date string", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({ ...base, closedAt: "2024-01-01T00:00:00Z" })
+    ).toBe(true);
+  });
+
+  it("returns true when isolated and closedAt is a Date object", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({ ...base, closedAt: new Date() })
+    ).toBe(true);
+  });
+
+  it("returns true when both closedAt is set and status is archived", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({
+        ...base,
+        closedAt: "2024-01-01T00:00:00Z",
+        status: "archived",
+      })
+    ).toBe(true);
+  });
+
+  it("returns false when non-isolated with closed status (mode takes priority)", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({
+        ...base,
+        mode: "shared_workspace",
+        status: "archived",
+      })
+    ).toBe(false);
+  });
+
+  it("returns false when non-isolated with closedAt set", () => {
+    expect(
+      isClosedIsolatedExecutionWorkspace({
+        ...base,
+        mode: "shared_workspace",
+        closedAt: "2024-01-01T00:00:00Z",
+      })
+    ).toBe(false);
+  });
+});
+
+// ============================================================================
+// getClosedIsolatedExecutionWorkspaceMessage
+// ============================================================================
+
+describe("getClosedIsolatedExecutionWorkspaceMessage", () => {
+  it("returns a message containing the workspace name", () => {
+    const msg = getClosedIsolatedExecutionWorkspaceMessage({ name: "my-workspace" });
+    expect(msg).toContain("my-workspace");
+  });
+
+  it("wraps workspace name in quotes", () => {
+    const msg = getClosedIsolatedExecutionWorkspaceMessage({ name: "feature-branch" });
+    expect(msg).toContain('"feature-branch"');
+  });
+
+  it("mentions 'closed workspace'", () => {
+    const msg = getClosedIsolatedExecutionWorkspaceMessage({ name: "ws" });
+    expect(msg).toMatch(/closed workspace/i);
+  });
+
+  it("mentions moving to an open workspace", () => {
+    const msg = getClosedIsolatedExecutionWorkspaceMessage({ name: "ws" });
+    expect(msg).toMatch(/open workspace/i);
+  });
+
+  it("works with an empty name string", () => {
+    const msg = getClosedIsolatedExecutionWorkspaceMessage({ name: "" });
+    expect(msg).toContain('""');
+  });
+
+  it("works with a name containing special characters", () => {
+    const msg = getClosedIsolatedExecutionWorkspaceMessage({ name: "ws/feature-123" });
+    expect(msg).toContain('"ws/feature-123"');
+  });
+});

--- a/packages/shared/src/execution-workspace-guards.test.ts
+++ b/packages/shared/src/execution-workspace-guards.test.ts
@@ -63,13 +63,13 @@ describe("isClosedIsolatedExecutionWorkspace", () => {
     ).toBe(true);
   });
 
-  it("returns true when isolated and closedAt is a date string", () => {
+  it("returns true when isolated and closedAt is a Date object", () => {
     expect(
-      isClosedIsolatedExecutionWorkspace({ ...base, closedAt: "2024-01-01T00:00:00Z" })
+      isClosedIsolatedExecutionWorkspace({ ...base, closedAt: new Date("2024-01-01T00:00:00Z") })
     ).toBe(true);
   });
 
-  it("returns true when isolated and closedAt is a Date object", () => {
+  it("returns true when isolated and closedAt is today's date", () => {
     expect(
       isClosedIsolatedExecutionWorkspace({ ...base, closedAt: new Date() })
     ).toBe(true);
@@ -79,7 +79,7 @@ describe("isClosedIsolatedExecutionWorkspace", () => {
     expect(
       isClosedIsolatedExecutionWorkspace({
         ...base,
-        closedAt: "2024-01-01T00:00:00Z",
+        closedAt: new Date("2024-01-01T00:00:00Z"),
         status: "archived",
       })
     ).toBe(true);
@@ -100,7 +100,7 @@ describe("isClosedIsolatedExecutionWorkspace", () => {
       isClosedIsolatedExecutionWorkspace({
         ...base,
         mode: "shared_workspace",
-        closedAt: "2024-01-01T00:00:00Z",
+        closedAt: new Date("2024-01-01T00:00:00Z"),
       })
     ).toBe(false);
   });

--- a/packages/shared/src/network-bind.test.ts
+++ b/packages/shared/src/network-bind.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from "vitest";
+import {
+  LOOPBACK_BIND_HOST,
+  ALL_INTERFACES_BIND_HOST,
+  isLoopbackHost,
+  isAllInterfacesHost,
+  inferBindModeFromHost,
+  validateConfiguredBindMode,
+  resolveRuntimeBind,
+} from "./network-bind.js";
+
+// ============================================================================
+// isLoopbackHost
+// ============================================================================
+
+describe("isLoopbackHost", () => {
+  it("returns true for '127.0.0.1'", () => {
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+  });
+
+  it("returns true for 'localhost'", () => {
+    expect(isLoopbackHost("localhost")).toBe(true);
+  });
+
+  it("returns true for 'LOCALHOST' (case-insensitive)", () => {
+    expect(isLoopbackHost("LOCALHOST")).toBe(true);
+  });
+
+  it("returns true for '::1' (IPv6 loopback)", () => {
+    expect(isLoopbackHost("::1")).toBe(true);
+  });
+
+  it("returns false for '0.0.0.0'", () => {
+    expect(isLoopbackHost("0.0.0.0")).toBe(false);
+  });
+
+  it("returns false for a public IP", () => {
+    expect(isLoopbackHost("192.168.1.1")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isLoopbackHost(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isLoopbackHost(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isLoopbackHost("")).toBe(false);
+  });
+
+  it("handles whitespace-padded host", () => {
+    expect(isLoopbackHost("  127.0.0.1  ")).toBe(true);
+  });
+});
+
+// ============================================================================
+// isAllInterfacesHost
+// ============================================================================
+
+describe("isAllInterfacesHost", () => {
+  it("returns true for '0.0.0.0'", () => {
+    expect(isAllInterfacesHost("0.0.0.0")).toBe(true);
+  });
+
+  it("returns true for '::' (IPv6 all interfaces)", () => {
+    expect(isAllInterfacesHost("::")).toBe(true);
+  });
+
+  it("returns false for '127.0.0.1'", () => {
+    expect(isAllInterfacesHost("127.0.0.1")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isAllInterfacesHost(null)).toBe(false);
+  });
+});
+
+// ============================================================================
+// inferBindModeFromHost
+// ============================================================================
+
+describe("inferBindModeFromHost", () => {
+  it("returns 'loopback' for null", () => {
+    expect(inferBindModeFromHost(null)).toBe("loopback");
+  });
+
+  it("returns 'loopback' for '127.0.0.1'", () => {
+    expect(inferBindModeFromHost("127.0.0.1")).toBe("loopback");
+  });
+
+  it("returns 'loopback' for 'localhost'", () => {
+    expect(inferBindModeFromHost("localhost")).toBe("loopback");
+  });
+
+  it("returns 'lan' for '0.0.0.0'", () => {
+    expect(inferBindModeFromHost("0.0.0.0")).toBe("lan");
+  });
+
+  it("returns 'tailnet' when host matches tailnetBindHost", () => {
+    expect(
+      inferBindModeFromHost("100.64.1.2", { tailnetBindHost: "100.64.1.2" })
+    ).toBe("tailnet");
+  });
+
+  it("returns 'custom' for an unrecognized host with no tailnet match", () => {
+    expect(inferBindModeFromHost("10.0.0.1")).toBe("custom");
+  });
+
+  it("returns 'custom' even when tailnetBindHost is set but host doesn't match", () => {
+    expect(
+      inferBindModeFromHost("10.0.0.1", { tailnetBindHost: "100.64.1.2" })
+    ).toBe("custom");
+  });
+});
+
+// ============================================================================
+// validateConfiguredBindMode
+// ============================================================================
+
+describe("validateConfiguredBindMode", () => {
+  it("returns no errors for a valid loopback local_trusted setup", () => {
+    const errors = validateConfiguredBindMode({
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bind: "loopback",
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("returns error when local_trusted is not loopback", () => {
+    const errors = validateConfiguredBindMode({
+      deploymentMode: "local_trusted",
+      deploymentExposure: "private",
+      bind: "lan",
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/loopback/);
+  });
+
+  it("returns error when bind=custom but customBindHost is missing", () => {
+    const errors = validateConfiguredBindMode({
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bind: "custom",
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/customBindHost/);
+  });
+
+  it("returns no error when bind=custom and customBindHost is set", () => {
+    const errors = validateConfiguredBindMode({
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bind: "custom",
+      customBindHost: "10.0.0.5",
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("returns error when authenticated/public uses tailnet", () => {
+    const errors = validateConfiguredBindMode({
+      deploymentMode: "authenticated",
+      deploymentExposure: "public",
+      bind: "tailnet",
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatch(/tailnet/);
+  });
+
+  it("allows tailnet for authenticated/private", () => {
+    const errors = validateConfiguredBindMode({
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bind: "tailnet",
+    });
+    expect(errors).toEqual([]);
+  });
+});
+
+// ============================================================================
+// resolveRuntimeBind
+// ============================================================================
+
+describe("resolveRuntimeBind", () => {
+  it("resolves loopback bind to 127.0.0.1", () => {
+    const result = resolveRuntimeBind({ bind: "loopback" });
+    expect(result.bind).toBe("loopback");
+    expect(result.host).toBe(LOOPBACK_BIND_HOST);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("resolves lan bind to 0.0.0.0", () => {
+    const result = resolveRuntimeBind({ bind: "lan" });
+    expect(result.bind).toBe("lan");
+    expect(result.host).toBe(ALL_INTERFACES_BIND_HOST);
+    expect(result.errors).toEqual([]);
+  });
+
+  it("resolves custom bind with customBindHost", () => {
+    const result = resolveRuntimeBind({ bind: "custom", customBindHost: "10.0.0.5" });
+    expect(result.host).toBe("10.0.0.5");
+    expect(result.errors).toEqual([]);
+  });
+
+  it("returns error for custom bind without customBindHost", () => {
+    const result = resolveRuntimeBind({ bind: "custom" });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/customBindHost/);
+  });
+
+  it("resolves tailnet bind with tailnetBindHost", () => {
+    const result = resolveRuntimeBind({ bind: "tailnet", tailnetBindHost: "100.64.1.2" });
+    expect(result.host).toBe("100.64.1.2");
+    expect(result.errors).toEqual([]);
+  });
+
+  it("returns error for tailnet bind without tailnetBindHost", () => {
+    const result = resolveRuntimeBind({ bind: "tailnet" });
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatch(/tailnet/);
+  });
+
+  it("infers bind mode from host when bind is not specified", () => {
+    const result = resolveRuntimeBind({ host: "0.0.0.0" });
+    expect(result.bind).toBe("lan");
+    expect(result.host).toBe(ALL_INTERFACES_BIND_HOST);
+  });
+});
+
+// ============================================================================
+// constants
+// ============================================================================
+
+describe("LOOPBACK_BIND_HOST and ALL_INTERFACES_BIND_HOST", () => {
+  it("LOOPBACK_BIND_HOST is 127.0.0.1", () => {
+    expect(LOOPBACK_BIND_HOST).toBe("127.0.0.1");
+  });
+
+  it("ALL_INTERFACES_BIND_HOST is 0.0.0.0", () => {
+    expect(ALL_INTERFACES_BIND_HOST).toBe("0.0.0.0");
+  });
+});

--- a/packages/shared/src/validators/execution-workspace-validators.test.ts
+++ b/packages/shared/src/validators/execution-workspace-validators.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from "vitest";
+import {
+  executionWorkspaceStatusSchema,
+  executionWorkspaceConfigSchema,
+  executionWorkspaceCloseReadinessStateSchema,
+  executionWorkspaceCloseActionKindSchema,
+  executionWorkspaceCloseActionSchema,
+  updateExecutionWorkspaceSchema,
+} from "./execution-workspace.js";
+import {
+  agentSkillStateSchema,
+  agentSkillOriginSchema,
+  agentSkillSyncModeSchema,
+  agentSkillEntrySchema,
+  agentSkillSnapshotSchema,
+  agentSkillSyncSchema,
+} from "./adapter-skills.js";
+
+// ============================================================================
+// execution-workspace.ts
+// ============================================================================
+
+describe("executionWorkspaceStatusSchema", () => {
+  it("accepts 'active'", () => {
+    expect(executionWorkspaceStatusSchema.parse("active")).toBe("active");
+  });
+
+  it("accepts 'archived'", () => {
+    expect(executionWorkspaceStatusSchema.parse("archived")).toBe("archived");
+  });
+
+  it("rejects unknown status", () => {
+    expect(() => executionWorkspaceStatusSchema.parse("deleted")).toThrow();
+  });
+});
+
+describe("executionWorkspaceConfigSchema", () => {
+  it("parses an empty config", () => {
+    const result = executionWorkspaceConfigSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts provisionCommand", () => {
+    const result = executionWorkspaceConfigSchema.parse({ provisionCommand: "npm install" });
+    expect(result.provisionCommand).toBe("npm install");
+  });
+
+  it("accepts desiredState 'running' or 'stopped'", () => {
+    const r1 = executionWorkspaceConfigSchema.parse({ desiredState: "running" });
+    const r2 = executionWorkspaceConfigSchema.parse({ desiredState: "stopped" });
+    expect(r1.desiredState).toBe("running");
+    expect(r2.desiredState).toBe("stopped");
+  });
+
+  it("rejects unknown desiredState", () => {
+    expect(() => executionWorkspaceConfigSchema.parse({ desiredState: "paused" })).toThrow();
+  });
+
+  it("rejects unknown fields (strict)", () => {
+    expect(() =>
+      executionWorkspaceConfigSchema.parse({ unknownField: "x" })
+    ).toThrow();
+  });
+});
+
+describe("executionWorkspaceCloseReadinessStateSchema", () => {
+  it("accepts all valid states", () => {
+    expect(executionWorkspaceCloseReadinessStateSchema.parse("ready")).toBe("ready");
+    expect(executionWorkspaceCloseReadinessStateSchema.parse("ready_with_warnings")).toBe("ready_with_warnings");
+    expect(executionWorkspaceCloseReadinessStateSchema.parse("blocked")).toBe("blocked");
+  });
+
+  it("rejects unknown state", () => {
+    expect(() =>
+      executionWorkspaceCloseReadinessStateSchema.parse("pending")
+    ).toThrow();
+  });
+});
+
+describe("executionWorkspaceCloseActionKindSchema", () => {
+  it("accepts 'archive_record'", () => {
+    expect(executionWorkspaceCloseActionKindSchema.parse("archive_record")).toBe("archive_record");
+  });
+
+  it("accepts 'git_worktree_remove'", () => {
+    expect(executionWorkspaceCloseActionKindSchema.parse("git_worktree_remove")).toBe("git_worktree_remove");
+  });
+
+  it("rejects unknown kind", () => {
+    expect(() => executionWorkspaceCloseActionKindSchema.parse("delete_bucket")).toThrow();
+  });
+});
+
+describe("executionWorkspaceCloseActionSchema", () => {
+  it("parses a valid close action", () => {
+    const result = executionWorkspaceCloseActionSchema.parse({
+      kind: "archive_record",
+      label: "Archive",
+      description: "Archive the workspace record",
+      command: null,
+    });
+    expect(result.kind).toBe("archive_record");
+    expect(result.command).toBeNull();
+  });
+
+  it("accepts a command string", () => {
+    const result = executionWorkspaceCloseActionSchema.parse({
+      kind: "cleanup_command",
+      label: "Cleanup",
+      description: "Run cleanup",
+      command: "npm run cleanup",
+    });
+    expect(result.command).toBe("npm run cleanup");
+  });
+
+  it("rejects unknown fields (strict)", () => {
+    expect(() =>
+      executionWorkspaceCloseActionSchema.parse({
+        kind: "archive_record",
+        label: "A",
+        description: "D",
+        command: null,
+        extra: "field",
+      })
+    ).toThrow();
+  });
+});
+
+describe("updateExecutionWorkspaceSchema", () => {
+  it("parses an empty update (all optional)", () => {
+    const result = updateExecutionWorkspaceSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts partial updates", () => {
+    const result = updateExecutionWorkspaceSchema.parse({ name: "new-name" });
+    expect(result.name).toBe("new-name");
+  });
+
+  it("accepts status update", () => {
+    const result = updateExecutionWorkspaceSchema.parse({ status: "idle" });
+    expect(result.status).toBe("idle");
+  });
+
+  it("accepts a config object", () => {
+    const result = updateExecutionWorkspaceSchema.parse({
+      config: { desiredState: "stopped" },
+    });
+    expect(result.config?.desiredState).toBe("stopped");
+  });
+
+  it("rejects unknown fields (strict)", () => {
+    expect(() =>
+      updateExecutionWorkspaceSchema.parse({ unknownField: "x" })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// adapter-skills.ts
+// ============================================================================
+
+describe("agentSkillStateSchema", () => {
+  it("accepts all valid states", () => {
+    const states = ["available", "configured", "installed", "missing", "stale", "external"];
+    for (const state of states) {
+      expect(agentSkillStateSchema.parse(state)).toBe(state);
+    }
+  });
+
+  it("rejects unknown state", () => {
+    expect(() => agentSkillStateSchema.parse("disabled")).toThrow();
+  });
+});
+
+describe("agentSkillOriginSchema", () => {
+  it("accepts all valid origins", () => {
+    const origins = ["company_managed", "paperclip_required", "user_installed", "external_unknown"];
+    for (const origin of origins) {
+      expect(agentSkillOriginSchema.parse(origin)).toBe(origin);
+    }
+  });
+
+  it("rejects unknown origin", () => {
+    expect(() => agentSkillOriginSchema.parse("vendor_installed")).toThrow();
+  });
+});
+
+describe("agentSkillSyncModeSchema", () => {
+  it("accepts all valid modes", () => {
+    const modes = ["unsupported", "persistent", "ephemeral"];
+    for (const mode of modes) {
+      expect(agentSkillSyncModeSchema.parse(mode)).toBe(mode);
+    }
+  });
+
+  it("rejects unknown mode", () => {
+    expect(() => agentSkillSyncModeSchema.parse("volatile")).toThrow();
+  });
+});
+
+describe("agentSkillEntrySchema", () => {
+  const validEntry = {
+    key: "claude-code",
+    runtimeName: "claude",
+    desired: true,
+    managed: true,
+    state: "installed",
+  };
+
+  it("parses a minimal skill entry", () => {
+    const result = agentSkillEntrySchema.parse(validEntry);
+    expect(result.key).toBe("claude-code");
+    expect(result.state).toBe("installed");
+  });
+
+  it("accepts null runtimeName", () => {
+    const result = agentSkillEntrySchema.parse({ ...validEntry, runtimeName: null });
+    expect(result.runtimeName).toBeNull();
+  });
+
+  it("rejects empty key", () => {
+    expect(() => agentSkillEntrySchema.parse({ ...validEntry, key: "" })).toThrow();
+  });
+
+  it("accepts optional origin", () => {
+    const result = agentSkillEntrySchema.parse({
+      ...validEntry,
+      origin: "company_managed",
+    });
+    expect(result.origin).toBe("company_managed");
+  });
+});
+
+describe("agentSkillSnapshotSchema", () => {
+  it("parses a valid snapshot", () => {
+    const result = agentSkillSnapshotSchema.parse({
+      adapterType: "claude_local",
+      supported: true,
+      mode: "persistent",
+      desiredSkills: ["skill-a"],
+      entries: [],
+      warnings: [],
+    });
+    expect(result.adapterType).toBe("claude_local");
+    expect(result.supported).toBe(true);
+    expect(result.entries).toEqual([]);
+  });
+
+  it("rejects empty adapterType", () => {
+    expect(() =>
+      agentSkillSnapshotSchema.parse({
+        adapterType: "",
+        supported: true,
+        mode: "persistent",
+        desiredSkills: [],
+        entries: [],
+        warnings: [],
+      })
+    ).toThrow();
+  });
+
+  it("rejects invalid sync mode", () => {
+    expect(() =>
+      agentSkillSnapshotSchema.parse({
+        adapterType: "claude_local",
+        supported: true,
+        mode: "manual",
+        desiredSkills: [],
+        entries: [],
+        warnings: [],
+      })
+    ).toThrow();
+  });
+});
+
+describe("agentSkillSyncSchema", () => {
+  it("parses a sync request", () => {
+    const result = agentSkillSyncSchema.parse({ desiredSkills: ["skill-a", "skill-b"] });
+    expect(result.desiredSkills).toEqual(["skill-a", "skill-b"]);
+  });
+
+  it("accepts empty desiredSkills array", () => {
+    const result = agentSkillSyncSchema.parse({ desiredSkills: [] });
+    expect(result.desiredSkills).toEqual([]);
+  });
+
+  it("rejects desiredSkills with empty strings", () => {
+    expect(() =>
+      agentSkillSyncSchema.parse({ desiredSkills: [""] })
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/validators/final-validators.test.ts
+++ b/packages/shared/src/validators/final-validators.test.ts
@@ -1,0 +1,556 @@
+import { describe, it, expect } from "vitest";
+
+// ---------------------------------------------------------------------------
+// agent.ts
+// ---------------------------------------------------------------------------
+import {
+  agentPermissionsSchema,
+  updateAgentInstructionsBundleSchema,
+  upsertAgentInstructionsFileSchema,
+  createAgentSchema,
+  updateAgentSchema,
+  createAgentKeySchema,
+  agentMineInboxQuerySchema,
+  wakeAgentSchema,
+  resetAgentSessionSchema,
+  updateAgentPermissionsSchema,
+} from "./agent.js";
+
+// ---------------------------------------------------------------------------
+// work-product.ts
+// ---------------------------------------------------------------------------
+import {
+  createIssueWorkProductSchema,
+  updateIssueWorkProductSchema,
+} from "./work-product.js";
+
+// ---------------------------------------------------------------------------
+// goal.ts — re-exported from index or direct
+// ---------------------------------------------------------------------------
+import { createGoalSchema, updateGoalSchema } from "./goal.js";
+
+// ---------------------------------------------------------------------------
+// asset.ts
+// ---------------------------------------------------------------------------
+import { createAssetImageMetadataSchema } from "./asset.js";
+
+// ---------------------------------------------------------------------------
+// instance.ts
+// ---------------------------------------------------------------------------
+import {
+  backupRetentionPolicySchema,
+  instanceGeneralSettingsSchema,
+  patchInstanceGeneralSettingsSchema,
+  instanceExperimentalSettingsSchema,
+  patchInstanceExperimentalSettingsSchema,
+} from "./instance.js";
+
+// ============================================================================
+// agent.ts — agentPermissionsSchema
+// ============================================================================
+
+describe("agentPermissionsSchema", () => {
+  it("defaults canCreateAgents to false", () => {
+    const result = agentPermissionsSchema.parse({});
+    expect(result.canCreateAgents).toBe(false);
+  });
+
+  it("accepts canCreateAgents=true", () => {
+    const result = agentPermissionsSchema.parse({ canCreateAgents: true });
+    expect(result.canCreateAgents).toBe(true);
+  });
+});
+
+// ============================================================================
+// agent.ts — updateAgentInstructionsBundleSchema
+// ============================================================================
+
+describe("updateAgentInstructionsBundleSchema", () => {
+  it("defaults clearLegacyPromptTemplate to false", () => {
+    const result = updateAgentInstructionsBundleSchema.parse({});
+    expect(result.clearLegacyPromptTemplate).toBe(false);
+  });
+
+  it("accepts mode 'managed'", () => {
+    const result = updateAgentInstructionsBundleSchema.parse({ mode: "managed" });
+    expect(result.mode).toBe("managed");
+  });
+
+  it("accepts mode 'external'", () => {
+    const result = updateAgentInstructionsBundleSchema.parse({ mode: "external" });
+    expect(result.mode).toBe("external");
+  });
+
+  it("rejects invalid mode", () => {
+    expect(() =>
+      updateAgentInstructionsBundleSchema.parse({ mode: "inline" })
+    ).toThrow();
+  });
+
+  it("rejects empty rootPath", () => {
+    expect(() =>
+      updateAgentInstructionsBundleSchema.parse({ rootPath: "" })
+    ).toThrow();
+  });
+
+  it("accepts null rootPath", () => {
+    const result = updateAgentInstructionsBundleSchema.parse({ rootPath: null });
+    expect(result.rootPath).toBeNull();
+  });
+});
+
+// ============================================================================
+// agent.ts — upsertAgentInstructionsFileSchema
+// ============================================================================
+
+describe("upsertAgentInstructionsFileSchema", () => {
+  it("parses a valid file upsert", () => {
+    const result = upsertAgentInstructionsFileSchema.parse({
+      path: "CLAUDE.md",
+      content: "# Agent Instructions",
+    });
+    expect(result.path).toBe("CLAUDE.md");
+    expect(result.content).toBe("# Agent Instructions");
+  });
+
+  it("rejects empty path", () => {
+    expect(() =>
+      upsertAgentInstructionsFileSchema.parse({ path: "", content: "x" })
+    ).toThrow();
+  });
+
+  it("defaults clearLegacyPromptTemplate to false", () => {
+    const result = upsertAgentInstructionsFileSchema.parse({
+      path: "p",
+      content: "c",
+    });
+    expect(result.clearLegacyPromptTemplate).toBe(false);
+  });
+});
+
+// ============================================================================
+// agent.ts — createAgentSchema
+// ============================================================================
+
+describe("createAgentSchema", () => {
+  it("parses a minimal agent (name required)", () => {
+    const result = createAgentSchema.parse({
+      name: "MyAgent",
+      adapterType: "claude_local",
+    });
+    expect(result.name).toBe("MyAgent");
+    expect(result.role).toBe("general");
+    expect(result.budgetMonthlyCents).toBe(0);
+  });
+
+  it("rejects empty name", () => {
+    expect(() =>
+      createAgentSchema.parse({ name: "", adapterType: "claude_local" })
+    ).toThrow();
+  });
+
+  it("defaults adapterConfig to empty object", () => {
+    const result = createAgentSchema.parse({
+      name: "a",
+      adapterType: "claude_local",
+    });
+    expect(result.adapterConfig).toEqual({});
+  });
+
+  it("rejects negative budgetMonthlyCents", () => {
+    expect(() =>
+      createAgentSchema.parse({ name: "a", adapterType: "claude_local", budgetMonthlyCents: -1 })
+    ).toThrow();
+  });
+
+  it("accepts adapterConfig with valid env bindings", () => {
+    const result = createAgentSchema.parse({
+      name: "a",
+      adapterType: "claude_local",
+      adapterConfig: { env: { FOO: "bar" } },
+    });
+    expect(result.adapterConfig.env).toEqual({ FOO: "bar" });
+  });
+
+  it("rejects adapterConfig with invalid env bindings", () => {
+    expect(() =>
+      createAgentSchema.parse({
+        name: "a",
+        adapterType: "claude_local",
+        adapterConfig: { env: { FOO: 123 } },
+      })
+    ).toThrow(/env must be a map of valid env bindings/i);
+  });
+});
+
+// ============================================================================
+// agent.ts — updateAgentSchema
+// ============================================================================
+
+describe("updateAgentSchema", () => {
+  it("parses an empty object (all partial)", () => {
+    const result = updateAgentSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts partial updates", () => {
+    const result = updateAgentSchema.parse({ name: "New Name" });
+    expect(result.name).toBe("New Name");
+  });
+
+  it("accepts replaceAdapterConfig flag", () => {
+    const result = updateAgentSchema.parse({ replaceAdapterConfig: true });
+    expect(result.replaceAdapterConfig).toBe(true);
+  });
+});
+
+// ============================================================================
+// agent.ts — createAgentKeySchema
+// ============================================================================
+
+describe("createAgentKeySchema", () => {
+  it("defaults name to 'default'", () => {
+    const result = createAgentKeySchema.parse({});
+    expect(result.name).toBe("default");
+  });
+
+  it("accepts a custom name", () => {
+    const result = createAgentKeySchema.parse({ name: "prod" });
+    expect(result.name).toBe("prod");
+  });
+});
+
+// ============================================================================
+// agent.ts — agentMineInboxQuerySchema
+// ============================================================================
+
+describe("agentMineInboxQuerySchema", () => {
+  it("parses with required userId", () => {
+    const result = agentMineInboxQuerySchema.parse({ userId: "user-123" });
+    expect(result.userId).toBe("user-123");
+  });
+
+  it("rejects empty userId", () => {
+    expect(() => agentMineInboxQuerySchema.parse({ userId: "" })).toThrow();
+  });
+
+  it("has a default status", () => {
+    const result = agentMineInboxQuerySchema.parse({ userId: "u" });
+    expect(typeof result.status).toBe("string");
+    expect(result.status.length).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================================
+// agent.ts — wakeAgentSchema
+// ============================================================================
+
+describe("wakeAgentSchema", () => {
+  it("defaults source to 'on_demand'", () => {
+    const result = wakeAgentSchema.parse({});
+    expect(result.source).toBe("on_demand");
+  });
+
+  it("defaults forceFreshSession to false", () => {
+    const result = wakeAgentSchema.parse({});
+    expect(result.forceFreshSession).toBe(false);
+  });
+
+  it("coerces null forceFreshSession to undefined (then defaults false)", () => {
+    const result = wakeAgentSchema.parse({ forceFreshSession: null });
+    expect(result.forceFreshSession).toBe(false);
+  });
+
+  it("accepts source 'timer'", () => {
+    const result = wakeAgentSchema.parse({ source: "timer" });
+    expect(result.source).toBe("timer");
+  });
+
+  it("rejects invalid source", () => {
+    expect(() => wakeAgentSchema.parse({ source: "push" })).toThrow();
+  });
+
+  it("accepts a reason string", () => {
+    const result = wakeAgentSchema.parse({ reason: "scheduled run" });
+    expect(result.reason).toBe("scheduled run");
+  });
+});
+
+// ============================================================================
+// agent.ts — resetAgentSessionSchema
+// ============================================================================
+
+describe("resetAgentSessionSchema", () => {
+  it("parses empty object", () => {
+    const result = resetAgentSessionSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts optional taskKey", () => {
+    const result = resetAgentSessionSchema.parse({ taskKey: "my-task" });
+    expect(result.taskKey).toBe("my-task");
+  });
+});
+
+// ============================================================================
+// agent.ts — updateAgentPermissionsSchema
+// ============================================================================
+
+describe("updateAgentPermissionsSchema", () => {
+  it("parses both required fields", () => {
+    const result = updateAgentPermissionsSchema.parse({
+      canCreateAgents: true,
+      canAssignTasks: false,
+    });
+    expect(result.canCreateAgents).toBe(true);
+    expect(result.canAssignTasks).toBe(false);
+  });
+
+  it("rejects missing canAssignTasks", () => {
+    expect(() =>
+      updateAgentPermissionsSchema.parse({ canCreateAgents: true })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// work-product.ts
+// ============================================================================
+
+describe("createIssueWorkProductSchema", () => {
+  const validBase = {
+    type: "pull_request",
+    provider: "github",
+    title: "My PR",
+  };
+
+  it("parses a valid work product", () => {
+    const result = createIssueWorkProductSchema.parse(validBase);
+    expect(result.type).toBe("pull_request");
+    expect(result.status).toBe("active");
+    expect(result.reviewState).toBe("none");
+    expect(result.isPrimary).toBe(false);
+    expect(result.healthStatus).toBe("unknown");
+  });
+
+  it("rejects invalid type", () => {
+    expect(() =>
+      createIssueWorkProductSchema.parse({ ...validBase, type: "ticket" })
+    ).toThrow();
+  });
+
+  it("rejects empty provider", () => {
+    expect(() =>
+      createIssueWorkProductSchema.parse({ ...validBase, provider: "" })
+    ).toThrow();
+  });
+
+  it("rejects empty title", () => {
+    expect(() =>
+      createIssueWorkProductSchema.parse({ ...validBase, title: "" })
+    ).toThrow();
+  });
+
+  it("accepts a valid URL", () => {
+    const result = createIssueWorkProductSchema.parse({
+      ...validBase,
+      url: "https://github.com/acme/repo/pull/1",
+    });
+    expect(result.url).toBe("https://github.com/acme/repo/pull/1");
+  });
+
+  it("rejects an invalid URL", () => {
+    expect(() =>
+      createIssueWorkProductSchema.parse({ ...validBase, url: "not-a-url" })
+    ).toThrow();
+  });
+
+  it("accepts reviewState 'approved'", () => {
+    const result = createIssueWorkProductSchema.parse({
+      ...validBase,
+      reviewState: "approved",
+    });
+    expect(result.reviewState).toBe("approved");
+  });
+});
+
+describe("updateIssueWorkProductSchema", () => {
+  it("parses an empty object (all partial)", () => {
+    const result = updateIssueWorkProductSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts partial updates", () => {
+    const result = updateIssueWorkProductSchema.parse({ status: "merged" });
+    expect(result.status).toBe("merged");
+  });
+});
+
+// ============================================================================
+// goal.ts
+// ============================================================================
+
+describe("createGoalSchema", () => {
+  it("parses a minimal goal", () => {
+    const result = createGoalSchema.parse({ title: "Q1 OKRs" });
+    expect(result.title).toBe("Q1 OKRs");
+    expect(result.level).toBe("task");
+    expect(result.status).toBe("planned");
+  });
+
+  it("rejects empty title", () => {
+    expect(() => createGoalSchema.parse({ title: "" })).toThrow();
+  });
+
+  it("accepts a valid level", () => {
+    const result = createGoalSchema.parse({ title: "t", level: "team" });
+    expect(result.level).toBe("team");
+  });
+
+  it("rejects invalid level", () => {
+    expect(() => createGoalSchema.parse({ title: "t", level: "epic" })).toThrow();
+  });
+
+  it("accepts optional parentId UUID", () => {
+    const id = "00000000-0000-0000-0000-000000000007";
+    const result = createGoalSchema.parse({ title: "t", parentId: id });
+    expect(result.parentId).toBe(id);
+  });
+
+  it("rejects non-UUID parentId", () => {
+    expect(() => createGoalSchema.parse({ title: "t", parentId: "bad" })).toThrow();
+  });
+});
+
+describe("updateGoalSchema", () => {
+  it("parses an empty object", () => {
+    const result = updateGoalSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts status update", () => {
+    const result = updateGoalSchema.parse({ status: "achieved" });
+    expect(result.status).toBe("achieved");
+  });
+});
+
+// ============================================================================
+// asset.ts
+// ============================================================================
+
+describe("createAssetImageMetadataSchema", () => {
+  it("parses empty object (namespace optional)", () => {
+    const result = createAssetImageMetadataSchema.parse({});
+    expect(result.namespace).toBeUndefined();
+  });
+
+  it("accepts a valid namespace", () => {
+    const result = createAssetImageMetadataSchema.parse({ namespace: "company/logos" });
+    expect(result.namespace).toBe("company/logos");
+  });
+
+  it("rejects namespaces with invalid characters", () => {
+    expect(() =>
+      createAssetImageMetadataSchema.parse({ namespace: "company logos" })
+    ).toThrow();
+    expect(() =>
+      createAssetImageMetadataSchema.parse({ namespace: "co!logo" })
+    ).toThrow();
+  });
+
+  it("rejects empty namespace", () => {
+    expect(() =>
+      createAssetImageMetadataSchema.parse({ namespace: "" })
+    ).toThrow();
+  });
+
+  it("rejects namespace over 120 chars", () => {
+    expect(() =>
+      createAssetImageMetadataSchema.parse({ namespace: "a".repeat(121) })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// instance.ts
+// ============================================================================
+
+describe("backupRetentionPolicySchema", () => {
+  it("parses with defaults", () => {
+    const result = backupRetentionPolicySchema.parse({});
+    expect(typeof result.dailyDays).toBe("number");
+    expect(typeof result.weeklyWeeks).toBe("number");
+    expect(typeof result.monthlyMonths).toBe("number");
+  });
+
+  it("rejects arbitrary numbers that are not in presets", () => {
+    // 3 is actually a valid dailyDays preset; use a clearly invalid one
+    expect(() =>
+      backupRetentionPolicySchema.parse({ dailyDays: 5 })
+    ).toThrow(/dailyDays/);
+  });
+});
+
+describe("instanceGeneralSettingsSchema", () => {
+  it("parses with defaults", () => {
+    const result = instanceGeneralSettingsSchema.parse({});
+    expect(result.censorUsernameInLogs).toBe(false);
+    expect(result.keyboardShortcuts).toBe(false);
+  });
+
+  it("accepts censorUsernameInLogs=true", () => {
+    const result = instanceGeneralSettingsSchema.parse({ censorUsernameInLogs: true });
+    expect(result.censorUsernameInLogs).toBe(true);
+  });
+
+  it("rejects unknown fields (strict)", () => {
+    expect(() =>
+      instanceGeneralSettingsSchema.parse({ unknownField: true })
+    ).toThrow();
+  });
+});
+
+describe("patchInstanceGeneralSettingsSchema", () => {
+  it("parses empty object", () => {
+    const result = patchInstanceGeneralSettingsSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts partial updates", () => {
+    const result = patchInstanceGeneralSettingsSchema.parse({ keyboardShortcuts: true });
+    expect(result.keyboardShortcuts).toBe(true);
+  });
+});
+
+describe("instanceExperimentalSettingsSchema", () => {
+  it("defaults both flags to false", () => {
+    const result = instanceExperimentalSettingsSchema.parse({});
+    expect(result.enableIsolatedWorkspaces).toBe(false);
+    expect(result.autoRestartDevServerWhenIdle).toBe(false);
+  });
+
+  it("accepts enableIsolatedWorkspaces=true", () => {
+    const result = instanceExperimentalSettingsSchema.parse({ enableIsolatedWorkspaces: true });
+    expect(result.enableIsolatedWorkspaces).toBe(true);
+  });
+
+  it("rejects unknown fields (strict)", () => {
+    expect(() =>
+      instanceExperimentalSettingsSchema.parse({ someNewFlag: true })
+    ).toThrow();
+  });
+});
+
+describe("patchInstanceExperimentalSettingsSchema", () => {
+  it("parses empty object", () => {
+    const result = patchInstanceExperimentalSettingsSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts one flag at a time", () => {
+    const result = patchInstanceExperimentalSettingsSchema.parse({
+      autoRestartDevServerWhenIdle: true,
+    });
+    expect(result.autoRestartDevServerWhenIdle).toBe(true);
+  });
+});

--- a/packages/shared/src/validators/issue-validators.test.ts
+++ b/packages/shared/src/validators/issue-validators.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect } from "vitest";
+import {
+  issueExecutionStagePrincipalSchema,
+  issueExecutionStageParticipantSchema,
+  issueExecutionStageSchema,
+  issueExecutionPolicySchema,
+  createIssueSchema,
+  createIssueLabelSchema,
+  checkoutIssueSchema,
+  addIssueCommentSchema,
+  issueDocumentKeySchema,
+  upsertIssueDocumentSchema,
+} from "./issue.js";
+
+// ============================================================================
+// issueExecutionStagePrincipalSchema — cross-field superRefine
+// ============================================================================
+
+describe("issueExecutionStagePrincipalSchema", () => {
+  const agentId = "00000000-0000-0000-0000-000000000001";
+
+  it("parses a valid agent principal", () => {
+    const result = issueExecutionStagePrincipalSchema.parse({ type: "agent", agentId });
+    expect(result.type).toBe("agent");
+    expect(result.agentId).toBe(agentId);
+  });
+
+  it("rejects an agent principal without agentId", () => {
+    expect(() =>
+      issueExecutionStagePrincipalSchema.parse({ type: "agent" })
+    ).toThrow(/agentId/i);
+  });
+
+  it("rejects an agent principal that has userId", () => {
+    expect(() =>
+      issueExecutionStagePrincipalSchema.parse({ type: "agent", agentId, userId: "user-1" })
+    ).toThrow(/userId/i);
+  });
+
+  it("parses a valid user principal", () => {
+    const result = issueExecutionStagePrincipalSchema.parse({ type: "user", userId: "user-1" });
+    expect(result.type).toBe("user");
+    expect(result.userId).toBe("user-1");
+  });
+
+  it("rejects a user principal without userId", () => {
+    expect(() =>
+      issueExecutionStagePrincipalSchema.parse({ type: "user" })
+    ).toThrow(/userId/i);
+  });
+
+  it("rejects a user principal that has agentId", () => {
+    expect(() =>
+      issueExecutionStagePrincipalSchema.parse({ type: "user", userId: "u", agentId })
+    ).toThrow(/agentId/i);
+  });
+});
+
+// ============================================================================
+// issueExecutionStageParticipantSchema
+// ============================================================================
+
+describe("issueExecutionStageParticipantSchema", () => {
+  const agentId = "00000000-0000-0000-0000-000000000002";
+
+  it("parses a valid agent participant", () => {
+    const result = issueExecutionStageParticipantSchema.parse({ type: "agent", agentId });
+    expect(result.type).toBe("agent");
+  });
+
+  it("accepts an optional participant id", () => {
+    const id = "00000000-0000-0000-0000-000000000003";
+    const result = issueExecutionStageParticipantSchema.parse({ type: "agent", agentId, id });
+    expect(result.id).toBe(id);
+  });
+
+  it("rejects agent participant without agentId", () => {
+    expect(() =>
+      issueExecutionStageParticipantSchema.parse({ type: "agent" })
+    ).toThrow(/agentId/i);
+  });
+});
+
+// ============================================================================
+// issueExecutionStageSchema
+// ============================================================================
+
+describe("issueExecutionStageSchema", () => {
+  it("parses a stage with defaults", () => {
+    const result = issueExecutionStageSchema.parse({ type: "review" });
+    expect(result.approvalsNeeded).toBe(1);
+    expect(result.participants).toEqual([]);
+  });
+
+  it("rejects invalid stage type", () => {
+    expect(() => issueExecutionStageSchema.parse({ type: "approve" })).toThrow();
+  });
+
+  it("accepts participants array", () => {
+    const agentId = "00000000-0000-0000-0000-000000000004";
+    const result = issueExecutionStageSchema.parse({
+      type: "review",
+      participants: [{ type: "agent", agentId }],
+    });
+    expect(result.participants).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// issueExecutionPolicySchema
+// ============================================================================
+
+describe("issueExecutionPolicySchema", () => {
+  it("parses with defaults", () => {
+    const result = issueExecutionPolicySchema.parse({});
+    expect(result.mode).toBe("normal");
+    expect(result.commentRequired).toBe(true);
+    expect(result.stages).toEqual([]);
+  });
+
+  it("accepts custom mode", () => {
+    const result = issueExecutionPolicySchema.parse({ mode: "auto" });
+    expect(result.mode).toBe("auto");
+  });
+
+  it("rejects invalid mode", () => {
+    expect(() => issueExecutionPolicySchema.parse({ mode: "manual" })).toThrow();
+  });
+});
+
+// ============================================================================
+// createIssueSchema
+// ============================================================================
+
+describe("createIssueSchema", () => {
+  it("parses a minimal issue", () => {
+    const result = createIssueSchema.parse({ title: "Fix login bug" });
+    expect(result.title).toBe("Fix login bug");
+    expect(result.status).toBe("backlog");
+    expect(result.priority).toBe("medium");
+    expect(result.requestDepth).toBe(0);
+  });
+
+  it("rejects empty title", () => {
+    expect(() => createIssueSchema.parse({ title: "" })).toThrow();
+  });
+
+  it("accepts valid status", () => {
+    const result = createIssueSchema.parse({ title: "t", status: "in_progress" });
+    expect(result.status).toBe("in_progress");
+  });
+
+  it("rejects invalid status", () => {
+    expect(() => createIssueSchema.parse({ title: "t", status: "deleted" })).toThrow();
+  });
+
+  it("accepts valid priority", () => {
+    const result = createIssueSchema.parse({ title: "t", priority: "critical" });
+    expect(result.priority).toBe("critical");
+  });
+
+  it("rejects non-UUID assigneeAgentId", () => {
+    expect(() =>
+      createIssueSchema.parse({ title: "t", assigneeAgentId: "not-uuid" })
+    ).toThrow();
+  });
+
+  it("accepts optional labelIds array of UUIDs", () => {
+    const id = "00000000-0000-0000-0000-000000000005";
+    const result = createIssueSchema.parse({ title: "t", labelIds: [id] });
+    expect(result.labelIds).toEqual([id]);
+  });
+});
+
+// ============================================================================
+// createIssueLabelSchema
+// ============================================================================
+
+describe("createIssueLabelSchema", () => {
+  it("parses a valid label", () => {
+    const result = createIssueLabelSchema.parse({ name: "bug", color: "#ff0000" });
+    expect(result.name).toBe("bug");
+    expect(result.color).toBe("#ff0000");
+  });
+
+  it("rejects empty name", () => {
+    expect(() => createIssueLabelSchema.parse({ name: "", color: "#000000" })).toThrow();
+  });
+
+  it("rejects name over 48 chars", () => {
+    expect(() =>
+      createIssueLabelSchema.parse({ name: "a".repeat(49), color: "#000000" })
+    ).toThrow();
+  });
+
+  it("rejects invalid hex color", () => {
+    expect(() => createIssueLabelSchema.parse({ name: "bug", color: "red" })).toThrow();
+    expect(() => createIssueLabelSchema.parse({ name: "bug", color: "#fff" })).toThrow();
+    expect(() => createIssueLabelSchema.parse({ name: "bug", color: "#gggggg" })).toThrow();
+  });
+
+  it("accepts 6-digit hex with uppercase", () => {
+    const result = createIssueLabelSchema.parse({ name: "bug", color: "#AABBCC" });
+    expect(result.color).toBe("#AABBCC");
+  });
+
+  it("trims whitespace from name", () => {
+    const result = createIssueLabelSchema.parse({ name: "  bug  ", color: "#ff0000" });
+    expect(result.name).toBe("bug");
+  });
+});
+
+// ============================================================================
+// checkoutIssueSchema
+// ============================================================================
+
+describe("checkoutIssueSchema", () => {
+  const agentId = "00000000-0000-0000-0000-000000000006";
+
+  it("parses a valid checkout", () => {
+    const result = checkoutIssueSchema.parse({
+      agentId,
+      expectedStatuses: ["backlog", "in_progress"],
+    });
+    expect(result.agentId).toBe(agentId);
+    expect(result.expectedStatuses).toHaveLength(2);
+  });
+
+  it("rejects empty expectedStatuses array", () => {
+    expect(() =>
+      checkoutIssueSchema.parse({ agentId, expectedStatuses: [] })
+    ).toThrow();
+  });
+
+  it("rejects invalid agentId", () => {
+    expect(() =>
+      checkoutIssueSchema.parse({ agentId: "bad", expectedStatuses: ["backlog"] })
+    ).toThrow();
+  });
+
+  it("rejects invalid status values", () => {
+    expect(() =>
+      checkoutIssueSchema.parse({ agentId, expectedStatuses: ["deleted"] })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// addIssueCommentSchema
+// ============================================================================
+
+describe("addIssueCommentSchema", () => {
+  it("parses a minimal comment", () => {
+    const result = addIssueCommentSchema.parse({ body: "Looks good!" });
+    expect(result.body).toBe("Looks good!");
+  });
+
+  it("rejects empty body", () => {
+    expect(() => addIssueCommentSchema.parse({ body: "" })).toThrow();
+  });
+
+  it("accepts optional reopen and interrupt flags", () => {
+    const result = addIssueCommentSchema.parse({ body: "done", reopen: true, interrupt: false });
+    expect(result.reopen).toBe(true);
+    expect(result.interrupt).toBe(false);
+  });
+});
+
+// ============================================================================
+// issueDocumentKeySchema
+// ============================================================================
+
+describe("issueDocumentKeySchema", () => {
+  it("accepts a valid lowercase key", () => {
+    const result = issueDocumentKeySchema.parse("my-doc_v2");
+    expect(result).toBe("my-doc_v2");
+  });
+
+  it("trims whitespace", () => {
+    const result = issueDocumentKeySchema.parse("  doc  ");
+    expect(result).toBe("doc");
+  });
+
+  it("rejects keys starting with a dash", () => {
+    expect(() => issueDocumentKeySchema.parse("-bad")).toThrow();
+  });
+
+  it("rejects keys with uppercase letters", () => {
+    expect(() => issueDocumentKeySchema.parse("MyDoc")).toThrow();
+  });
+
+  it("rejects keys with spaces", () => {
+    expect(() => issueDocumentKeySchema.parse("my doc")).toThrow();
+  });
+
+  it("rejects empty key", () => {
+    expect(() => issueDocumentKeySchema.parse("")).toThrow();
+  });
+
+  it("rejects keys over 64 chars", () => {
+    expect(() => issueDocumentKeySchema.parse("a".repeat(65))).toThrow();
+  });
+});
+
+// ============================================================================
+// upsertIssueDocumentSchema
+// ============================================================================
+
+describe("upsertIssueDocumentSchema", () => {
+  it("parses a valid document upsert", () => {
+    const result = upsertIssueDocumentSchema.parse({
+      format: "markdown",
+      body: "# Hello",
+    });
+    expect(result.format).toBe("markdown");
+    expect(result.body).toBe("# Hello");
+  });
+
+  it("rejects invalid format", () => {
+    expect(() =>
+      upsertIssueDocumentSchema.parse({ format: "html", body: "<h1>x</h1>" })
+    ).toThrow();
+  });
+
+  it("rejects body over 524288 chars", () => {
+    expect(() =>
+      upsertIssueDocumentSchema.parse({ format: "markdown", body: "x".repeat(524289) })
+    ).toThrow();
+  });
+
+  it("accepts an optional changeSummary", () => {
+    const result = upsertIssueDocumentSchema.parse({
+      format: "markdown",
+      body: "content",
+      changeSummary: "Added intro",
+    });
+    expect(result.changeSummary).toBe("Added intro");
+  });
+
+  it("rejects changeSummary over 500 chars", () => {
+    expect(() =>
+      upsertIssueDocumentSchema.parse({
+        format: "markdown",
+        body: "content",
+        changeSummary: "x".repeat(501),
+      })
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/validators/more-validators.test.ts
+++ b/packages/shared/src/validators/more-validators.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect } from "vitest";
+
+// ---------------------------------------------------------------------------
+// routine.ts
+// ---------------------------------------------------------------------------
+import {
+  routineVariableSchema,
+  createRoutineSchema,
+  createRoutineTriggerSchema,
+  updateRoutineTriggerSchema,
+  runRoutineSchema,
+} from "./routine.js";
+
+// ---------------------------------------------------------------------------
+// company.ts
+// ---------------------------------------------------------------------------
+import {
+  createCompanySchema,
+  updateCompanySchema,
+  updateCompanyBrandingSchema,
+} from "./company.js";
+
+// ---------------------------------------------------------------------------
+// project.ts
+// ---------------------------------------------------------------------------
+import {
+  createProjectWorkspaceSchema,
+  updateProjectWorkspaceSchema,
+  projectExecutionWorkspacePolicySchema,
+  createProjectSchema,
+  updateProjectSchema,
+} from "./project.js";
+
+// ============================================================================
+// routine.ts — routineVariableSchema
+// ============================================================================
+
+describe("routineVariableSchema", () => {
+  it("parses a basic text variable", () => {
+    const result = routineVariableSchema.parse({ name: "myVar" });
+    expect(result.name).toBe("myVar");
+    expect(result.type).toBe("text");
+    expect(result.required).toBe(true);
+    expect(result.options).toEqual([]);
+  });
+
+  it("rejects names that don't start with a letter", () => {
+    expect(() => routineVariableSchema.parse({ name: "1bad" })).toThrow();
+    expect(() => routineVariableSchema.parse({ name: "_bad" })).toThrow();
+  });
+
+  it("accepts names with letters, digits, and underscores after the first character", () => {
+    const result = routineVariableSchema.parse({ name: "my_Var2" });
+    expect(result.name).toBe("my_Var2");
+  });
+
+  it("rejects a select variable with no options", () => {
+    expect(() =>
+      routineVariableSchema.parse({ name: "x", type: "select", options: [] })
+    ).toThrow(/at least one option/i);
+  });
+
+  it("parses a valid select variable with options", () => {
+    const result = routineVariableSchema.parse({
+      name: "x",
+      type: "select",
+      options: ["a", "b"],
+    });
+    expect(result.options).toEqual(["a", "b"]);
+  });
+
+  it("rejects options on a non-select variable", () => {
+    expect(() =>
+      routineVariableSchema.parse({ name: "x", type: "text", options: ["a"] })
+    ).toThrow(/Only select variables/i);
+  });
+
+  it("rejects a select defaultValue not in options", () => {
+    expect(() =>
+      routineVariableSchema.parse({
+        name: "x",
+        type: "select",
+        options: ["a", "b"],
+        defaultValue: "c",
+      })
+    ).toThrow(/match one of the allowed options/i);
+  });
+
+  it("accepts a select defaultValue that is in options", () => {
+    const result = routineVariableSchema.parse({
+      name: "x",
+      type: "select",
+      options: ["a", "b"],
+      defaultValue: "a",
+    });
+    expect(result.defaultValue).toBe("a");
+  });
+
+  it("accepts a numeric defaultValue for text variables", () => {
+    const result = routineVariableSchema.parse({ name: "x", defaultValue: 42 });
+    expect(result.defaultValue).toBe(42);
+  });
+
+  it("accepts label with max 120 chars", () => {
+    const result = routineVariableSchema.parse({ name: "x", label: "a".repeat(120) });
+    expect(result.label).toHaveLength(120);
+  });
+
+  it("rejects label over 120 chars", () => {
+    expect(() => routineVariableSchema.parse({ name: "x", label: "a".repeat(121) })).toThrow();
+  });
+});
+
+// ============================================================================
+// routine.ts — createRoutineSchema
+// ============================================================================
+
+describe("createRoutineSchema", () => {
+  it("parses a minimal routine", () => {
+    const result = createRoutineSchema.parse({ title: "Daily Sync" });
+    expect(result.title).toBe("Daily Sync");
+    expect(result.priority).toBe("medium");
+    expect(result.status).toBe("active");
+    expect(result.concurrencyPolicy).toBe("coalesce_if_active");
+    expect(result.catchUpPolicy).toBe("skip_missed");
+    expect(result.variables).toEqual([]);
+  });
+
+  it("rejects empty title", () => {
+    expect(() => createRoutineSchema.parse({ title: "" })).toThrow();
+  });
+
+  it("rejects title over 200 chars", () => {
+    expect(() => createRoutineSchema.parse({ title: "x".repeat(201) })).toThrow();
+  });
+
+  it("accepts variables array", () => {
+    const result = createRoutineSchema.parse({
+      title: "t",
+      variables: [{ name: "myVar" }],
+    });
+    expect(result.variables).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// routine.ts — createRoutineTriggerSchema
+// ============================================================================
+
+describe("createRoutineTriggerSchema", () => {
+  it("parses a schedule trigger", () => {
+    const result = createRoutineTriggerSchema.parse({
+      kind: "schedule",
+      cronExpression: "0 9 * * 1-5",
+    });
+    expect(result.kind).toBe("schedule");
+    if (result.kind === "schedule") {
+      expect(result.timezone).toBe("UTC");
+    }
+  });
+
+  it("parses a webhook trigger with defaults", () => {
+    const result = createRoutineTriggerSchema.parse({ kind: "webhook" });
+    expect(result.kind).toBe("webhook");
+    if (result.kind === "webhook") {
+      expect(result.signingMode).toBe("bearer");
+      expect(result.replayWindowSec).toBe(300);
+    }
+  });
+
+  it("parses an api trigger", () => {
+    const result = createRoutineTriggerSchema.parse({ kind: "api" });
+    expect(result.kind).toBe("api");
+  });
+
+  it("rejects invalid kind", () => {
+    expect(() => createRoutineTriggerSchema.parse({ kind: "cron" })).toThrow();
+  });
+
+  it("rejects schedule trigger with empty cronExpression", () => {
+    expect(() =>
+      createRoutineTriggerSchema.parse({ kind: "schedule", cronExpression: "" })
+    ).toThrow();
+  });
+
+  it("defaults enabled to true", () => {
+    const result = createRoutineTriggerSchema.parse({ kind: "api" });
+    expect(result.enabled).toBe(true);
+  });
+
+  it("rejects replayWindowSec below 30", () => {
+    expect(() =>
+      createRoutineTriggerSchema.parse({ kind: "webhook", replayWindowSec: 29 })
+    ).toThrow();
+  });
+
+  it("rejects replayWindowSec above 86400", () => {
+    expect(() =>
+      createRoutineTriggerSchema.parse({ kind: "webhook", replayWindowSec: 86401 })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// routine.ts — updateRoutineTriggerSchema
+// ============================================================================
+
+describe("updateRoutineTriggerSchema", () => {
+  it("parses an empty object (all optional)", () => {
+    const result = updateRoutineTriggerSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts partial updates", () => {
+    const result = updateRoutineTriggerSchema.parse({ enabled: false });
+    expect(result.enabled).toBe(false);
+  });
+});
+
+// ============================================================================
+// routine.ts — runRoutineSchema
+// ============================================================================
+
+describe("runRoutineSchema", () => {
+  it("parses an empty object with defaults", () => {
+    const result = runRoutineSchema.parse({});
+    expect(result.source).toBe("manual");
+  });
+
+  it("accepts 'api' source", () => {
+    const result = runRoutineSchema.parse({ source: "api" });
+    expect(result.source).toBe("api");
+  });
+
+  it("accepts an idempotencyKey", () => {
+    const result = runRoutineSchema.parse({ idempotencyKey: "run-abc-123" });
+    expect(result.idempotencyKey).toBe("run-abc-123");
+  });
+
+  it("rejects idempotencyKey over 255 chars", () => {
+    expect(() => runRoutineSchema.parse({ idempotencyKey: "x".repeat(256) })).toThrow();
+  });
+});
+
+// ============================================================================
+// company.ts
+// ============================================================================
+
+describe("createCompanySchema", () => {
+  it("parses a valid company", () => {
+    const result = createCompanySchema.parse({ name: "Acme Inc" });
+    expect(result.name).toBe("Acme Inc");
+    expect(result.budgetMonthlyCents).toBe(0);
+  });
+
+  it("rejects empty name", () => {
+    expect(() => createCompanySchema.parse({ name: "" })).toThrow();
+  });
+
+  it("rejects negative budgetMonthlyCents", () => {
+    expect(() => createCompanySchema.parse({ name: "Acme", budgetMonthlyCents: -1 })).toThrow();
+  });
+
+  it("rejects fractional budgetMonthlyCents", () => {
+    expect(() => createCompanySchema.parse({ name: "Acme", budgetMonthlyCents: 1.5 })).toThrow();
+  });
+});
+
+describe("updateCompanySchema", () => {
+  it("parses an empty object (all optional)", () => {
+    const result = updateCompanySchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts partial updates", () => {
+    const result = updateCompanySchema.parse({ name: "New Name" });
+    expect(result.name).toBe("New Name");
+  });
+
+  it("accepts a valid brandColor", () => {
+    const result = updateCompanySchema.parse({ brandColor: "#a1b2c3" });
+    expect(result.brandColor).toBe("#a1b2c3");
+  });
+
+  it("rejects an invalid brandColor format", () => {
+    expect(() => updateCompanySchema.parse({ brandColor: "red" })).toThrow();
+    expect(() => updateCompanySchema.parse({ brandColor: "#xyz" })).toThrow();
+  });
+
+  it("rejects negative spentMonthlyCents", () => {
+    expect(() => updateCompanySchema.parse({ spentMonthlyCents: -1 })).toThrow();
+  });
+});
+
+describe("updateCompanyBrandingSchema", () => {
+  it("parses when at least one field is provided", () => {
+    const result = updateCompanyBrandingSchema.parse({ name: "Acme" });
+    expect(result.name).toBe("Acme");
+  });
+
+  it("rejects when no field is provided", () => {
+    expect(() => updateCompanyBrandingSchema.parse({})).toThrow(/at least one/i);
+  });
+
+  it("accepts a valid brandColor", () => {
+    const result = updateCompanyBrandingSchema.parse({ brandColor: "#AABBCC" });
+    expect(result.brandColor).toBe("#AABBCC");
+  });
+
+  it("rejects an invalid brandColor", () => {
+    expect(() => updateCompanyBrandingSchema.parse({ brandColor: "#12345" })).toThrow();
+  });
+
+  it("rejects unknown fields (strict)", () => {
+    expect(() =>
+      updateCompanyBrandingSchema.parse({ name: "Acme", unknownField: "x" })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// project.ts
+// ============================================================================
+
+describe("createProjectWorkspaceSchema", () => {
+  it("parses a local_path workspace with cwd", () => {
+    const result = createProjectWorkspaceSchema.parse({ cwd: "/home/user/project" });
+    expect(result.cwd).toBe("/home/user/project");
+    expect(result.isPrimary).toBe(false);
+  });
+
+  it("parses a git_repo workspace with repoUrl", () => {
+    const result = createProjectWorkspaceSchema.parse({
+      sourceType: "git_repo",
+      repoUrl: "https://github.com/acme/repo",
+    });
+    expect(result.sourceType).toBe("git_repo");
+  });
+
+  it("rejects when neither cwd nor repoUrl is provided for local types", () => {
+    expect(() => createProjectWorkspaceSchema.parse({ name: "ws" })).toThrow(
+      /cwd or repoUrl/i,
+    );
+  });
+
+  it("parses a remote_managed workspace with remoteWorkspaceRef", () => {
+    const result = createProjectWorkspaceSchema.parse({
+      sourceType: "remote_managed",
+      remoteWorkspaceRef: "ws-ref-123",
+    });
+    expect(result.sourceType).toBe("remote_managed");
+  });
+
+  it("rejects remote_managed workspace with neither remoteWorkspaceRef nor repoUrl", () => {
+    expect(() =>
+      createProjectWorkspaceSchema.parse({ sourceType: "remote_managed" })
+    ).toThrow(/remoteWorkspaceRef or repoUrl/i);
+  });
+
+  it("defaults isPrimary to false", () => {
+    const result = createProjectWorkspaceSchema.parse({ cwd: "/tmp" });
+    expect(result.isPrimary).toBe(false);
+  });
+});
+
+describe("updateProjectWorkspaceSchema", () => {
+  it("parses an empty object (all partial)", () => {
+    const result = updateProjectWorkspaceSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts partial workspace updates", () => {
+    const result = updateProjectWorkspaceSchema.parse({ name: "new-name" });
+    expect(result.name).toBe("new-name");
+  });
+});
+
+describe("projectExecutionWorkspacePolicySchema", () => {
+  it("parses with enabled=true", () => {
+    const result = projectExecutionWorkspacePolicySchema.parse({ enabled: true });
+    expect(result.enabled).toBe(true);
+  });
+
+  it("parses a full policy object", () => {
+    const result = projectExecutionWorkspacePolicySchema.parse({
+      enabled: true,
+      defaultMode: "isolated_workspace",
+      allowIssueOverride: true,
+    });
+    expect(result.defaultMode).toBe("isolated_workspace");
+  });
+
+  it("rejects invalid defaultMode", () => {
+    expect(() =>
+      projectExecutionWorkspacePolicySchema.parse({
+        enabled: true,
+        defaultMode: "invalid_mode",
+      })
+    ).toThrow();
+  });
+
+  it("rejects unknown fields (strict)", () => {
+    expect(() =>
+      projectExecutionWorkspacePolicySchema.parse({ enabled: true, unknownField: "x" })
+    ).toThrow();
+  });
+});
+
+describe("createProjectSchema", () => {
+  it("parses a minimal project", () => {
+    const result = createProjectSchema.parse({ name: "My Project" });
+    expect(result.name).toBe("My Project");
+    expect(result.status).toBe("backlog");
+  });
+
+  it("rejects empty name", () => {
+    expect(() => createProjectSchema.parse({ name: "" })).toThrow();
+  });
+
+  it("accepts a workspace inline", () => {
+    const result = createProjectSchema.parse({
+      name: "p",
+      workspace: { cwd: "/tmp" },
+    });
+    expect(result.workspace?.cwd).toBe("/tmp");
+  });
+});
+
+describe("updateProjectSchema", () => {
+  it("parses an empty object (all partial)", () => {
+    const result = updateProjectSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts status update", () => {
+    const result = updateProjectSchema.parse({ status: "in_progress" });
+    expect(result.status).toBe("in_progress");
+  });
+
+  it("rejects invalid status", () => {
+    expect(() => updateProjectSchema.parse({ status: "deleted" })).toThrow();
+  });
+});

--- a/packages/shared/src/validators/plugin-validators.test.ts
+++ b/packages/shared/src/validators/plugin-validators.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect } from "vitest";
+import {
+  jsonSchemaSchema,
+  pluginJobDeclarationSchema,
+  pluginWebhookDeclarationSchema,
+  pluginToolDeclarationSchema,
+  pluginUiSlotDeclarationSchema,
+} from "./plugin.js";
+
+// ============================================================================
+// jsonSchemaSchema
+// ============================================================================
+
+describe("jsonSchemaSchema", () => {
+  it("accepts an empty object", () => {
+    const result = jsonSchemaSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts an object with a 'type' field", () => {
+    const result = jsonSchemaSchema.parse({ type: "object", properties: {} });
+    expect(result.type).toBe("object");
+  });
+
+  it("accepts an object with a '$ref' field", () => {
+    const result = jsonSchemaSchema.parse({ $ref: "#/definitions/Foo" });
+    expect(result.$ref).toBe("#/definitions/Foo");
+  });
+
+  it("accepts a oneOf composition", () => {
+    const result = jsonSchemaSchema.parse({ oneOf: [{ type: "string" }, { type: "number" }] });
+    expect(result.oneOf).toBeDefined();
+  });
+
+  it("accepts anyOf composition", () => {
+    const result = jsonSchemaSchema.parse({ anyOf: [{ type: "null" }] });
+    expect(result.anyOf).toBeDefined();
+  });
+
+  it("accepts allOf composition", () => {
+    const result = jsonSchemaSchema.parse({ allOf: [{ type: "object" }] });
+    expect(result.allOf).toBeDefined();
+  });
+
+  it("rejects a non-empty object missing type/$ref/composition", () => {
+    expect(() =>
+      jsonSchemaSchema.parse({ description: "just a description" })
+    ).toThrow(/valid JSON Schema/i);
+  });
+});
+
+// ============================================================================
+// pluginJobDeclarationSchema
+// ============================================================================
+
+describe("pluginJobDeclarationSchema", () => {
+  it("parses a minimal job declaration", () => {
+    const result = pluginJobDeclarationSchema.parse({
+      jobKey: "sync",
+      displayName: "Sync Job",
+    });
+    expect(result.jobKey).toBe("sync");
+    expect(result.displayName).toBe("Sync Job");
+    expect(result.schedule).toBeUndefined();
+  });
+
+  it("accepts a valid 5-field cron schedule", () => {
+    const result = pluginJobDeclarationSchema.parse({
+      jobKey: "hourly",
+      displayName: "Hourly",
+      schedule: "0 * * * *",
+    });
+    expect(result.schedule).toBe("0 * * * *");
+  });
+
+  it("accepts a step cron expression", () => {
+    const result = pluginJobDeclarationSchema.parse({
+      jobKey: "frequent",
+      displayName: "Every 15 min",
+      schedule: "*/15 * * * *",
+    });
+    expect(result.schedule).toBe("*/15 * * * *");
+  });
+
+  it("rejects a cron expression with too few fields", () => {
+    expect(() =>
+      pluginJobDeclarationSchema.parse({
+        jobKey: "k",
+        displayName: "d",
+        schedule: "* * * *",
+      })
+    ).toThrow(/5-field cron/i);
+  });
+
+  it("rejects a cron expression with too many fields", () => {
+    expect(() =>
+      pluginJobDeclarationSchema.parse({
+        jobKey: "k",
+        displayName: "d",
+        schedule: "* * * * * *",
+      })
+    ).toThrow(/5-field cron/i);
+  });
+
+  it("rejects empty jobKey", () => {
+    expect(() =>
+      pluginJobDeclarationSchema.parse({ jobKey: "", displayName: "d" })
+    ).toThrow();
+  });
+
+  it("rejects empty displayName", () => {
+    expect(() =>
+      pluginJobDeclarationSchema.parse({ jobKey: "k", displayName: "" })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// pluginWebhookDeclarationSchema
+// ============================================================================
+
+describe("pluginWebhookDeclarationSchema", () => {
+  it("parses a valid webhook declaration", () => {
+    const result = pluginWebhookDeclarationSchema.parse({
+      endpointKey: "my-hook",
+      displayName: "My Webhook",
+    });
+    expect(result.endpointKey).toBe("my-hook");
+    expect(result.displayName).toBe("My Webhook");
+  });
+
+  it("accepts optional description", () => {
+    const result = pluginWebhookDeclarationSchema.parse({
+      endpointKey: "k",
+      displayName: "d",
+      description: "handles push events",
+    });
+    expect(result.description).toBe("handles push events");
+  });
+
+  it("rejects empty endpointKey", () => {
+    expect(() =>
+      pluginWebhookDeclarationSchema.parse({ endpointKey: "", displayName: "d" })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// pluginToolDeclarationSchema
+// ============================================================================
+
+describe("pluginToolDeclarationSchema", () => {
+  const validTool = {
+    name: "search_issues",
+    displayName: "Search Issues",
+    description: "Search for issues",
+    parametersSchema: { type: "object", properties: {} },
+  };
+
+  it("parses a valid tool declaration", () => {
+    const result = pluginToolDeclarationSchema.parse(validTool);
+    expect(result.name).toBe("search_issues");
+  });
+
+  it("rejects empty name", () => {
+    expect(() =>
+      pluginToolDeclarationSchema.parse({ ...validTool, name: "" })
+    ).toThrow();
+  });
+
+  it("rejects empty description", () => {
+    expect(() =>
+      pluginToolDeclarationSchema.parse({ ...validTool, description: "" })
+    ).toThrow();
+  });
+
+  it("rejects invalid parametersSchema", () => {
+    expect(() =>
+      pluginToolDeclarationSchema.parse({ ...validTool, parametersSchema: { label: "not valid" } })
+    ).toThrow(/valid JSON Schema/i);
+  });
+
+  it("accepts empty parametersSchema ({})", () => {
+    const result = pluginToolDeclarationSchema.parse({ ...validTool, parametersSchema: {} });
+    expect(result.parametersSchema).toEqual({});
+  });
+});
+
+// ============================================================================
+// pluginUiSlotDeclarationSchema — superRefine cross-field validation
+// ============================================================================
+
+describe("pluginUiSlotDeclarationSchema", () => {
+  it("parses a page slot without entityTypes", () => {
+    const result = pluginUiSlotDeclarationSchema.parse({
+      type: "page",
+      id: "my-page",
+      displayName: "My Page",
+      exportName: "MyPage",
+    });
+    expect(result.type).toBe("page");
+  });
+
+  it("accepts a detailTab slot with entityTypes", () => {
+    const result = pluginUiSlotDeclarationSchema.parse({
+      type: "detailTab",
+      id: "issue-tab",
+      displayName: "Issue Tab",
+      exportName: "IssueTab",
+      entityTypes: ["issue"],
+    });
+    expect(result.entityTypes).toEqual(["issue"]);
+  });
+
+  it("rejects detailTab without entityTypes", () => {
+    expect(() =>
+      pluginUiSlotDeclarationSchema.parse({
+        type: "detailTab",
+        id: "tab",
+        displayName: "Tab",
+        exportName: "Tab",
+      })
+    ).toThrow(/entityType/i);
+  });
+
+  it("rejects projectSidebarItem without entityType 'project'", () => {
+    expect(() =>
+      pluginUiSlotDeclarationSchema.parse({
+        type: "projectSidebarItem",
+        id: "sidebar",
+        displayName: "Sidebar",
+        exportName: "Sidebar",
+        entityTypes: ["issue"],
+      })
+    ).toThrow(/project/i);
+  });
+
+  it("accepts projectSidebarItem with entityType 'project'", () => {
+    const result = pluginUiSlotDeclarationSchema.parse({
+      type: "projectSidebarItem",
+      id: "sidebar",
+      displayName: "Sidebar",
+      exportName: "Sidebar",
+      entityTypes: ["project"],
+    });
+    expect(result.entityTypes).toContain("project");
+  });
+
+  it("rejects commentAnnotation without entityType 'comment'", () => {
+    expect(() =>
+      pluginUiSlotDeclarationSchema.parse({
+        type: "commentAnnotation",
+        id: "ann",
+        displayName: "Annotation",
+        exportName: "Ann",
+        entityTypes: ["issue"],
+      })
+    ).toThrow(/comment/i);
+  });
+
+  it("accepts routePath as a valid lowercase slug", () => {
+    const result = pluginUiSlotDeclarationSchema.parse({
+      type: "page",
+      id: "p",
+      displayName: "Page",
+      exportName: "Page",
+      routePath: "my-route",
+    });
+    expect(result.routePath).toBe("my-route");
+  });
+
+  it("rejects routePath starting with hyphen", () => {
+    expect(() =>
+      pluginUiSlotDeclarationSchema.parse({
+        type: "page",
+        id: "p",
+        displayName: "Page",
+        exportName: "Page",
+        routePath: "-bad",
+      })
+    ).toThrow();
+  });
+
+  it("rejects routePath with uppercase letters", () => {
+    expect(() =>
+      pluginUiSlotDeclarationSchema.parse({
+        type: "page",
+        id: "p",
+        displayName: "Page",
+        exportName: "Page",
+        routePath: "MyRoute",
+      })
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/validators/portability-validators.test.ts
+++ b/packages/shared/src/validators/portability-validators.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect } from "vitest";
+import {
+  portabilityIncludeSchema,
+  portabilityEnvInputSchema,
+  portabilityFileEntrySchema,
+  portabilityCollisionStrategySchema,
+  portabilitySourceSchema,
+  portabilityTargetSchema,
+  portabilityAgentSelectionSchema,
+  companyPortabilityExportSchema,
+  companyPortabilityPreviewSchema,
+} from "./company-portability.js";
+
+// ============================================================================
+// portabilityIncludeSchema
+// ============================================================================
+
+describe("portabilityIncludeSchema", () => {
+  it("parses empty object (all optional)", () => {
+    const result = portabilityIncludeSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts all include flags", () => {
+    const result = portabilityIncludeSchema.parse({
+      company: true,
+      agents: false,
+      projects: true,
+      issues: false,
+      skills: true,
+    });
+    expect(result.company).toBe(true);
+    expect(result.agents).toBe(false);
+  });
+});
+
+// ============================================================================
+// portabilityEnvInputSchema
+// ============================================================================
+
+describe("portabilityEnvInputSchema", () => {
+  const validBase = {
+    key: "API_KEY",
+    description: "The API key",
+    agentSlug: null,
+    projectSlug: null,
+    kind: "secret",
+    requirement: "required",
+    defaultValue: null,
+    portability: "portable",
+  };
+
+  it("parses a valid env input", () => {
+    const result = portabilityEnvInputSchema.parse(validBase);
+    expect(result.key).toBe("API_KEY");
+    expect(result.kind).toBe("secret");
+  });
+
+  it("rejects empty key", () => {
+    expect(() =>
+      portabilityEnvInputSchema.parse({ ...validBase, key: "" })
+    ).toThrow();
+  });
+
+  it("rejects invalid kind", () => {
+    expect(() =>
+      portabilityEnvInputSchema.parse({ ...validBase, kind: "encrypted" })
+    ).toThrow();
+  });
+
+  it("rejects invalid portability", () => {
+    expect(() =>
+      portabilityEnvInputSchema.parse({ ...validBase, portability: "always" })
+    ).toThrow();
+  });
+
+  it("accepts 'plain' kind", () => {
+    const result = portabilityEnvInputSchema.parse({ ...validBase, kind: "plain" });
+    expect(result.kind).toBe("plain");
+  });
+
+  it("accepts 'optional' requirement", () => {
+    const result = portabilityEnvInputSchema.parse({ ...validBase, requirement: "optional" });
+    expect(result.requirement).toBe("optional");
+  });
+
+  it("accepts 'system_dependent' portability", () => {
+    const result = portabilityEnvInputSchema.parse({
+      ...validBase,
+      portability: "system_dependent",
+    });
+    expect(result.portability).toBe("system_dependent");
+  });
+});
+
+// ============================================================================
+// portabilityFileEntrySchema (union: string | base64 object)
+// ============================================================================
+
+describe("portabilityFileEntrySchema", () => {
+  it("accepts a bare string (file content)", () => {
+    const result = portabilityFileEntrySchema.parse("file content");
+    expect(result).toBe("file content");
+  });
+
+  it("accepts a base64 object", () => {
+    const result = portabilityFileEntrySchema.parse({
+      encoding: "base64",
+      data: "SGVsbG8gV29ybGQ=",
+    });
+    expect(result).toMatchObject({ encoding: "base64", data: "SGVsbG8gV29ybGQ=" });
+  });
+
+  it("accepts a base64 object with optional contentType", () => {
+    const result = portabilityFileEntrySchema.parse({
+      encoding: "base64",
+      data: "abc",
+      contentType: "image/png",
+    });
+    expect(result).toMatchObject({ contentType: "image/png" });
+  });
+
+  it("rejects a number", () => {
+    expect(() => portabilityFileEntrySchema.parse(42)).toThrow();
+  });
+
+  it("rejects a base64 object with wrong encoding", () => {
+    expect(() =>
+      portabilityFileEntrySchema.parse({ encoding: "hex", data: "abc" })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// portabilityCollisionStrategySchema
+// ============================================================================
+
+describe("portabilityCollisionStrategySchema", () => {
+  it("accepts 'rename'", () => {
+    expect(portabilityCollisionStrategySchema.parse("rename")).toBe("rename");
+  });
+
+  it("accepts 'skip'", () => {
+    expect(portabilityCollisionStrategySchema.parse("skip")).toBe("skip");
+  });
+
+  it("accepts 'replace'", () => {
+    expect(portabilityCollisionStrategySchema.parse("replace")).toBe("replace");
+  });
+
+  it("rejects unknown strategies", () => {
+    expect(() => portabilityCollisionStrategySchema.parse("merge")).toThrow();
+  });
+});
+
+// ============================================================================
+// portabilitySourceSchema (discriminated union)
+// ============================================================================
+
+describe("portabilitySourceSchema", () => {
+  it("parses an inline source", () => {
+    const result = portabilitySourceSchema.parse({
+      type: "inline",
+      files: {
+        "CLAUDE.md": "content",
+        "agent.json": { encoding: "base64", data: "e30=" },
+      },
+    });
+    expect(result.type).toBe("inline");
+  });
+
+  it("parses a github source", () => {
+    const result = portabilitySourceSchema.parse({
+      type: "github",
+      url: "https://github.com/acme/export",
+    });
+    expect(result.type).toBe("github");
+    if (result.type === "github") {
+      expect(result.url).toBe("https://github.com/acme/export");
+    }
+  });
+
+  it("rejects github source with invalid URL", () => {
+    expect(() =>
+      portabilitySourceSchema.parse({ type: "github", url: "not-a-url" })
+    ).toThrow();
+  });
+
+  it("rejects unknown source type", () => {
+    expect(() =>
+      portabilitySourceSchema.parse({ type: "s3", url: "s3://bucket" })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// portabilityTargetSchema (discriminated union)
+// ============================================================================
+
+describe("portabilityTargetSchema", () => {
+  it("parses new_company target", () => {
+    const result = portabilityTargetSchema.parse({ mode: "new_company" });
+    expect(result.mode).toBe("new_company");
+  });
+
+  it("accepts optional newCompanyName", () => {
+    const result = portabilityTargetSchema.parse({
+      mode: "new_company",
+      newCompanyName: "Acme Corp",
+    });
+    if (result.mode === "new_company") {
+      expect(result.newCompanyName).toBe("Acme Corp");
+    }
+  });
+
+  it("parses existing_company target with UUID", () => {
+    const id = "00000000-0000-0000-0000-000000000008";
+    const result = portabilityTargetSchema.parse({ mode: "existing_company", companyId: id });
+    expect(result.mode).toBe("existing_company");
+    if (result.mode === "existing_company") {
+      expect(result.companyId).toBe(id);
+    }
+  });
+
+  it("rejects existing_company with non-UUID companyId", () => {
+    expect(() =>
+      portabilityTargetSchema.parse({ mode: "existing_company", companyId: "not-uuid" })
+    ).toThrow();
+  });
+
+  it("rejects unknown mode", () => {
+    expect(() =>
+      portabilityTargetSchema.parse({ mode: "temp_company" })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// portabilityAgentSelectionSchema (union: 'all' | string[])
+// ============================================================================
+
+describe("portabilityAgentSelectionSchema", () => {
+  it("accepts the literal 'all'", () => {
+    expect(portabilityAgentSelectionSchema.parse("all")).toBe("all");
+  });
+
+  it("accepts an array of agent slugs", () => {
+    const result = portabilityAgentSelectionSchema.parse(["agent-a", "agent-b"]);
+    expect(result).toEqual(["agent-a", "agent-b"]);
+  });
+
+  it("rejects an array with empty strings", () => {
+    expect(() =>
+      portabilityAgentSelectionSchema.parse(["agent-a", ""])
+    ).toThrow();
+  });
+
+  it("rejects a non-'all' string", () => {
+    expect(() => portabilityAgentSelectionSchema.parse("some")).toThrow();
+  });
+});
+
+// ============================================================================
+// companyPortabilityExportSchema
+// ============================================================================
+
+describe("companyPortabilityExportSchema", () => {
+  it("parses an empty object (all optional)", () => {
+    const result = companyPortabilityExportSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts arrays of agent/skill/project slugs", () => {
+    const result = companyPortabilityExportSchema.parse({
+      agents: ["my-agent"],
+      skills: ["my-skill"],
+      projects: ["proj-1"],
+    });
+    expect(result.agents).toEqual(["my-agent"]);
+  });
+
+  it("rejects empty slug strings", () => {
+    expect(() =>
+      companyPortabilityExportSchema.parse({ agents: [""] })
+    ).toThrow();
+  });
+});
+
+// ============================================================================
+// companyPortabilityPreviewSchema
+// ============================================================================
+
+describe("companyPortabilityPreviewSchema", () => {
+  const id = "00000000-0000-0000-0000-000000000009";
+  const validBase = {
+    source: { type: "inline", files: {} },
+    target: { mode: "existing_company", companyId: id },
+  };
+
+  it("parses a valid preview", () => {
+    const result = companyPortabilityPreviewSchema.parse(validBase);
+    expect(result.source.type).toBe("inline");
+    expect(result.target.mode).toBe("existing_company");
+  });
+
+  it("accepts optional agents selection", () => {
+    const result = companyPortabilityPreviewSchema.parse({
+      ...validBase,
+      agents: "all",
+    });
+    expect(result.agents).toBe("all");
+  });
+
+  it("accepts optional collisionStrategy", () => {
+    const result = companyPortabilityPreviewSchema.parse({
+      ...validBase,
+      collisionStrategy: "rename",
+    });
+    expect(result.collisionStrategy).toBe("rename");
+  });
+
+  it("rejects missing required source", () => {
+    expect(() =>
+      companyPortabilityPreviewSchema.parse({ target: validBase.target })
+    ).toThrow();
+  });
+
+  it("rejects missing required target", () => {
+    expect(() =>
+      companyPortabilityPreviewSchema.parse({ source: validBase.source })
+    ).toThrow();
+  });
+});

--- a/packages/shared/src/validators/shared-validators.test.ts
+++ b/packages/shared/src/validators/shared-validators.test.ts
@@ -1,0 +1,652 @@
+import { describe, it, expect } from "vitest";
+
+// ---------------------------------------------------------------------------
+// cost.ts
+// ---------------------------------------------------------------------------
+import {
+  createCostEventSchema,
+  updateBudgetSchema,
+} from "./cost.js";
+
+// ---------------------------------------------------------------------------
+// finance.ts
+// ---------------------------------------------------------------------------
+import { createFinanceEventSchema } from "./finance.js";
+
+// ---------------------------------------------------------------------------
+// approval.ts
+// ---------------------------------------------------------------------------
+import {
+  createApprovalSchema,
+  resolveApprovalSchema,
+  requestApprovalRevisionSchema,
+  resubmitApprovalSchema,
+  addApprovalCommentSchema,
+} from "./approval.js";
+
+// ---------------------------------------------------------------------------
+// budget.ts
+// ---------------------------------------------------------------------------
+import {
+  upsertBudgetPolicySchema,
+  resolveBudgetIncidentSchema,
+} from "./budget.js";
+
+// ---------------------------------------------------------------------------
+// secret.ts
+// ---------------------------------------------------------------------------
+import {
+  envBindingPlainSchema,
+  envBindingSecretRefSchema,
+  envBindingSchema,
+  envConfigSchema,
+  createSecretSchema,
+  rotateSecretSchema,
+  updateSecretSchema,
+} from "./secret.js";
+
+// ---------------------------------------------------------------------------
+// access.ts
+// ---------------------------------------------------------------------------
+import {
+  createCompanyInviteSchema,
+  acceptInviteSchema,
+  listJoinRequestsQuerySchema,
+  claimJoinRequestApiKeySchema,
+  createCliAuthChallengeSchema,
+  resolveCliAuthChallengeSchema,
+  updateMemberPermissionsSchema,
+  updateUserCompanyAccessSchema,
+} from "./access.js";
+
+// ============================================================================
+// cost.ts
+// ============================================================================
+
+describe("createCostEventSchema", () => {
+  const validBase = {
+    agentId: "00000000-0000-0000-0000-000000000001",
+    provider: "anthropic",
+    model: "claude-3-5-sonnet",
+    inputTokens: 100,
+    outputTokens: 50,
+    costCents: 12,
+    occurredAt: new Date().toISOString(),
+  };
+
+  it("parses a valid cost event", () => {
+    const result = createCostEventSchema.parse(validBase);
+    expect(result.provider).toBe("anthropic");
+    expect(result.costCents).toBe(12);
+  });
+
+  it("defaults billingType to 'unknown'", () => {
+    const result = createCostEventSchema.parse(validBase);
+    expect(result.billingType).toBe("unknown");
+  });
+
+  it("defaults inputTokens to 0 when omitted", () => {
+    const { inputTokens: _, ...rest } = validBase;
+    const result = createCostEventSchema.parse(rest);
+    expect(result.inputTokens).toBe(0);
+  });
+
+  it("sets biller to provider when biller is omitted", () => {
+    const result = createCostEventSchema.parse(validBase);
+    expect(result.biller).toBe("anthropic");
+  });
+
+  it("uses explicit biller when provided", () => {
+    const result = createCostEventSchema.parse({ ...validBase, biller: "acme" });
+    expect(result.biller).toBe("acme");
+  });
+
+  it("rejects negative costCents", () => {
+    expect(() => createCostEventSchema.parse({ ...validBase, costCents: -1 })).toThrow();
+  });
+
+  it("rejects fractional inputTokens", () => {
+    expect(() => createCostEventSchema.parse({ ...validBase, inputTokens: 1.5 })).toThrow();
+  });
+
+  it("rejects invalid datetime for occurredAt", () => {
+    expect(() => createCostEventSchema.parse({ ...validBase, occurredAt: "not-a-date" })).toThrow();
+  });
+
+  it("rejects invalid UUID for agentId", () => {
+    expect(() => createCostEventSchema.parse({ ...validBase, agentId: "not-a-uuid" })).toThrow();
+  });
+});
+
+describe("updateBudgetSchema", () => {
+  it("parses a valid budget update", () => {
+    const result = updateBudgetSchema.parse({ budgetMonthlyCents: 5000 });
+    expect(result.budgetMonthlyCents).toBe(5000);
+  });
+
+  it("accepts zero", () => {
+    const result = updateBudgetSchema.parse({ budgetMonthlyCents: 0 });
+    expect(result.budgetMonthlyCents).toBe(0);
+  });
+
+  it("rejects negative amounts", () => {
+    expect(() => updateBudgetSchema.parse({ budgetMonthlyCents: -1 })).toThrow();
+  });
+
+  it("rejects fractional amounts", () => {
+    expect(() => updateBudgetSchema.parse({ budgetMonthlyCents: 1.5 })).toThrow();
+  });
+});
+
+// ============================================================================
+// finance.ts
+// ============================================================================
+
+describe("createFinanceEventSchema", () => {
+  const validBase = {
+    biller: "stripe",
+    eventKind: "inference_charge",
+    amountCents: 100,
+    occurredAt: new Date().toISOString(),
+  };
+
+  it("parses a valid finance event", () => {
+    const result = createFinanceEventSchema.parse(validBase);
+    expect(result.biller).toBe("stripe");
+    expect(result.amountCents).toBe(100);
+  });
+
+  it("defaults direction to 'debit'", () => {
+    const result = createFinanceEventSchema.parse(validBase);
+    expect(result.direction).toBe("debit");
+  });
+
+  it("defaults currency to 'USD'", () => {
+    const result = createFinanceEventSchema.parse(validBase);
+    expect(result.currency).toBe("USD");
+  });
+
+  it("upcases the currency", () => {
+    const result = createFinanceEventSchema.parse({ ...validBase, currency: "eur" });
+    expect(result.currency).toBe("EUR");
+  });
+
+  it("defaults estimated to false", () => {
+    const result = createFinanceEventSchema.parse(validBase);
+    expect(result.estimated).toBe(false);
+  });
+
+  it("rejects invalid eventKind", () => {
+    expect(() => createFinanceEventSchema.parse({ ...validBase, eventKind: "nope" })).toThrow();
+  });
+
+  it("rejects currency with wrong length", () => {
+    expect(() => createFinanceEventSchema.parse({ ...validBase, currency: "US" })).toThrow();
+  });
+
+  it("rejects negative amountCents", () => {
+    expect(() => createFinanceEventSchema.parse({ ...validBase, amountCents: -1 })).toThrow();
+  });
+});
+
+// ============================================================================
+// approval.ts
+// ============================================================================
+
+describe("createApprovalSchema", () => {
+  it("parses a valid approval", () => {
+    const result = createApprovalSchema.parse({
+      type: "hire_agent",
+      payload: { reason: "need more capacity" },
+    });
+    expect(result.type).toBe("hire_agent");
+    expect(result.payload).toEqual({ reason: "need more capacity" });
+  });
+
+  it("accepts optional issueIds array", () => {
+    const id = "00000000-0000-0000-0000-000000000002";
+    const result = createApprovalSchema.parse({
+      type: "hire_agent",
+      payload: {},
+      issueIds: [id],
+    });
+    expect(result.issueIds).toEqual([id]);
+  });
+
+  it("rejects invalid approval type", () => {
+    expect(() => createApprovalSchema.parse({ type: "invalid", payload: {} })).toThrow();
+  });
+
+  it("rejects non-record payload", () => {
+    expect(() => createApprovalSchema.parse({ type: "hire_agent", payload: "string" })).toThrow();
+  });
+});
+
+describe("resolveApprovalSchema", () => {
+  it("parses with defaults", () => {
+    const result = resolveApprovalSchema.parse({});
+    expect(result.decidedByUserId).toBe("board");
+  });
+
+  it("accepts a decision note", () => {
+    const result = resolveApprovalSchema.parse({ decisionNote: "approved" });
+    expect(result.decisionNote).toBe("approved");
+  });
+});
+
+describe("requestApprovalRevisionSchema", () => {
+  it("parses with defaults", () => {
+    const result = requestApprovalRevisionSchema.parse({});
+    expect(result.decidedByUserId).toBe("board");
+  });
+});
+
+describe("resubmitApprovalSchema", () => {
+  it("parses empty object", () => {
+    const result = resubmitApprovalSchema.parse({});
+    expect(result.payload).toBeUndefined();
+  });
+
+  it("accepts an updated payload", () => {
+    const result = resubmitApprovalSchema.parse({ payload: { updated: true } });
+    expect(result.payload).toEqual({ updated: true });
+  });
+});
+
+describe("addApprovalCommentSchema", () => {
+  it("parses a non-empty body", () => {
+    const result = addApprovalCommentSchema.parse({ body: "looks good" });
+    expect(result.body).toBe("looks good");
+  });
+
+  it("rejects an empty body", () => {
+    expect(() => addApprovalCommentSchema.parse({ body: "" })).toThrow();
+  });
+});
+
+// ============================================================================
+// budget.ts
+// ============================================================================
+
+describe("upsertBudgetPolicySchema", () => {
+  const validBase = {
+    scopeType: "company",
+    scopeId: "00000000-0000-0000-0000-000000000003",
+    amount: 100000,
+  };
+
+  it("parses a valid budget policy", () => {
+    const result = upsertBudgetPolicySchema.parse(validBase);
+    expect(result.scopeType).toBe("company");
+    expect(result.amount).toBe(100000);
+  });
+
+  it("defaults metric to 'billed_cents'", () => {
+    const result = upsertBudgetPolicySchema.parse(validBase);
+    expect(result.metric).toBe("billed_cents");
+  });
+
+  it("defaults windowKind to 'calendar_month_utc'", () => {
+    const result = upsertBudgetPolicySchema.parse(validBase);
+    expect(result.windowKind).toBe("calendar_month_utc");
+  });
+
+  it("defaults warnPercent to 80", () => {
+    const result = upsertBudgetPolicySchema.parse(validBase);
+    expect(result.warnPercent).toBe(80);
+  });
+
+  it("defaults hardStopEnabled to true", () => {
+    const result = upsertBudgetPolicySchema.parse(validBase);
+    expect(result.hardStopEnabled).toBe(true);
+  });
+
+  it("rejects warnPercent of 0", () => {
+    expect(() => upsertBudgetPolicySchema.parse({ ...validBase, warnPercent: 0 })).toThrow();
+  });
+
+  it("rejects warnPercent of 100", () => {
+    expect(() => upsertBudgetPolicySchema.parse({ ...validBase, warnPercent: 100 })).toThrow();
+  });
+
+  it("rejects invalid scopeType", () => {
+    expect(() => upsertBudgetPolicySchema.parse({ ...validBase, scopeType: "team" })).toThrow();
+  });
+});
+
+describe("resolveBudgetIncidentSchema", () => {
+  it("parses 'keep_paused' without amount", () => {
+    const result = resolveBudgetIncidentSchema.parse({ action: "keep_paused" });
+    expect(result.action).toBe("keep_paused");
+  });
+
+  it("parses 'raise_budget_and_resume' with amount", () => {
+    const result = resolveBudgetIncidentSchema.parse({
+      action: "raise_budget_and_resume",
+      amount: 50000,
+    });
+    expect(result.amount).toBe(50000);
+  });
+
+  it("rejects 'raise_budget_and_resume' without amount", () => {
+    expect(() =>
+      resolveBudgetIncidentSchema.parse({ action: "raise_budget_and_resume" })
+    ).toThrow();
+  });
+
+  it("accepts optional decisionNote", () => {
+    const result = resolveBudgetIncidentSchema.parse({
+      action: "keep_paused",
+      decisionNote: "waiting for review",
+    });
+    expect(result.decisionNote).toBe("waiting for review");
+  });
+});
+
+// ============================================================================
+// secret.ts
+// ============================================================================
+
+describe("envBindingPlainSchema", () => {
+  it("parses a plain binding", () => {
+    const result = envBindingPlainSchema.parse({ type: "plain", value: "abc" });
+    expect(result.type).toBe("plain");
+    expect(result.value).toBe("abc");
+  });
+
+  it("rejects wrong type literal", () => {
+    expect(() => envBindingPlainSchema.parse({ type: "secret_ref", value: "x" })).toThrow();
+  });
+});
+
+describe("envBindingSecretRefSchema", () => {
+  it("parses a secret_ref binding", () => {
+    const result = envBindingSecretRefSchema.parse({
+      type: "secret_ref",
+      secretId: "00000000-0000-0000-0000-000000000004",
+    });
+    expect(result.type).toBe("secret_ref");
+    expect(result.secretId).toBe("00000000-0000-0000-0000-000000000004");
+  });
+
+  it("accepts 'latest' version", () => {
+    const result = envBindingSecretRefSchema.parse({
+      type: "secret_ref",
+      secretId: "00000000-0000-0000-0000-000000000004",
+      version: "latest",
+    });
+    expect(result.version).toBe("latest");
+  });
+
+  it("accepts integer version", () => {
+    const result = envBindingSecretRefSchema.parse({
+      type: "secret_ref",
+      secretId: "00000000-0000-0000-0000-000000000004",
+      version: 3,
+    });
+    expect(result.version).toBe(3);
+  });
+
+  it("rejects non-UUID secretId", () => {
+    expect(() =>
+      envBindingSecretRefSchema.parse({ type: "secret_ref", secretId: "not-uuid" })
+    ).toThrow();
+  });
+});
+
+describe("envBindingSchema", () => {
+  it("accepts a bare string (legacy inline value)", () => {
+    const result = envBindingSchema.parse("direct-value");
+    expect(result).toBe("direct-value");
+  });
+
+  it("accepts a plain object", () => {
+    const result = envBindingSchema.parse({ type: "plain", value: "v" });
+    expect(result).toMatchObject({ type: "plain" });
+  });
+
+  it("accepts a secret_ref object", () => {
+    const result = envBindingSchema.parse({
+      type: "secret_ref",
+      secretId: "00000000-0000-0000-0000-000000000005",
+    });
+    expect(result).toMatchObject({ type: "secret_ref" });
+  });
+
+  it("rejects a number", () => {
+    expect(() => envBindingSchema.parse(42)).toThrow();
+  });
+});
+
+describe("envConfigSchema", () => {
+  it("parses a record of env bindings", () => {
+    const result = envConfigSchema.parse({
+      FOO: "bar",
+      TOKEN: { type: "plain", value: "xyz" },
+    });
+    expect(result.FOO).toBe("bar");
+    expect(result.TOKEN).toMatchObject({ type: "plain", value: "xyz" });
+  });
+
+  it("rejects non-object at root", () => {
+    expect(() => envConfigSchema.parse(["array"])).toThrow();
+  });
+});
+
+describe("createSecretSchema", () => {
+  it("parses a valid secret", () => {
+    const result = createSecretSchema.parse({ name: "my-secret", value: "s3cr3t" });
+    expect(result.name).toBe("my-secret");
+    expect(result.value).toBe("s3cr3t");
+  });
+
+  it("rejects empty name", () => {
+    expect(() => createSecretSchema.parse({ name: "", value: "v" })).toThrow();
+  });
+
+  it("rejects empty value", () => {
+    expect(() => createSecretSchema.parse({ name: "n", value: "" })).toThrow();
+  });
+
+  it("accepts valid provider", () => {
+    const result = createSecretSchema.parse({ name: "n", value: "v", provider: "local_encrypted" });
+    expect(result.provider).toBe("local_encrypted");
+  });
+});
+
+describe("rotateSecretSchema", () => {
+  it("parses with a new value", () => {
+    const result = rotateSecretSchema.parse({ value: "new-val" });
+    expect(result.value).toBe("new-val");
+  });
+
+  it("rejects empty value", () => {
+    expect(() => rotateSecretSchema.parse({ value: "" })).toThrow();
+  });
+});
+
+describe("updateSecretSchema", () => {
+  it("parses an empty object (all optional)", () => {
+    const result = updateSecretSchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts partial updates", () => {
+    const result = updateSecretSchema.parse({ name: "new-name" });
+    expect(result.name).toBe("new-name");
+  });
+});
+
+// ============================================================================
+// access.ts
+// ============================================================================
+
+describe("createCompanyInviteSchema", () => {
+  it("parses with defaults", () => {
+    const result = createCompanyInviteSchema.parse({});
+    expect(result.allowedJoinTypes).toBe("both");
+  });
+
+  it("accepts allowedJoinTypes 'agent'", () => {
+    const result = createCompanyInviteSchema.parse({ allowedJoinTypes: "agent" });
+    expect(result.allowedJoinTypes).toBe("agent");
+  });
+
+  it("rejects invalid allowedJoinTypes", () => {
+    expect(() => createCompanyInviteSchema.parse({ allowedJoinTypes: "robot" })).toThrow();
+  });
+
+  it("rejects agentMessage over 4000 chars", () => {
+    expect(() =>
+      createCompanyInviteSchema.parse({ agentMessage: "x".repeat(4001) })
+    ).toThrow();
+  });
+});
+
+describe("acceptInviteSchema", () => {
+  it("parses with requestType 'agent'", () => {
+    const result = acceptInviteSchema.parse({ requestType: "agent" });
+    expect(result.requestType).toBe("agent");
+  });
+
+  it("parses with requestType 'human'", () => {
+    const result = acceptInviteSchema.parse({ requestType: "human" });
+    expect(result.requestType).toBe("human");
+  });
+
+  it("rejects invalid requestType", () => {
+    expect(() => acceptInviteSchema.parse({ requestType: "bot" })).toThrow();
+  });
+
+  it("accepts optional agentName", () => {
+    const result = acceptInviteSchema.parse({ requestType: "agent", agentName: "MyAgent" });
+    expect(result.agentName).toBe("MyAgent");
+  });
+
+  it("rejects agentName over 120 chars", () => {
+    expect(() =>
+      acceptInviteSchema.parse({ requestType: "agent", agentName: "a".repeat(121) })
+    ).toThrow();
+  });
+});
+
+describe("listJoinRequestsQuerySchema", () => {
+  it("parses empty query (all optional)", () => {
+    const result = listJoinRequestsQuerySchema.parse({});
+    expect(result).toEqual({});
+  });
+
+  it("accepts a valid status", () => {
+    const result = listJoinRequestsQuerySchema.parse({ status: "pending_approval" });
+    expect(result.status).toBe("pending_approval");
+  });
+
+  it("accepts a valid requestType", () => {
+    const result = listJoinRequestsQuerySchema.parse({ requestType: "agent" });
+    expect(result.requestType).toBe("agent");
+  });
+});
+
+describe("claimJoinRequestApiKeySchema", () => {
+  it("parses a valid claimSecret", () => {
+    const secret = "a".repeat(16);
+    const result = claimJoinRequestApiKeySchema.parse({ claimSecret: secret });
+    expect(result.claimSecret).toBe(secret);
+  });
+
+  it("rejects claimSecret shorter than 16 chars", () => {
+    expect(() =>
+      claimJoinRequestApiKeySchema.parse({ claimSecret: "short" })
+    ).toThrow();
+  });
+
+  it("rejects claimSecret longer than 256 chars", () => {
+    expect(() =>
+      claimJoinRequestApiKeySchema.parse({ claimSecret: "a".repeat(257) })
+    ).toThrow();
+  });
+});
+
+describe("createCliAuthChallengeSchema", () => {
+  it("parses a valid challenge", () => {
+    const result = createCliAuthChallengeSchema.parse({
+      command: "paperclip auth login",
+    });
+    expect(result.command).toBe("paperclip auth login");
+    expect(result.requestedAccess).toBe("board");
+  });
+
+  it("defaults requestedAccess to 'board'", () => {
+    const result = createCliAuthChallengeSchema.parse({ command: "cmd" });
+    expect(result.requestedAccess).toBe("board");
+  });
+
+  it("accepts 'instance_admin_required'", () => {
+    const result = createCliAuthChallengeSchema.parse({
+      command: "cmd",
+      requestedAccess: "instance_admin_required",
+    });
+    expect(result.requestedAccess).toBe("instance_admin_required");
+  });
+
+  it("rejects empty command", () => {
+    expect(() => createCliAuthChallengeSchema.parse({ command: "" })).toThrow();
+  });
+
+  it("rejects command over 240 chars", () => {
+    expect(() =>
+      createCliAuthChallengeSchema.parse({ command: "x".repeat(241) })
+    ).toThrow();
+  });
+});
+
+describe("resolveCliAuthChallengeSchema", () => {
+  it("parses a valid token", () => {
+    const token = "t".repeat(32);
+    const result = resolveCliAuthChallengeSchema.parse({ token });
+    expect(result.token).toBe(token);
+  });
+
+  it("rejects token under 16 chars", () => {
+    expect(() => resolveCliAuthChallengeSchema.parse({ token: "short" })).toThrow();
+  });
+});
+
+describe("updateMemberPermissionsSchema", () => {
+  it("parses an empty grants array", () => {
+    const result = updateMemberPermissionsSchema.parse({ grants: [] });
+    expect(result.grants).toHaveLength(0);
+  });
+
+  it("parses grants with a valid permissionKey", () => {
+    const result = updateMemberPermissionsSchema.parse({
+      grants: [{ permissionKey: "agents:create" }],
+    });
+    expect(result.grants[0]?.permissionKey).toBe("agents:create");
+  });
+
+  it("rejects an invalid permissionKey", () => {
+    expect(() =>
+      updateMemberPermissionsSchema.parse({ grants: [{ permissionKey: "invalid:key" }] })
+    ).toThrow();
+  });
+});
+
+describe("updateUserCompanyAccessSchema", () => {
+  it("defaults companyIds to empty array", () => {
+    const result = updateUserCompanyAccessSchema.parse({});
+    expect(result.companyIds).toEqual([]);
+  });
+
+  it("accepts UUID companyIds", () => {
+    const id = "00000000-0000-0000-0000-000000000006";
+    const result = updateUserCompanyAccessSchema.parse({ companyIds: [id] });
+    expect(result.companyIds).toEqual([id]);
+  });
+
+  it("rejects non-UUID companyIds", () => {
+    expect(() =>
+      updateUserCompanyAccessSchema.parse({ companyIds: ["not-uuid"] })
+    ).toThrow();
+  });
+});

--- a/server/src/__tests__/agent-permissions-service.test.ts
+++ b/server/src/__tests__/agent-permissions-service.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  defaultPermissionsForRole,
+  normalizeAgentPermissions,
+} from "../services/agent-permissions.js";
+
+// ---------------------------------------------------------------------------
+// defaultPermissionsForRole
+// ---------------------------------------------------------------------------
+
+describe("defaultPermissionsForRole", () => {
+  it("grants canCreateAgents=true for 'ceo' role", () => {
+    expect(defaultPermissionsForRole("ceo").canCreateAgents).toBe(true);
+  });
+
+  it("denies canCreateAgents for 'engineer' role", () => {
+    expect(defaultPermissionsForRole("engineer").canCreateAgents).toBe(false);
+  });
+
+  it("denies canCreateAgents for 'cto' role", () => {
+    expect(defaultPermissionsForRole("cto").canCreateAgents).toBe(false);
+  });
+
+  it("denies canCreateAgents for 'CEO' (case-sensitive check)", () => {
+    expect(defaultPermissionsForRole("CEO").canCreateAgents).toBe(false);
+  });
+
+  it("denies canCreateAgents for empty string", () => {
+    expect(defaultPermissionsForRole("").canCreateAgents).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeAgentPermissions
+// ---------------------------------------------------------------------------
+
+describe("normalizeAgentPermissions", () => {
+  it("returns defaults when permissions is null", () => {
+    const result = normalizeAgentPermissions(null, "ceo");
+    expect(result.canCreateAgents).toBe(true);
+  });
+
+  it("returns defaults when permissions is undefined", () => {
+    const result = normalizeAgentPermissions(undefined, "engineer");
+    expect(result.canCreateAgents).toBe(false);
+  });
+
+  it("returns defaults when permissions is a string", () => {
+    const result = normalizeAgentPermissions("yes", "ceo");
+    expect(result.canCreateAgents).toBe(true);
+  });
+
+  it("returns defaults when permissions is an array", () => {
+    const result = normalizeAgentPermissions([], "ceo");
+    expect(result.canCreateAgents).toBe(true);
+  });
+
+  it("reads canCreateAgents=true from a plain object", () => {
+    const result = normalizeAgentPermissions({ canCreateAgents: true }, "engineer");
+    expect(result.canCreateAgents).toBe(true);
+  });
+
+  it("reads canCreateAgents=false from a plain object", () => {
+    const result = normalizeAgentPermissions({ canCreateAgents: false }, "ceo");
+    expect(result.canCreateAgents).toBe(false);
+  });
+
+  it("falls back to role default when canCreateAgents is not a boolean", () => {
+    // "yes" string → not a boolean → falls back to defaults.canCreateAgents
+    const result = normalizeAgentPermissions({ canCreateAgents: "yes" }, "ceo");
+    expect(result.canCreateAgents).toBe(true); // ceo default = true
+  });
+
+  it("falls back to role default when canCreateAgents key is absent", () => {
+    const result = normalizeAgentPermissions({ otherField: 42 }, "engineer");
+    expect(result.canCreateAgents).toBe(false); // engineer default = false
+  });
+
+  it("ignores extra keys in permissions object (only normalises known fields)", () => {
+    const result = normalizeAgentPermissions({ canCreateAgents: true, unknown: "ignored" }, "engineer");
+    expect(result.canCreateAgents).toBe(true);
+  });
+});

--- a/server/src/__tests__/board-auth-utils.test.ts
+++ b/server/src/__tests__/board-auth-utils.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  BOARD_API_KEY_TTL_MS,
+  CLI_AUTH_CHALLENGE_TTL_MS,
+  hashBearerToken,
+  tokenHashesMatch,
+  createBoardApiToken,
+  createCliAuthSecret,
+  boardApiKeyExpiresAt,
+  cliAuthChallengeExpiresAt,
+} from "../services/board-auth.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+describe("board-auth constants", () => {
+  it("BOARD_API_KEY_TTL_MS is 30 days in milliseconds", () => {
+    expect(BOARD_API_KEY_TTL_MS).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it("CLI_AUTH_CHALLENGE_TTL_MS is 10 minutes in milliseconds", () => {
+    expect(CLI_AUTH_CHALLENGE_TTL_MS).toBe(10 * 60 * 1000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hashBearerToken
+// ---------------------------------------------------------------------------
+
+describe("hashBearerToken", () => {
+  it("returns a 64-character hex string (SHA-256)", () => {
+    const hash = hashBearerToken("my-secret-token");
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(hashBearerToken("abc")).toBe(hashBearerToken("abc"));
+  });
+
+  it("produces different hashes for different inputs", () => {
+    expect(hashBearerToken("token-a")).not.toBe(hashBearerToken("token-b"));
+  });
+
+  it("handles empty string input", () => {
+    const hash = hashBearerToken("");
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tokenHashesMatch
+// ---------------------------------------------------------------------------
+
+describe("tokenHashesMatch", () => {
+  it("returns true for identical strings", () => {
+    const h = hashBearerToken("token");
+    expect(tokenHashesMatch(h, h)).toBe(true);
+  });
+
+  it("returns false for strings that differ by one character", () => {
+    const h1 = hashBearerToken("token-a");
+    const h2 = hashBearerToken("token-b");
+    expect(tokenHashesMatch(h1, h2)).toBe(false);
+  });
+
+  it("returns false when lengths differ", () => {
+    expect(tokenHashesMatch("short", "a-much-longer-string")).toBe(false);
+  });
+
+  it("is symmetric", () => {
+    const h1 = hashBearerToken("x");
+    const h2 = hashBearerToken("y");
+    expect(tokenHashesMatch(h1, h2)).toBe(tokenHashesMatch(h2, h1));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createBoardApiToken
+// ---------------------------------------------------------------------------
+
+describe("createBoardApiToken", () => {
+  it("starts with the pcp_board_ prefix", () => {
+    expect(createBoardApiToken()).toMatch(/^pcp_board_/);
+  });
+
+  it("contains 48 hex characters after the prefix (24 random bytes)", () => {
+    const token = createBoardApiToken();
+    const hex = token.slice("pcp_board_".length);
+    expect(hex).toMatch(/^[0-9a-f]{48}$/);
+  });
+
+  it("generates unique tokens on each call", () => {
+    const tokens = new Set(Array.from({ length: 10 }, () => createBoardApiToken()));
+    expect(tokens.size).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCliAuthSecret
+// ---------------------------------------------------------------------------
+
+describe("createCliAuthSecret", () => {
+  it("starts with the pcp_cli_auth_ prefix", () => {
+    expect(createCliAuthSecret()).toMatch(/^pcp_cli_auth_/);
+  });
+
+  it("contains 48 hex characters after the prefix", () => {
+    const secret = createCliAuthSecret();
+    const hex = secret.slice("pcp_cli_auth_".length);
+    expect(hex).toMatch(/^[0-9a-f]{48}$/);
+  });
+
+  it("generates unique secrets on each call", () => {
+    const secrets = new Set(Array.from({ length: 10 }, () => createCliAuthSecret()));
+    expect(secrets.size).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// boardApiKeyExpiresAt
+// ---------------------------------------------------------------------------
+
+describe("boardApiKeyExpiresAt", () => {
+  it("returns a Date 30 days after the given timestamp", () => {
+    const nowMs = 1_700_000_000_000;
+    const result = boardApiKeyExpiresAt(nowMs);
+    expect(result).toBeInstanceOf(Date);
+    expect(result.getTime()).toBe(nowMs + BOARD_API_KEY_TTL_MS);
+  });
+
+  it("defaults to approximately now when no argument is given", () => {
+    const before = Date.now();
+    const result = boardApiKeyExpiresAt();
+    const after = Date.now();
+    const expectedMin = before + BOARD_API_KEY_TTL_MS;
+    const expectedMax = after + BOARD_API_KEY_TTL_MS;
+    expect(result.getTime()).toBeGreaterThanOrEqual(expectedMin);
+    expect(result.getTime()).toBeLessThanOrEqual(expectedMax);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cliAuthChallengeExpiresAt
+// ---------------------------------------------------------------------------
+
+describe("cliAuthChallengeExpiresAt", () => {
+  it("returns a Date 10 minutes after the given timestamp", () => {
+    const nowMs = 1_700_000_000_000;
+    const result = cliAuthChallengeExpiresAt(nowMs);
+    expect(result).toBeInstanceOf(Date);
+    expect(result.getTime()).toBe(nowMs + CLI_AUTH_CHALLENGE_TTL_MS);
+  });
+
+  it("defaults to approximately now when no argument is given", () => {
+    const before = Date.now();
+    const result = cliAuthChallengeExpiresAt();
+    const after = Date.now();
+    const expectedMin = before + CLI_AUTH_CHALLENGE_TTL_MS;
+    const expectedMax = after + CLI_AUTH_CHALLENGE_TTL_MS;
+    expect(result.getTime()).toBeGreaterThanOrEqual(expectedMin);
+    expect(result.getTime()).toBeLessThanOrEqual(expectedMax);
+  });
+});

--- a/server/src/__tests__/company-export-readme.test.ts
+++ b/server/src/__tests__/company-export-readme.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateOrgChartMermaid,
+  generateReadme,
+} from "../services/company-export-readme.js";
+import type {
+  CompanyPortabilityAgentManifestEntry,
+  CompanyPortabilitySkillManifestEntry,
+  CompanyPortabilityProjectManifestEntry,
+  CompanyPortabilityManifest,
+} from "@paperclipai/shared";
+
+function makeAgent(overrides: Partial<CompanyPortabilityAgentManifestEntry> = {}): CompanyPortabilityAgentManifestEntry {
+  return {
+    slug: "test-agent",
+    name: "Test Agent",
+    path: "agents/test-agent",
+    skills: [],
+    role: "engineer",
+    title: null,
+    icon: null,
+    capabilities: null,
+    reportsToSlug: null,
+    adapterType: "claude_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    permissions: {},
+    budgetMonthlyCents: 0,
+    metadata: null,
+    ...overrides,
+  };
+}
+
+function makeSkill(overrides: Partial<CompanyPortabilitySkillManifestEntry> = {}): CompanyPortabilitySkillManifestEntry {
+  return {
+    key: "skill-key",
+    slug: "skill-slug",
+    name: "Test Skill",
+    path: "skills/test-skill",
+    description: null,
+    sourceType: "local",
+    sourceLocator: null,
+    sourceRef: null,
+    trustLevel: null,
+    compatibility: null,
+    metadata: null,
+    fileInventory: [],
+    ...overrides,
+  };
+}
+
+function makeProject(overrides: Partial<CompanyPortabilityProjectManifestEntry> = {}): CompanyPortabilityProjectManifestEntry {
+  return {
+    slug: "project-slug",
+    name: "Test Project",
+    path: "projects/test-project",
+    description: null,
+    ownerAgentSlug: null,
+    leadAgentSlug: null,
+    targetDate: null,
+    color: null,
+    status: "in_progress",
+    executionWorkspacePolicy: null,
+    workspaces: [],
+    ...overrides,
+  };
+}
+
+function makeManifest(overrides: Partial<CompanyPortabilityManifest> = {}): CompanyPortabilityManifest {
+  return {
+    schemaVersion: 1,
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    source: null,
+    includes: { agents: true, skills: true, projects: true, issues: false },
+    company: null,
+    sidebar: null,
+    agents: [],
+    skills: [],
+    projects: [],
+    issues: [],
+    envInputs: [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// generateOrgChartMermaid
+// ---------------------------------------------------------------------------
+
+describe("generateOrgChartMermaid", () => {
+  it("returns null when agents array is empty", () => {
+    expect(generateOrgChartMermaid([])).toBeNull();
+  });
+
+  it("renders a single agent node with known role label", () => {
+    const result = generateOrgChartMermaid([makeAgent({ name: "Alice", slug: "alice", role: "cto" })]);
+    expect(result).not.toBeNull();
+    expect(result).toContain("```mermaid");
+    expect(result).toContain("graph TD");
+    expect(result).toContain("alice");
+    expect(result).toContain("Alice");
+    expect(result).toContain("CTO");
+  });
+
+  it("renders unknown roles verbatim", () => {
+    const result = generateOrgChartMermaid([makeAgent({ slug: "bob", role: "wizard" })]);
+    expect(result).toContain("wizard");
+  });
+
+  it("renders edges between agents when reportsToSlug is set", () => {
+    const agents = [
+      makeAgent({ name: "CEO", slug: "ceo-agent", role: "ceo", reportsToSlug: null }),
+      makeAgent({ name: "Dev", slug: "dev-agent", role: "engineer", reportsToSlug: "ceo-agent" }),
+    ];
+    const result = generateOrgChartMermaid(agents)!;
+    expect(result).toContain("ceo_agent --> dev_agent");
+  });
+
+  it("skips edges to agents not present in the set", () => {
+    const agents = [makeAgent({ slug: "dev-agent", role: "engineer", reportsToSlug: "nonexistent-slug" })];
+    const result = generateOrgChartMermaid(agents)!;
+    expect(result).not.toContain("-->");
+  });
+
+  it("replaces hyphens in slugs with underscores for Mermaid node IDs", () => {
+    const result = generateOrgChartMermaid([makeAgent({ slug: "my-agent-slug" })])!;
+    expect(result).toContain("my_agent_slug[");
+    expect(result).not.toContain("my-agent-slug[");
+  });
+
+  it("escapes double quotes in agent names", () => {
+    const result = generateOrgChartMermaid([makeAgent({ name: 'Agent "Quote"', slug: "q" })])!;
+    expect(result).toContain("&quot;");
+    expect(result).not.toContain('"Quote"');
+  });
+
+  it("escapes angle brackets in agent names", () => {
+    const result = generateOrgChartMermaid([makeAgent({ name: "Agent <Beta>", slug: "beta" })])!;
+    expect(result).toContain("&lt;Beta&gt;");
+  });
+
+  it("wraps output in mermaid code fence", () => {
+    const result = generateOrgChartMermaid([makeAgent()])!;
+    expect(result).toMatch(/^```mermaid\n/);
+    expect(result).toMatch(/\n```$/);
+  });
+
+  it("labels known roles: ceo, cmo, cfo, coo, vp, manager, agent", () => {
+    const roleMap: Record<string, string> = {
+      ceo: "CEO", cmo: "CMO", cfo: "CFO", coo: "COO",
+      vp: "VP", manager: "Manager", agent: "Agent",
+    };
+    for (const [role, label] of Object.entries(roleMap)) {
+      const result = generateOrgChartMermaid([makeAgent({ slug: role, role })])!;
+      expect(result).toContain(label);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateReadme
+// ---------------------------------------------------------------------------
+
+describe("generateReadme", () => {
+  it("includes the company name as an H1 heading", () => {
+    const result = generateReadme(makeManifest(), { companyName: "Acme Corp", companyDescription: null });
+    expect(result).toContain("# Acme Corp");
+  });
+
+  it("includes description as a blockquote when provided", () => {
+    const result = generateReadme(makeManifest(), { companyName: "Acme", companyDescription: "Best company ever" });
+    expect(result).toContain("> Best company ever");
+  });
+
+  it("does not include a description line when companyDescription is null", () => {
+    const result = generateReadme(makeManifest(), { companyName: "Acme", companyDescription: null });
+    // Verify no user-supplied description blockquote appears (the fixed > line
+    // in What's Inside is a different marker and is fine to have).
+    expect(result).not.toContain("> null");
+    // When a description is provided it appears right after the H1 blank line;
+    // here we confirm that slot is not populated.
+    const lines = result.split("\n");
+    const h1Idx = lines.findIndex((l) => l === "# Acme");
+    // Line at h1Idx+1 is a blank; h1Idx+2 should be a section header or blank, not a description.
+    expect(lines[h1Idx + 2]).not.toMatch(/^> [A-Z]/);
+  });
+
+  it("includes org chart image when agents are present", () => {
+    const result = generateReadme(makeManifest({ agents: [makeAgent()] }), { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("![Org Chart](images/org-chart.png)");
+  });
+
+  it("omits org chart image when no agents", () => {
+    const result = generateReadme(makeManifest({ agents: [] }), { companyName: "Acme", companyDescription: null });
+    expect(result).not.toContain("![Org Chart]");
+  });
+
+  it("includes agents table with correct role labels and reports-to column", () => {
+    const manifest = makeManifest({
+      agents: [
+        makeAgent({ name: "Boss", slug: "boss", role: "ceo", reportsToSlug: null }),
+        makeAgent({ name: "Coder", slug: "coder", role: "engineer", reportsToSlug: "boss" }),
+      ],
+    });
+    const result = generateReadme(manifest, { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("| Agent | Role | Reports To |");
+    expect(result).toContain("| Boss | CEO | \u2014 |");
+    expect(result).toContain("| Coder | Engineer | boss |");
+  });
+
+  it("includes projects list with description", () => {
+    const manifest = makeManifest({ projects: [makeProject({ name: "Alpha", description: "First project" })] });
+    const result = generateReadme(manifest, { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("### Projects");
+    expect(result).toContain("**Alpha**");
+    expect(result).toContain("First project");
+  });
+
+  it("omits projects section when no projects", () => {
+    const result = generateReadme(makeManifest({ projects: [] }), { companyName: "Acme", companyDescription: null });
+    expect(result).not.toContain("### Projects");
+  });
+
+  it("renders github skill source as a markdown link", () => {
+    const manifest = makeManifest({
+      skills: [makeSkill({ name: "Reviewer", sourceType: "github", sourceLocator: "https://github.com/org/repo" })],
+    });
+    const result = generateReadme(manifest, { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("### Skills");
+    expect(result).toContain("[github](https://github.com/org/repo)");
+  });
+
+  it("renders skills_sh skill source as a markdown link", () => {
+    const manifest = makeManifest({
+      skills: [makeSkill({ sourceType: "skills_sh", sourceLocator: "https://skills.sh/my-skill" })],
+    });
+    const result = generateReadme(manifest, { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("[skills_sh](https://skills.sh/my-skill)");
+  });
+
+  it("renders url skill source as a markdown link", () => {
+    const manifest = makeManifest({
+      skills: [makeSkill({ sourceType: "url", sourceLocator: "https://example.com/skill" })],
+    });
+    const result = generateReadme(manifest, { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("[url](https://example.com/skill)");
+  });
+
+  it("shows plain sourceLocator for non-link source types", () => {
+    const manifest = makeManifest({
+      skills: [makeSkill({ sourceType: "registry", sourceLocator: "registry-id-123" })],
+    });
+    const result = generateReadme(manifest, { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("registry-id-123");
+    expect(result).not.toContain("[registry]");
+  });
+
+  it("shows 'local' for local source type with no locator", () => {
+    const manifest = makeManifest({
+      skills: [makeSkill({ sourceType: "local", sourceLocator: null })],
+    });
+    const result = generateReadme(manifest, { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("| local |");
+  });
+
+  it("shows em-dash for skills with null sourceType and null sourceLocator", () => {
+    const manifest = makeManifest({
+      skills: [makeSkill({ sourceType: null as never, sourceLocator: null })],
+    });
+    const result = generateReadme(manifest, { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("| \u2014 |");
+  });
+
+  it("includes What's Inside counts table when content is present", () => {
+    const manifest = makeManifest({ agents: [makeAgent()], skills: [makeSkill()] });
+    const result = generateReadme(manifest, { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("| Content | Count |");
+    expect(result).toContain("| Agents | 1 |");
+    expect(result).toContain("| Skills | 1 |");
+  });
+
+  it("omits What's Inside table when all arrays are empty", () => {
+    const result = generateReadme(makeManifest(), { companyName: "Acme", companyDescription: null });
+    expect(result).not.toContain("| Content | Count |");
+  });
+
+  it("includes Getting Started section with install command", () => {
+    const result = generateReadme(makeManifest(), { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("## Getting Started");
+    expect(result).toContain("pnpm paperclipai company import");
+  });
+
+  it("includes a footer with export date", () => {
+    const result = generateReadme(makeManifest(), { companyName: "Acme", companyDescription: null });
+    expect(result).toContain("Exported from");
+    const today = new Date().toISOString().split("T")[0];
+    expect(result).toContain(today);
+  });
+});

--- a/server/src/__tests__/cron-parser.test.ts
+++ b/server/src/__tests__/cron-parser.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseCron,
+  validateCron,
+  nextCronTick,
+  nextCronTickFromExpression,
+} from "../services/cron.js";
+
+// ---------------------------------------------------------------------------
+// Helper: create a UTC Date from components
+// ---------------------------------------------------------------------------
+
+function utc(year: number, month: number, day: number, hour = 0, minute = 0): Date {
+  return new Date(Date.UTC(year, month - 1, day, hour, minute, 0, 0));
+}
+
+// ---------------------------------------------------------------------------
+// parseCron
+// ---------------------------------------------------------------------------
+
+describe("parseCron", () => {
+  it("parses '* * * * *' — all wildcards", () => {
+    const c = parseCron("* * * * *");
+    expect(c.minutes).toHaveLength(60); // 0-59
+    expect(c.hours).toHaveLength(24); // 0-23
+    expect(c.daysOfMonth).toHaveLength(31); // 1-31
+    expect(c.months).toHaveLength(12); // 1-12
+    expect(c.daysOfWeek).toHaveLength(7); // 0-6
+  });
+
+  it("parses exact values", () => {
+    const c = parseCron("30 14 5 6 1");
+    expect(c.minutes).toEqual([30]);
+    expect(c.hours).toEqual([14]);
+    expect(c.daysOfMonth).toEqual([5]);
+    expect(c.months).toEqual([6]);
+    expect(c.daysOfWeek).toEqual([1]);
+  });
+
+  it("parses a range expression '1-5' in minutes", () => {
+    const c = parseCron("1-5 * * * *");
+    expect(c.minutes).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("parses a step expression '*/15' in minutes", () => {
+    const c = parseCron("*/15 * * * *");
+    expect(c.minutes).toEqual([0, 15, 30, 45]);
+  });
+
+  it("parses a range+step expression '0-30/10' in minutes", () => {
+    const c = parseCron("0-30/10 * * * *");
+    expect(c.minutes).toEqual([0, 10, 20, 30]);
+  });
+
+  it("parses a comma-separated list '0,15,30,45' in minutes", () => {
+    const c = parseCron("0,15,30,45 * * * *");
+    expect(c.minutes).toEqual([0, 15, 30, 45]);
+  });
+
+  it("parses mixed comma-list with range '0,10-12,30' in minutes", () => {
+    const c = parseCron("0,10-12,30 * * * *");
+    expect(c.minutes).toContain(0);
+    expect(c.minutes).toContain(10);
+    expect(c.minutes).toContain(11);
+    expect(c.minutes).toContain(12);
+    expect(c.minutes).toContain(30);
+  });
+
+  it("trims leading/trailing whitespace", () => {
+    expect(() => parseCron("  * * * * *  ")).not.toThrow();
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseCron("")).toThrow(/empty/i);
+  });
+
+  it("throws on fewer than 5 fields", () => {
+    expect(() => parseCron("* * * *")).toThrow(/5 fields/);
+  });
+
+  it("throws on more than 5 fields", () => {
+    expect(() => parseCron("* * * * * *")).toThrow(/5 fields/);
+  });
+
+  it("throws when minute is out of range (60)", () => {
+    expect(() => parseCron("60 * * * *")).toThrow();
+  });
+
+  it("throws when hour is out of range (24)", () => {
+    expect(() => parseCron("* 24 * * *")).toThrow();
+  });
+
+  it("throws when month is out of range (0)", () => {
+    expect(() => parseCron("* * * 0 *")).toThrow();
+  });
+
+  it("throws when month is out of range (13)", () => {
+    expect(() => parseCron("* * * 13 *")).toThrow();
+  });
+
+  it("throws when dayOfWeek is out of range (7)", () => {
+    expect(() => parseCron("* * * * 7")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCron
+// ---------------------------------------------------------------------------
+
+describe("validateCron", () => {
+  it("returns null for a valid expression", () => {
+    expect(validateCron("* * * * *")).toBeNull();
+    expect(validateCron("0 9 * * 1-5")).toBeNull();
+    expect(validateCron("*/5 * * * *")).toBeNull();
+  });
+
+  it("returns an error string for an empty expression", () => {
+    const result = validateCron("");
+    expect(typeof result).toBe("string");
+    expect(result!.length).toBeGreaterThan(0);
+  });
+
+  it("returns an error string for a 4-field expression", () => {
+    const result = validateCron("* * * *");
+    expect(typeof result).toBe("string");
+  });
+
+  it("returns an error string when minute is out of range", () => {
+    const result = validateCron("60 * * * *");
+    expect(typeof result).toBe("string");
+  });
+
+  it("returns an error string when hour is out of range", () => {
+    const result = validateCron("* 25 * * *");
+    expect(typeof result).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nextCronTick
+// ---------------------------------------------------------------------------
+
+describe("nextCronTick", () => {
+  it("returns the next minute for '* * * * *' (every minute)", () => {
+    const cron = parseCron("* * * * *");
+    const after = utc(2024, 1, 15, 10, 30);
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCHours()).toBe(10);
+    expect(next!.getUTCMinutes()).toBe(31);
+  });
+
+  it("returns next matching minute within the same hour", () => {
+    const cron = parseCron("0,15,30,45 * * * *");
+    const after = utc(2024, 1, 15, 10, 20);
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCMinutes()).toBe(30);
+    expect(next!.getUTCHours()).toBe(10);
+  });
+
+  it("wraps to the next hour when no more matching minutes in the current hour", () => {
+    const cron = parseCron("0 * * * *");
+    const after = utc(2024, 1, 15, 10, 0); // already at :00, so next is 11:00
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCHours()).toBe(11);
+    expect(next!.getUTCMinutes()).toBe(0);
+  });
+
+  it("skips to next matching hour when the current hour does not match", () => {
+    const cron = parseCron("0 9 * * *");
+    const after = utc(2024, 1, 15, 8, 0);
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCHours()).toBe(9);
+    expect(next!.getUTCMinutes()).toBe(0);
+  });
+
+  it("advances to the next day when hour does not match today", () => {
+    const cron = parseCron("0 6 * * *");
+    const after = utc(2024, 1, 15, 10, 0); // past 6am
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCDate()).toBe(16);
+    expect(next!.getUTCHours()).toBe(6);
+  });
+
+  it("respects day-of-week constraints", () => {
+    // 0 9 * * 1 = every Monday at 09:00 UTC
+    const cron = parseCron("0 9 * * 1");
+    const after = utc(2024, 1, 15, 9, 0); // 2024-01-15 is a Monday at 09:00 UTC
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    // Next Monday is 2024-01-22
+    expect(next!.getUTCFullYear()).toBe(2024);
+    expect(next!.getUTCMonth() + 1).toBe(1);
+    expect(next!.getUTCDate()).toBe(22);
+    expect(next!.getUTCHours()).toBe(9);
+  });
+
+  it("respects day-of-month constraints", () => {
+    // 0 0 1 * * = first of every month at midnight
+    const cron = parseCron("0 0 1 * *");
+    const after = utc(2024, 1, 15);
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCDate()).toBe(1);
+    expect(next!.getUTCMonth() + 1).toBe(2); // February
+  });
+
+  it("respects month constraints", () => {
+    // 0 0 1 6 * = June 1 at midnight
+    const cron = parseCron("0 0 1 6 *");
+    const after = utc(2024, 1, 15);
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCMonth() + 1).toBe(6);
+    expect(next!.getUTCDate()).toBe(1);
+  });
+
+  it("handles @daily equivalent '0 0 * * *'", () => {
+    const cron = parseCron("0 0 * * *");
+    const after = utc(2024, 3, 10, 12, 0);
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCDate()).toBe(11);
+    expect(next!.getUTCHours()).toBe(0);
+    expect(next!.getUTCMinutes()).toBe(0);
+  });
+
+  it("handles @weekly equivalent '0 0 * * 0' (Sunday)", () => {
+    const cron = parseCron("0 0 * * 0");
+    const after = utc(2024, 1, 15, 0, 0); // Monday 2024-01-15
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCDay()).toBe(0); // Sunday
+  });
+
+  it("handles step expression '*/5 * * * *'", () => {
+    const cron = parseCron("*/5 * * * *");
+    const after = utc(2024, 1, 15, 10, 7);
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCMinutes()).toBe(10);
+  });
+
+  it("always returns a time strictly after the reference", () => {
+    const cron = parseCron("* * * * *");
+    const after = utc(2024, 6, 15, 12, 30);
+    const next = nextCronTick(cron, after);
+    expect(next!.getTime()).toBeGreaterThan(after.getTime());
+  });
+
+  it("returns a Date with seconds and ms zeroed", () => {
+    const cron = parseCron("* * * * *");
+    const after = utc(2024, 1, 15, 10, 30);
+    const next = nextCronTick(cron, after);
+    expect(next!.getUTCSeconds()).toBe(0);
+    expect(next!.getUTCMilliseconds()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nextCronTickFromExpression
+// ---------------------------------------------------------------------------
+
+describe("nextCronTickFromExpression", () => {
+  it("returns the next cron tick for a valid expression", () => {
+    const after = utc(2024, 1, 15, 10, 30);
+    const next = nextCronTickFromExpression("*/30 * * * *", after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCMinutes()).toBe(0);
+    expect(next!.getUTCHours()).toBe(11);
+  });
+
+  it("throws for an invalid expression", () => {
+    expect(() => nextCronTickFromExpression("not a cron", utc(2024, 1, 1))).toThrow();
+  });
+
+  it("uses current time when no 'after' argument is given", () => {
+    const before = new Date();
+    const next = nextCronTickFromExpression("* * * * *");
+    expect(next).not.toBeNull();
+    expect(next!.getTime()).toBeGreaterThan(before.getTime());
+  });
+});

--- a/server/src/__tests__/default-agent-instructions.test.ts
+++ b/server/src/__tests__/default-agent-instructions.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveDefaultAgentInstructionsBundleRole,
+  loadDefaultAgentInstructionsBundle,
+} from "../services/default-agent-instructions.js";
+
+describe("resolveDefaultAgentInstructionsBundleRole", () => {
+  it("returns 'ceo' for role 'ceo'", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("ceo")).toBe("ceo");
+  });
+
+  it("returns 'default' for any non-ceo role", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("engineer")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("cto")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("manager")).toBe("default");
+    expect(resolveDefaultAgentInstructionsBundleRole("")).toBe("default");
+  });
+
+  it("is case-sensitive — 'CEO' is not the same as 'ceo'", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("CEO")).toBe("default");
+  });
+});
+
+describe("loadDefaultAgentInstructionsBundle", () => {
+  it("loads the default bundle containing AGENTS.md", async () => {
+    const bundle = await loadDefaultAgentInstructionsBundle("default");
+    expect(bundle).toHaveProperty("AGENTS.md");
+    expect(typeof bundle["AGENTS.md"]).toBe("string");
+    expect(bundle["AGENTS.md"].length).toBeGreaterThan(0);
+  });
+
+  it("loads the ceo bundle containing all four files", async () => {
+    const bundle = await loadDefaultAgentInstructionsBundle("ceo");
+    expect(bundle).toHaveProperty("AGENTS.md");
+    expect(bundle).toHaveProperty("HEARTBEAT.md");
+    expect(bundle).toHaveProperty("SOUL.md");
+    expect(bundle).toHaveProperty("TOOLS.md");
+    for (const content of Object.values(bundle)) {
+      expect(typeof content).toBe("string");
+      expect(content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("default bundle only contains AGENTS.md (not ceo files)", async () => {
+    const bundle = await loadDefaultAgentInstructionsBundle("default");
+    expect(Object.keys(bundle)).toEqual(["AGENTS.md"]);
+  });
+});

--- a/server/src/__tests__/feedback-redaction.test.ts
+++ b/server/src/__tests__/feedback-redaction.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from "vitest";
+import {
+  createFeedbackRedactionState,
+  sanitizeFeedbackText,
+  sanitizeFeedbackValue,
+  finalizeFeedbackRedactionSummary,
+  stableStringify,
+  sha256Digest,
+} from "../services/feedback-redaction.js";
+
+// ---------------------------------------------------------------------------
+// createFeedbackRedactionState
+// ---------------------------------------------------------------------------
+
+describe("createFeedbackRedactionState", () => {
+  it("returns empty sets and map", () => {
+    const state = createFeedbackRedactionState();
+    expect(state.redactedFields.size).toBe(0);
+    expect(state.truncatedFields.size).toBe(0);
+    expect(state.omittedFields.size).toBe(0);
+    expect(state.notes.size).toBe(0);
+    expect(state.counts.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeFeedbackText — pattern redaction
+// ---------------------------------------------------------------------------
+
+describe("sanitizeFeedbackText", () => {
+  function redact(input: string, maxLength = 10_000) {
+    const state = createFeedbackRedactionState();
+    const output = sanitizeFeedbackText(input, state, "field", maxLength);
+    return { output, state };
+  }
+
+  it("passes through text with no sensitive content unchanged", () => {
+    const { output } = redact("Hello, world!");
+    expect(output).toBe("Hello, world!");
+  });
+
+  it("redacts PEM block", () => {
+    const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAK==\n-----END RSA PRIVATE KEY-----";
+    const { output, state } = redact(pem);
+    expect(output).toContain("[REDACTED_PEM_BLOCK]");
+    expect(output).not.toContain("MIIEowIBAAK");
+    expect(state.counts.get("pem_block")).toBe(1);
+  });
+
+  it("redacts secret key assignments", () => {
+    const { output, state } = redact("api_key=super-secret-value and password=hunter2");
+    expect(output).toContain("api_key=[REDACTED]");
+    expect(output).toContain("password=[REDACTED]");
+    expect(output).not.toContain("super-secret-value");
+    expect(state.counts.get("secret_assignment")).toBeGreaterThanOrEqual(2);
+  });
+
+  it("redacts bearer tokens", () => {
+    // Avoid "Authorization:" prefix — that triggers secret_assignment first
+    const { output, state } = redact("header value: Bearer eyJhbGciOiJIUzI1NiJ9.payload.sig");
+    expect(output).toContain("Bearer [REDACTED_TOKEN]");
+    expect(state.counts.get("bearer_token")).toBeGreaterThanOrEqual(1);
+  });
+
+  it("redacts GitHub tokens (ghp_ prefix)", () => {
+    const { output, state } = redact("token: ghp_A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6");
+    expect(output).toContain("[REDACTED_GITHUB_TOKEN]");
+    expect(state.counts.get("github_token")).toBe(1);
+  });
+
+  it("redacts GitHub OAuth tokens (gho_ prefix)", () => {
+    // Use a prefix that won't trigger the secret_assignment pattern first
+    const { output } = redact("found gho_A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6 in logs");
+    expect(output).toContain("[REDACTED_GITHUB_TOKEN]");
+  });
+
+  it("redacts Anthropic/OpenAI API keys (sk- prefix)", () => {
+    const { output, state } = redact("key=sk-ant-api03-ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    expect(output).toContain("[REDACTED_API_KEY]");
+    expect(state.counts.get("provider_api_key")).toBe(1);
+  });
+
+  it("redacts JWT tokens (three-part dot structure)", () => {
+    const { output, state } = redact("token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+    expect(output).toContain("[REDACTED_JWT]");
+    expect(state.counts.get("jwt")).toBeGreaterThanOrEqual(1);
+  });
+
+  it("redacts database connection strings", () => {
+    const { output, state } = redact("postgres://user:pass@host:5432/mydb");
+    expect(output).toContain("[REDACTED_CONNECTION_STRING]");
+    expect(state.counts.get("dsn")).toBe(1);
+  });
+
+  it("redacts mongodb+srv connection strings", () => {
+    const { output } = redact("mongodb+srv://user:pass@cluster.mongodb.net/db");
+    expect(output).toContain("[REDACTED_CONNECTION_STRING]");
+  });
+
+  it("redacts email addresses", () => {
+    const { output, state } = redact("Contact: alice@example.com for help");
+    expect(output).toContain("[REDACTED_EMAIL]");
+    expect(output).not.toContain("alice@example.com");
+    expect(state.counts.get("email")).toBe(1);
+  });
+
+  it("redacts phone numbers", () => {
+    const { output, state } = redact("Call +1 (555) 867-5309 for support");
+    expect(output).toContain("[REDACTED_PHONE]");
+    expect(state.counts.get("phone")).toBe(1);
+  });
+
+  it("records the field path when redaction occurs", () => {
+    const state = createFeedbackRedactionState();
+    sanitizeFeedbackText("api_key=secret", state, "config.apiKey", 10_000);
+    expect(state.redactedFields.has("config.apiKey")).toBe(true);
+  });
+
+  it("does not record field path when nothing is redacted", () => {
+    const { state } = redact("plain text with no secrets");
+    expect(state.redactedFields.size).toBe(0);
+  });
+
+  it("truncates text exceeding maxLength and records the field", () => {
+    const state = createFeedbackRedactionState();
+    const long = "a".repeat(100);
+    const output = sanitizeFeedbackText(long, state, "body", 10);
+    // Implementation: slice(0, maxLength-1) + "..." = (maxLength-1) + 3 chars
+    expect(output).toMatch(/\.\.\.$/);
+    expect(output.length).toBeLessThan(100);
+    expect(state.truncatedFields.has("body")).toBe(true);
+  });
+
+  it("does not truncate text shorter than maxLength", () => {
+    const state = createFeedbackRedactionState();
+    const text = "short";
+    const output = sanitizeFeedbackText(text, state, "body", 1000);
+    expect(output).toBe(text);
+    expect(state.truncatedFields.size).toBe(0);
+  });
+
+  it("handles multiple patterns on a single input", () => {
+    const { output, state } = redact(
+      "api_key=abc123 and email user@test.com with postgres://x:y@host/db"
+    );
+    expect(output).not.toContain("abc123");
+    expect(output).not.toContain("user@test.com");
+    expect(output).not.toContain("postgres://");
+    expect(state.counts.size).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeFeedbackValue
+// ---------------------------------------------------------------------------
+
+describe("sanitizeFeedbackValue", () => {
+  function redactValue(value: unknown, maxLength = 10_000) {
+    const state = createFeedbackRedactionState();
+    const output = sanitizeFeedbackValue(value, state, "root", maxLength);
+    return { output, state };
+  }
+
+  it("sanitizes string values", () => {
+    const { output } = redactValue("api_key=secret");
+    expect(output).toContain("[REDACTED]");
+  });
+
+  it("passes through non-string primitives unchanged", () => {
+    expect(redactValue(42).output).toBe(42);
+    expect(redactValue(true).output).toBe(true);
+    expect(redactValue(null).output).toBeNull();
+  });
+
+  it("sanitizes strings inside arrays", () => {
+    const { output } = redactValue(["api_key=secret", "safe text"]);
+    const arr = output as string[];
+    expect(arr[0]).toContain("[REDACTED]");
+    expect(arr[1]).toBe("safe text");
+  });
+
+  it("recursively sanitizes nested plain objects", () => {
+    const { output } = redactValue({ nested: { token: "ghp_A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6" } });
+    const obj = output as Record<string, unknown>;
+    expect(JSON.stringify(obj)).not.toContain("ghp_");
+  });
+
+  it("redacts object keys matching secret patterns via sanitizeRecord", () => {
+    const { output, state } = redactValue({ api_key: "my-secret" });
+    const obj = output as Record<string, unknown>;
+    expect(obj["api_key"]).not.toBe("my-secret");
+    expect(state.counts.get("structured_secret")).toBe(1);
+  });
+
+  it("handles nested arrays with mixed content", () => {
+    const { output } = redactValue([42, "api_key=sec", { safe: "value" }]);
+    const arr = output as unknown[];
+    expect(arr[0]).toBe(42);
+    expect(arr[1]).toContain("[REDACTED]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// finalizeFeedbackRedactionSummary
+// ---------------------------------------------------------------------------
+
+describe("finalizeFeedbackRedactionSummary", () => {
+  it("returns sorted, serializable summary", () => {
+    const state = createFeedbackRedactionState();
+    state.redactedFields.add("b.field");
+    state.redactedFields.add("a.field");
+    state.truncatedFields.add("c.field");
+    state.counts.set("email", 2);
+    state.counts.set("bearer_token", 1);
+
+    const summary = finalizeFeedbackRedactionSummary(state);
+    expect(summary.strategy).toBe("deterministic_feedback_v2");
+    expect(summary.redactedFields).toEqual(["a.field", "b.field"]);
+    expect(summary.truncatedFields).toEqual(["c.field"]);
+    expect(summary.counts).toEqual({ bearer_token: 1, email: 2 });
+  });
+
+  it("returns empty arrays and object when state is empty", () => {
+    const summary = finalizeFeedbackRedactionSummary(createFeedbackRedactionState());
+    expect(summary.redactedFields).toEqual([]);
+    expect(summary.truncatedFields).toEqual([]);
+    expect(summary.omittedFields).toEqual([]);
+    expect(summary.notes).toEqual([]);
+    expect(summary.counts).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stableStringify
+// ---------------------------------------------------------------------------
+
+describe("stableStringify", () => {
+  it("serializes primitives the same as JSON.stringify", () => {
+    expect(stableStringify(null)).toBe("null");
+    expect(stableStringify(42)).toBe("42");
+    expect(stableStringify("hello")).toBe('"hello"');
+    expect(stableStringify(true)).toBe("true");
+  });
+
+  it("serializes arrays in order", () => {
+    expect(stableStringify([1, 2, 3])).toBe("[1,2,3]");
+    expect(stableStringify(["b", "a"])).toBe('["b","a"]');
+  });
+
+  it("sorts object keys alphabetically", () => {
+    const result = stableStringify({ z: 1, a: 2, m: 3 });
+    expect(result).toBe('{"a":2,"m":3,"z":1}');
+  });
+
+  it("produces identical output for objects with same content in different key order", () => {
+    const a = stableStringify({ b: 2, a: 1 });
+    const b = stableStringify({ a: 1, b: 2 });
+    expect(a).toBe(b);
+  });
+
+  it("handles nested objects and arrays", () => {
+    const result = stableStringify({ arr: [3, 1, 2], obj: { z: "last", a: "first" } });
+    expect(result).toBe('{"arr":[3,1,2],"obj":{"a":"first","z":"last"}}');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sha256Digest
+// ---------------------------------------------------------------------------
+
+describe("sha256Digest", () => {
+  it("returns a 64-character hex string", () => {
+    const digest = sha256Digest("hello");
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(sha256Digest({ a: 1, b: 2 })).toBe(sha256Digest({ b: 2, a: 1 }));
+  });
+
+  it("produces different digests for different inputs", () => {
+    expect(sha256Digest("hello")).not.toBe(sha256Digest("world"));
+  });
+
+  it("works with null", () => {
+    const digest = sha256Digest(null);
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/server/src/__tests__/issue-assignment-wakeup.test.ts
+++ b/server/src/__tests__/issue-assignment-wakeup.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi } from "vitest";
+import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeWakeup() {
+  return vi.fn().mockResolvedValue(undefined);
+}
+
+function makeIssue(overrides: Partial<{ id: string; assigneeAgentId: string | null; status: string }> = {}) {
+  return { id: "issue-123", assigneeAgentId: "agent-abc", status: "open", ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// queueIssueAssignmentWakeup
+// ---------------------------------------------------------------------------
+
+describe("queueIssueAssignmentWakeup", () => {
+  it("calls wakeup with the correct parameters when assignee is present", async () => {
+    const wakeup = makeWakeup();
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: makeIssue(),
+      reason: "assigned",
+      mutation: "issue.assign",
+      contextSource: "api",
+    });
+    expect(wakeup).toHaveBeenCalledOnce();
+    const [agentId, opts] = wakeup.mock.calls[0] as [string, Record<string, unknown>];
+    expect(agentId).toBe("agent-abc");
+    expect(opts).toMatchObject({
+      source: "assignment",
+      triggerDetail: "system",
+      reason: "assigned",
+      payload: { issueId: "issue-123", mutation: "issue.assign" },
+    });
+  });
+
+  it("includes contextSnapshot with issueId and contextSource", async () => {
+    const wakeup = makeWakeup();
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: makeIssue(),
+      reason: "assigned",
+      mutation: "issue.assign",
+      contextSource: "webhooks",
+    });
+    const opts = wakeup.mock.calls[0]![1] as Record<string, unknown>;
+    expect(opts.contextSnapshot).toEqual({ issueId: "issue-123", source: "webhooks" });
+  });
+
+  it("does NOT call wakeup when assigneeAgentId is null", async () => {
+    const wakeup = makeWakeup();
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: makeIssue({ assigneeAgentId: null }),
+      reason: "assigned",
+      mutation: "issue.assign",
+      contextSource: "api",
+    });
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call wakeup when issue status is 'backlog'", async () => {
+    const wakeup = makeWakeup();
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: makeIssue({ status: "backlog" }),
+      reason: "assigned",
+      mutation: "issue.assign",
+      contextSource: "api",
+    });
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
+  it("passes requestedByActorType and requestedByActorId through to wakeup", async () => {
+    const wakeup = makeWakeup();
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: makeIssue(),
+      reason: "assigned",
+      mutation: "issue.assign",
+      contextSource: "api",
+      requestedByActorType: "user",
+      requestedByActorId: "user-xyz",
+    });
+    const opts = wakeup.mock.calls[0]![1] as Record<string, unknown>;
+    expect(opts.requestedByActorType).toBe("user");
+    expect(opts.requestedByActorId).toBe("user-xyz");
+  });
+
+  it("defaults requestedByActorId to null when not provided", async () => {
+    const wakeup = makeWakeup();
+    await queueIssueAssignmentWakeup({
+      heartbeat: { wakeup },
+      issue: makeIssue(),
+      reason: "assigned",
+      mutation: "issue.assign",
+      contextSource: "api",
+    });
+    const opts = wakeup.mock.calls[0]![1] as Record<string, unknown>;
+    expect(opts.requestedByActorId).toBeNull();
+  });
+
+  it("swallows errors by default (rethrowOnError=false)", async () => {
+    const wakeup = vi.fn().mockRejectedValue(new Error("queue unavailable"));
+    await expect(
+      queueIssueAssignmentWakeup({
+        heartbeat: { wakeup },
+        issue: makeIssue(),
+        reason: "assigned",
+        mutation: "issue.assign",
+        contextSource: "api",
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("rethrows errors when rethrowOnError=true", async () => {
+    const wakeup = vi.fn().mockRejectedValue(new Error("queue unavailable"));
+    await expect(
+      queueIssueAssignmentWakeup({
+        heartbeat: { wakeup },
+        issue: makeIssue(),
+        reason: "assigned",
+        mutation: "issue.assign",
+        contextSource: "api",
+        rethrowOnError: true,
+      }),
+    ).rejects.toThrow("queue unavailable");
+  });
+});

--- a/server/src/__tests__/live-events.test.ts
+++ b/server/src/__tests__/live-events.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import {
+  publishLiveEvent,
+  publishGlobalLiveEvent,
+  subscribeCompanyLiveEvents,
+  subscribeGlobalLiveEvents,
+} from "../services/live-events.js";
+import type { LiveEvent } from "@paperclipai/shared";
+
+// ---------------------------------------------------------------------------
+// publishLiveEvent
+// ---------------------------------------------------------------------------
+
+describe("publishLiveEvent", () => {
+  it("returns an event object with the correct shape", () => {
+    const event = publishLiveEvent({
+      companyId: "co-1",
+      type: "agent.status",
+      payload: { status: "active" },
+    });
+    expect(event.companyId).toBe("co-1");
+    expect(event.type).toBe("agent.status");
+    expect(event.payload).toEqual({ status: "active" });
+    expect(typeof event.id).toBe("number");
+    expect(typeof event.createdAt).toBe("string");
+  });
+
+  it("defaults payload to an empty object when omitted", () => {
+    const event = publishLiveEvent({ companyId: "co-1", type: "agent.status" });
+    expect(event.payload).toEqual({});
+  });
+
+  it("increments the event id with each call", () => {
+    const e1 = publishLiveEvent({ companyId: "co-1", type: "agent.status" });
+    const e2 = publishLiveEvent({ companyId: "co-1", type: "agent.status" });
+    expect(e2.id).toBe(e1.id + 1);
+  });
+
+  it("delivers the event to a subscribed company listener", () => {
+    const received: LiveEvent[] = [];
+    const unsubscribe = subscribeCompanyLiveEvents("co-deliver", (e) => received.push(e));
+
+    publishLiveEvent({ companyId: "co-deliver", type: "activity.logged" });
+
+    unsubscribe();
+    expect(received).toHaveLength(1);
+    expect(received[0].type).toBe("activity.logged");
+  });
+
+  it("does NOT deliver to a listener for a different company", () => {
+    const received: LiveEvent[] = [];
+    const unsubscribe = subscribeCompanyLiveEvents("co-other", (e) => received.push(e));
+
+    publishLiveEvent({ companyId: "co-isolated", type: "agent.status" });
+
+    unsubscribe();
+    expect(received).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// publishGlobalLiveEvent
+// ---------------------------------------------------------------------------
+
+describe("publishGlobalLiveEvent", () => {
+  it("returns an event with companyId='*'", () => {
+    const event = publishGlobalLiveEvent({ type: "plugin.ui.updated" });
+    expect(event.companyId).toBe("*");
+    expect(event.type).toBe("plugin.ui.updated");
+  });
+
+  it("delivers the event to a global subscriber", () => {
+    const received: LiveEvent[] = [];
+    const unsubscribe = subscribeGlobalLiveEvents((e) => received.push(e));
+
+    publishGlobalLiveEvent({ type: "plugin.worker.crashed", payload: { pluginId: "x" } });
+
+    unsubscribe();
+    expect(received).toHaveLength(1);
+    expect(received[0].payload).toEqual({ pluginId: "x" });
+  });
+
+  it("does NOT deliver to a company-scoped subscriber", () => {
+    const received: LiveEvent[] = [];
+    const unsubscribe = subscribeCompanyLiveEvents("co-global-check", (e) => received.push(e));
+
+    publishGlobalLiveEvent({ type: "agent.status" });
+
+    unsubscribe();
+    expect(received).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subscribeCompanyLiveEvents — unsubscribe
+// ---------------------------------------------------------------------------
+
+describe("subscribeCompanyLiveEvents (unsubscribe)", () => {
+  it("stops receiving events after unsubscribe is called", () => {
+    const received: LiveEvent[] = [];
+    const unsubscribe = subscribeCompanyLiveEvents("co-unsub", (e) => received.push(e));
+
+    publishLiveEvent({ companyId: "co-unsub", type: "agent.status" });
+    unsubscribe();
+    publishLiveEvent({ companyId: "co-unsub", type: "agent.status" });
+
+    expect(received).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subscribeGlobalLiveEvents — unsubscribe
+// ---------------------------------------------------------------------------
+
+describe("subscribeGlobalLiveEvents (unsubscribe)", () => {
+  it("stops receiving events after unsubscribe is called", () => {
+    const received: LiveEvent[] = [];
+    const unsubscribe = subscribeGlobalLiveEvents((e) => received.push(e));
+
+    publishGlobalLiveEvent({ type: "agent.status" });
+    unsubscribe();
+    publishGlobalLiveEvent({ type: "agent.status" });
+
+    expect(received).toHaveLength(1);
+  });
+
+  it("multiple subscribers receive the same global event independently", () => {
+    const r1: LiveEvent[] = [];
+    const r2: LiveEvent[] = [];
+    const u1 = subscribeGlobalLiveEvents((e) => r1.push(e));
+    const u2 = subscribeGlobalLiveEvents((e) => r2.push(e));
+
+    publishGlobalLiveEvent({ type: "agent.status" });
+
+    u1();
+    u2();
+    expect(r1).toHaveLength(1);
+    expect(r2).toHaveLength(1);
+  });
+});

--- a/server/src/__tests__/plugin-capability-scoped-invoker.test.ts
+++ b/server/src/__tests__/plugin-capability-scoped-invoker.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  createCapabilityScopedInvoker,
+  PluginSandboxError,
+} from "../services/plugin-runtime-sandbox.js";
+import { pluginManifestValidator } from "../services/plugin-manifest-validator.js";
+import { pluginCapabilityValidator } from "../services/plugin-capability-validator.js";
+import { PLUGIN_API_VERSION } from "@paperclipai/shared";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mv = pluginManifestValidator();
+const cv = pluginCapabilityValidator();
+
+function makeManifest(capabilities: string[]): PaperclipPluginManifestV1 {
+  return mv.parseOrThrow({
+    id: "test-plugin",
+    apiVersion: PLUGIN_API_VERSION,
+    version: "1.0.0",
+    displayName: "Test",
+    description: "test",
+    author: "Acme",
+    categories: ["connector"],
+    capabilities,
+    entrypoints: { worker: "dist/worker.js" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// PluginSandboxError
+// ---------------------------------------------------------------------------
+
+describe("PluginSandboxError", () => {
+  it("is an instance of Error", () => {
+    const err = new PluginSandboxError("oops");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("has the correct name and message", () => {
+    const err = new PluginSandboxError("sandbox violation");
+    expect(err.name).toBe("PluginSandboxError");
+    expect(err.message).toBe("sandbox violation");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createCapabilityScopedInvoker
+// ---------------------------------------------------------------------------
+
+describe("createCapabilityScopedInvoker", () => {
+  it("invokes the function and returns its result when the capability check passes", async () => {
+    const manifest = makeManifest(["issues.read"]);
+    const invoker = createCapabilityScopedInvoker(manifest, cv);
+    const result = await invoker.invoke("issues.list", () => Promise.resolve("ok"));
+    expect(result).toBe("ok");
+  });
+
+  it("works with synchronous functions", async () => {
+    const manifest = makeManifest(["issues.read"]);
+    const invoker = createCapabilityScopedInvoker(manifest, cv);
+    const result = await invoker.invoke("issues.list", () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("throws (403) when the plugin lacks the required capability", async () => {
+    const manifest = makeManifest(["issues.read"]);
+    const invoker = createCapabilityScopedInvoker(manifest, cv);
+    await expect(invoker.invoke("issues.create", () => Promise.resolve("never"))).rejects.toThrow();
+  });
+
+  it("throws for an unknown operation (rejected by default)", async () => {
+    const manifest = makeManifest(["issues.read"]);
+    const invoker = createCapabilityScopedInvoker(manifest, cv);
+    await expect(invoker.invoke("unknown.operation", () => Promise.resolve("x"))).rejects.toThrow();
+  });
+
+  it("calls the function exactly once when it passes", async () => {
+    const manifest = makeManifest(["issues.read"]);
+    const invoker = createCapabilityScopedInvoker(manifest, cv);
+    const fn = vi.fn().mockResolvedValue("result");
+    await invoker.invoke("issues.list", fn);
+    expect(fn).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT call the function when the capability check fails", async () => {
+    const manifest = makeManifest(["issues.read"]);
+    const invoker = createCapabilityScopedInvoker(manifest, cv);
+    const fn = vi.fn().mockResolvedValue("result");
+    await expect(invoker.invoke("issues.create", fn)).rejects.toThrow();
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/plugin-capability-validator.test.ts
+++ b/server/src/__tests__/plugin-capability-validator.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from "vitest";
+import { pluginCapabilityValidator } from "../services/plugin-capability-validator.js";
+import { pluginManifestValidator } from "../services/plugin-manifest-validator.js";
+import { PLUGIN_API_VERSION } from "@paperclipai/shared";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mv = pluginManifestValidator();
+
+function makeManifest(capabilities: string[], overrides: Record<string, unknown> = {}): PaperclipPluginManifestV1 {
+  return mv.parseOrThrow({
+    id: "test-plugin",
+    apiVersion: PLUGIN_API_VERSION,
+    version: "1.0.0",
+    displayName: "Test Plugin",
+    description: "A plugin for testing",
+    author: "Acme",
+    categories: ["connector"],
+    capabilities,
+    entrypoints: { worker: "dist/worker.js" },
+    ...overrides,
+  });
+}
+
+const cv = pluginCapabilityValidator();
+
+// ---------------------------------------------------------------------------
+// hasCapability
+// ---------------------------------------------------------------------------
+
+describe("hasCapability", () => {
+  it("returns true when the capability is declared", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(cv.hasCapability(m, "issues.read")).toBe(true);
+  });
+
+  it("returns false when the capability is not declared", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(cv.hasCapability(m, "issues.create")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasAllCapabilities
+// ---------------------------------------------------------------------------
+
+describe("hasAllCapabilities", () => {
+  it("returns allowed=true when all capabilities are present", () => {
+    const m = makeManifest(["issues.read", "issues.create"]);
+    const result = cv.hasAllCapabilities(m, ["issues.read", "issues.create"]);
+    expect(result.allowed).toBe(true);
+    expect(result.missing).toEqual([]);
+  });
+
+  it("returns allowed=false with the missing list when any capability is absent", () => {
+    const m = makeManifest(["issues.read"]);
+    const result = cv.hasAllCapabilities(m, ["issues.read", "issues.create"]);
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain("issues.create");
+  });
+
+  it("returns allowed=true for an empty required list", () => {
+    const m = makeManifest(["issues.read"]);
+    const result = cv.hasAllCapabilities(m, []);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("includes pluginId in the result", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(cv.hasAllCapabilities(m, ["issues.read"]).pluginId).toBe("test-plugin");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasAnyCapability
+// ---------------------------------------------------------------------------
+
+describe("hasAnyCapability", () => {
+  it("returns true when at least one capability is declared", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(cv.hasAnyCapability(m, ["issues.create", "issues.read"])).toBe(true);
+  });
+
+  it("returns false when none of the capabilities are declared", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(cv.hasAnyCapability(m, ["issues.create", "issues.update"])).toBe(false);
+  });
+
+  it("returns false for an empty capability list", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(cv.hasAnyCapability(m, [])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkOperation
+// ---------------------------------------------------------------------------
+
+describe("checkOperation", () => {
+  it("returns allowed=true when the plugin has all required capabilities", () => {
+    const m = makeManifest(["issues.read"]);
+    const result = cv.checkOperation(m, "issues.list");
+    expect(result.allowed).toBe(true);
+    expect(result.missing).toEqual([]);
+  });
+
+  it("returns allowed=false when a required capability is missing", () => {
+    const m = makeManifest(["issues.read"]);
+    const result = cv.checkOperation(m, "issues.create");
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain("issues.create");
+  });
+
+  it("returns allowed=false for an unknown operation", () => {
+    const m = makeManifest(["issues.read"]);
+    const result = cv.checkOperation(m, "unknown.operation");
+    expect(result.allowed).toBe(false);
+  });
+
+  it("includes operation and pluginId in the result", () => {
+    const m = makeManifest(["issues.read"]);
+    const result = cv.checkOperation(m, "issues.list");
+    expect(result.operation).toBe("issues.list");
+    expect(result.pluginId).toBe("test-plugin");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertOperation
+// ---------------------------------------------------------------------------
+
+describe("assertOperation", () => {
+  it("does not throw when the plugin has the required capability", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(() => cv.assertOperation(m, "issues.list")).not.toThrow();
+  });
+
+  it("throws when a required capability is missing", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(() => cv.assertOperation(m, "issues.create")).toThrow();
+  });
+
+  it("throws for an unknown operation", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(() => cv.assertOperation(m, "unknown.operation")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertCapability
+// ---------------------------------------------------------------------------
+
+describe("assertCapability", () => {
+  it("does not throw when capability is present", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(() => cv.assertCapability(m, "issues.read")).not.toThrow();
+  });
+
+  it("throws when capability is missing", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(() => cv.assertCapability(m, "issues.create")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkUiSlot
+// ---------------------------------------------------------------------------
+
+describe("checkUiSlot", () => {
+  it("returns allowed=true when the plugin has the required UI slot capability", () => {
+    const m = makeManifest(["ui.sidebar.register"]);
+    const result = cv.checkUiSlot(m, "sidebar");
+    expect(result.allowed).toBe(true);
+    expect(result.missing).toEqual([]);
+  });
+
+  it("returns allowed=false when the required UI slot capability is missing", () => {
+    const m = makeManifest(["issues.read"]);
+    const result = cv.checkUiSlot(m, "page");
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain("ui.page.register");
+  });
+
+  it("returns allowed=false for an unknown slot type", () => {
+    const m = makeManifest(["issues.read"]);
+    const result = cv.checkUiSlot(m, "unknown-slot" as never);
+    expect(result.allowed).toBe(false);
+  });
+
+  it("includes operation name in result", () => {
+    const m = makeManifest(["ui.sidebar.register"]);
+    const result = cv.checkUiSlot(m, "sidebar");
+    expect(result.operation).toContain("sidebar");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateManifestCapabilities
+// ---------------------------------------------------------------------------
+
+describe("validateManifestCapabilities", () => {
+  it("returns allowed=true for a manifest with no declared features", () => {
+    const m = makeManifest(["issues.read"]);
+    const result = cv.validateManifestCapabilities(m);
+    expect(result.allowed).toBe(true);
+    expect(result.missing).toEqual([]);
+  });
+
+  const sampleTool = {
+    name: "my_tool",
+    displayName: "My Tool",
+    description: "does stuff",
+    parametersSchema: { type: "object", properties: {}, required: [] },
+  };
+
+  it("returns allowed=true when tools are declared with agent.tools.register capability", () => {
+    const m = makeManifest(["agent.tools.register"], { tools: [sampleTool] });
+    const result = cv.validateManifestCapabilities(m);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("returns allowed=false when tools are declared without agent.tools.register (cast bypass)", () => {
+    // The Zod schema normally enforces the capability, but the capability validator
+    // is also responsible for enforcing it independently. We construct the invalid
+    // state via type casting to test the validator's own logic.
+    const m = {
+      ...makeManifest(["issues.read"]),
+      tools: [sampleTool],
+    } as PaperclipPluginManifestV1;
+    const result = cv.validateManifestCapabilities(m);
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain("agent.tools.register");
+  });
+
+  it("includes pluginId in the result", () => {
+    const m = makeManifest(["issues.read"]);
+    expect(cv.validateManifestCapabilities(m).pluginId).toBe("test-plugin");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRequiredCapabilities
+// ---------------------------------------------------------------------------
+
+describe("getRequiredCapabilities", () => {
+  it("returns the required capabilities for a known operation", () => {
+    const caps = cv.getRequiredCapabilities("issues.list");
+    expect(caps).toContain("issues.read");
+  });
+
+  it("returns an empty array for an unknown operation", () => {
+    const caps = cv.getRequiredCapabilities("unknown.op");
+    expect(caps).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUiSlotCapability
+// ---------------------------------------------------------------------------
+
+describe("getUiSlotCapability", () => {
+  it("returns the required capability for a known slot type", () => {
+    expect(cv.getUiSlotCapability("sidebar")).toBe("ui.sidebar.register");
+    expect(cv.getUiSlotCapability("page")).toBe("ui.page.register");
+    expect(cv.getUiSlotCapability("detailTab")).toBe("ui.detailTab.register");
+  });
+
+  it("returns undefined for an unknown slot type", () => {
+    expect(cv.getUiSlotCapability("unknown-slot" as never)).toBeUndefined();
+  });
+});

--- a/server/src/__tests__/plugin-config-validator.test.ts
+++ b/server/src/__tests__/plugin-config-validator.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { validateInstanceConfig } from "../services/plugin-config-validator.js";
+
+describe("validateInstanceConfig", () => {
+  it("returns valid=true for config that matches the schema", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { apiKey: { type: "string" } },
+      required: ["apiKey"],
+    };
+    const result = validateInstanceConfig({ apiKey: "my-key" }, schema);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it("returns valid=false when a required property is missing", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { apiKey: { type: "string" } },
+      required: ["apiKey"],
+    };
+    const result = validateInstanceConfig({}, schema);
+    expect(result.valid).toBe(false);
+    expect(Array.isArray(result.errors)).toBe(true);
+    expect(result.errors!.length).toBeGreaterThan(0);
+  });
+
+  it("returns errors with field path and message", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { count: { type: "number" } },
+      required: ["count"],
+    };
+    const result = validateInstanceConfig({ count: "not-a-number" }, schema);
+    expect(result.valid).toBe(false);
+    const err = result.errors![0];
+    expect(err).toHaveProperty("field");
+    expect(err).toHaveProperty("message");
+  });
+
+  it("returns valid=true for an empty config against an empty schema", () => {
+    const result = validateInstanceConfig({}, { type: "object" as const, properties: {} });
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates string format constraints", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { email: { type: "string", format: "email" } },
+      required: ["email"],
+    };
+    const valid = validateInstanceConfig({ email: "user@example.com" }, schema);
+    expect(valid.valid).toBe(true);
+
+    const invalid = validateInstanceConfig({ email: "not-an-email" }, schema);
+    expect(invalid.valid).toBe(false);
+  });
+
+  it("collects all errors when multiple fields are invalid", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        a: { type: "string" },
+        b: { type: "number" },
+      },
+      required: ["a", "b"],
+    };
+    const result = validateInstanceConfig({ a: 123, b: "wrong" }, schema);
+    expect(result.valid).toBe(false);
+    expect(result.errors!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("accepts a secret-ref format value without error", () => {
+    const schema = {
+      type: "object" as const,
+      properties: {
+        secretToken: { type: "string", format: "secret-ref" },
+      },
+      required: ["secretToken"],
+    };
+    // secret-ref is registered as always-valid; any string should pass
+    const result = validateInstanceConfig({ secretToken: "some-uuid-value" }, schema);
+    expect(result.valid).toBe(true);
+  });
+
+  it("uses '/' as field path when the error is at the root level", () => {
+    const schema = { type: "array" as const };
+    // Pass an object where the schema expects an array
+    const result = validateInstanceConfig({} as never, schema as never);
+    expect(result.valid).toBe(false);
+    const rootError = result.errors!.find((e) => e.field === "/");
+    expect(rootError).toBeDefined();
+  });
+});

--- a/server/src/__tests__/plugin-event-bus.test.ts
+++ b/server/src/__tests__/plugin-event-bus.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi } from "vitest";
+import { createPluginEventBus } from "../services/plugin-event-bus.js";
+import type { PluginEvent } from "@paperclipai/plugin-sdk";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeEvent(overrides: Partial<PluginEvent> = {}): PluginEvent {
+  return {
+    eventId: "evt-1",
+    eventType: "issue.created",
+    companyId: "co-1",
+    occurredAt: new Date().toISOString(),
+    actorType: "system",
+    actorId: null,
+    entityType: "issue",
+    entityId: "iss-1",
+    payload: { projectId: "proj-1" },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// emit — basic delivery
+// ---------------------------------------------------------------------------
+
+describe("PluginEventBus.emit (basic delivery)", () => {
+  it("delivers an event to a matching subscriber", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", handler);
+
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ eventType: "issue.created" }));
+  });
+
+  it("does NOT deliver when the event type does not match the subscription pattern", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", handler);
+
+    await bus.emit(makeEvent({ eventType: "agent.status" }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("delivers to multiple plugins subscribed to the same event type", async () => {
+    const bus = createPluginEventBus();
+    const h1 = vi.fn().mockResolvedValue(undefined);
+    const h2 = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", h1);
+    bus.forPlugin("plugin-b").subscribe("issue.created", h2);
+
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(h1).toHaveBeenCalledOnce();
+    expect(h2).toHaveBeenCalledOnce();
+  });
+
+  it("returns errors from misbehaving handlers without disrupting other handlers", async () => {
+    const bus = createPluginEventBus();
+    const throwing = vi.fn().mockRejectedValue(new Error("handler failure"));
+    const ok = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("bad-plugin").subscribe("issue.created", throwing);
+    bus.forPlugin("good-plugin").subscribe("issue.created", ok);
+
+    const result = await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(ok).toHaveBeenCalledOnce();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].pluginId).toBe("bad-plugin");
+  });
+
+  it("returns empty errors array on successful delivery", async () => {
+    const bus = createPluginEventBus();
+    bus.forPlugin("plugin-a").subscribe("issue.created", vi.fn().mockResolvedValue(undefined));
+    const result = await bus.emit(makeEvent());
+    expect(result.errors).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emit — wildcard pattern matching
+// ---------------------------------------------------------------------------
+
+describe("PluginEventBus.emit (wildcard patterns)", () => {
+  it("delivers to a '.*' wildcard subscriber", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("plugin.acme.linear.*", handler);
+
+    await bus.emit(makeEvent({ eventType: "plugin.acme.linear.sync-done" }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("does NOT deliver when the wildcard prefix does not match", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("plugin.acme.linear.*", handler);
+
+    await bus.emit(makeEvent({ eventType: "plugin.acme.other.sync-done" }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// emit — EventFilter
+// ---------------------------------------------------------------------------
+
+describe("PluginEventBus.emit (EventFilter)", () => {
+  it("passes events that match the companyId filter", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", { companyId: "co-1" }, handler);
+
+    await bus.emit(makeEvent({ companyId: "co-1" }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("blocks events that do NOT match the companyId filter", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", { companyId: "co-other" }, handler);
+
+    await bus.emit(makeEvent({ companyId: "co-1" }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("passes events matching projectId when entityType is 'project'", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("project.created", { projectId: "proj-1" }, handler);
+
+    await bus.emit(makeEvent({
+      eventType: "project.created",
+      entityType: "project",
+      entityId: "proj-1",
+    }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("passes events matching projectId from payload when entityType is not 'project'", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", { projectId: "proj-1" }, handler);
+
+    await bus.emit(makeEvent({
+      eventType: "issue.created",
+      entityType: "issue",
+      payload: { projectId: "proj-1" },
+    }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("blocks events when projectId filter does not match payload", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", { projectId: "proj-other" }, handler);
+
+    await bus.emit(makeEvent({ eventType: "issue.created", payload: { projectId: "proj-1" } }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("throws when a filter is provided without a handler function", () => {
+    const bus = createPluginEventBus();
+    expect(() => {
+      bus.forPlugin("plugin-a").subscribe("issue.created", { companyId: "co-1" }, undefined as never);
+    }).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ScopedPluginEventBus.emit
+// ---------------------------------------------------------------------------
+
+describe("ScopedPluginEventBus.emit", () => {
+  it("namespaces the event type as 'plugin.<pluginId>.<name>'", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-b").subscribe("plugin.plugin-a.*", handler);
+
+    await bus.forPlugin("plugin-a").emit("sync-done", "co-1", { result: "ok" });
+
+    expect(handler).toHaveBeenCalledOnce();
+    const event = handler.mock.calls[0]![0] as PluginEvent;
+    expect(event.eventType).toBe("plugin.plugin-a.sync-done");
+    expect(event.actorType).toBe("plugin");
+    expect(event.actorId).toBe("plugin-a");
+  });
+
+  it("throws when the event name is empty", async () => {
+    const bus = createPluginEventBus();
+    await expect(bus.forPlugin("plugin-a").emit("", "co-1", {})).rejects.toThrow(
+      /non-empty event name/,
+    );
+  });
+
+  it("throws when the companyId is empty", async () => {
+    const bus = createPluginEventBus();
+    await expect(bus.forPlugin("plugin-a").emit("sync-done", "", {})).rejects.toThrow(
+      /companyId/,
+    );
+  });
+
+  it("throws when the event name includes the 'plugin.' prefix", async () => {
+    const bus = createPluginEventBus();
+    await expect(
+      bus.forPlugin("plugin-a").emit("plugin.sync-done", "co-1", {}),
+    ).rejects.toThrow(/must not include the "plugin\." prefix/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clearPlugin / ScopedPluginEventBus.clear
+// ---------------------------------------------------------------------------
+
+describe("clearPlugin / ScopedPluginEventBus.clear", () => {
+  it("clearPlugin removes all subscriptions for the plugin", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", handler);
+    bus.clearPlugin("plugin-a");
+
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("ScopedPluginEventBus.clear removes all subscriptions for that plugin", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const scopedBus = bus.forPlugin("plugin-a");
+    scopedBus.subscribe("issue.created", handler);
+    scopedBus.clear();
+
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("clearPlugin does not affect subscriptions of other plugins", async () => {
+    const bus = createPluginEventBus();
+    const handlerA = vi.fn().mockResolvedValue(undefined);
+    const handlerB = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", handlerA);
+    bus.forPlugin("plugin-b").subscribe("issue.created", handlerB);
+    bus.clearPlugin("plugin-a");
+
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(handlerA).not.toHaveBeenCalled();
+    expect(handlerB).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subscriptionCount
+// ---------------------------------------------------------------------------
+
+describe("subscriptionCount", () => {
+  it("returns 0 when no subscriptions exist", () => {
+    const bus = createPluginEventBus();
+    expect(bus.subscriptionCount()).toBe(0);
+  });
+
+  it("returns the total subscription count", () => {
+    const bus = createPluginEventBus();
+    bus.forPlugin("plugin-a").subscribe("issue.created", vi.fn());
+    bus.forPlugin("plugin-a").subscribe("agent.status", vi.fn());
+    bus.forPlugin("plugin-b").subscribe("issue.created", vi.fn());
+    expect(bus.subscriptionCount()).toBe(3);
+  });
+
+  it("returns the count scoped to a specific plugin", () => {
+    const bus = createPluginEventBus();
+    bus.forPlugin("plugin-a").subscribe("issue.created", vi.fn());
+    bus.forPlugin("plugin-a").subscribe("agent.status", vi.fn());
+    bus.forPlugin("plugin-b").subscribe("issue.created", vi.fn());
+    expect(bus.subscriptionCount("plugin-a")).toBe(2);
+    expect(bus.subscriptionCount("plugin-b")).toBe(1);
+  });
+
+  it("returns 0 after clearPlugin", () => {
+    const bus = createPluginEventBus();
+    bus.forPlugin("plugin-a").subscribe("issue.created", vi.fn());
+    bus.clearPlugin("plugin-a");
+    expect(bus.subscriptionCount("plugin-a")).toBe(0);
+  });
+});

--- a/server/src/__tests__/plugin-host-service-cleanup.test.ts
+++ b/server/src/__tests__/plugin-host-service-cleanup.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from "vitest";
+import { createPluginHostServiceCleanup } from "../services/plugin-host-service-cleanup.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type EventHandler = (event: { pluginId: string }) => void;
+
+function makeLifecycle() {
+  const handlers: Map<string, EventHandler> = new Map();
+  return {
+    on: vi.fn((event: string, handler: EventHandler) => {
+      handlers.set(event, handler);
+    }),
+    off: vi.fn(),
+    emit: (event: string, payload: { pluginId: string }) => {
+      handlers.get(event)?.(payload);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createPluginHostServiceCleanup
+// ---------------------------------------------------------------------------
+
+describe("createPluginHostServiceCleanup", () => {
+  it("registers lifecycle listeners on creation", () => {
+    const lifecycle = makeLifecycle();
+    const disposers = new Map<string, () => void>();
+    createPluginHostServiceCleanup(lifecycle, disposers);
+    expect(lifecycle.on).toHaveBeenCalledWith("plugin.worker_stopped", expect.any(Function));
+    expect(lifecycle.on).toHaveBeenCalledWith("plugin.unloaded", expect.any(Function));
+  });
+
+  // -------------------------------------------------------------------------
+  // handleWorkerEvent
+  // -------------------------------------------------------------------------
+
+  it("handleWorkerEvent: calls disposer when type is 'plugin.worker.crashed'", () => {
+    const lifecycle = makeLifecycle();
+    const dispose = vi.fn();
+    const disposers = new Map([["my-plugin", dispose]]);
+    const ctrl = createPluginHostServiceCleanup(lifecycle, disposers);
+
+    ctrl.handleWorkerEvent({ type: "plugin.worker.crashed", pluginId: "my-plugin" });
+
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("handleWorkerEvent: does NOT call disposer when type is 'plugin.worker.restarted'", () => {
+    const lifecycle = makeLifecycle();
+    const dispose = vi.fn();
+    const disposers = new Map([["my-plugin", dispose]]);
+    const ctrl = createPluginHostServiceCleanup(lifecycle, disposers);
+
+    ctrl.handleWorkerEvent({ type: "plugin.worker.restarted", pluginId: "my-plugin" });
+
+    expect(dispose).not.toHaveBeenCalled();
+  });
+
+  it("handleWorkerEvent: is a no-op when there is no disposer for the plugin", () => {
+    const lifecycle = makeLifecycle();
+    const ctrl = createPluginHostServiceCleanup(lifecycle, new Map());
+    expect(() => ctrl.handleWorkerEvent({ type: "plugin.worker.crashed", pluginId: "unknown" })).not.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // Lifecycle event: plugin.worker_stopped
+  // -------------------------------------------------------------------------
+
+  it("calls disposer (but keeps it) when plugin.worker_stopped fires", () => {
+    const lifecycle = makeLifecycle();
+    const dispose = vi.fn();
+    const disposers = new Map([["plugin-x", dispose]]);
+    createPluginHostServiceCleanup(lifecycle, disposers);
+
+    lifecycle.emit("plugin.worker_stopped", { pluginId: "plugin-x" });
+
+    expect(dispose).toHaveBeenCalledOnce();
+    // Disposer remains in the map (plugin can restart)
+    expect(disposers.has("plugin-x")).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Lifecycle event: plugin.unloaded
+  // -------------------------------------------------------------------------
+
+  it("calls disposer AND removes it when plugin.unloaded fires", () => {
+    const lifecycle = makeLifecycle();
+    const dispose = vi.fn();
+    const disposers = new Map([["plugin-y", dispose]]);
+    createPluginHostServiceCleanup(lifecycle, disposers);
+
+    lifecycle.emit("plugin.unloaded", { pluginId: "plugin-y" });
+
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(disposers.has("plugin-y")).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // disposeAll
+  // -------------------------------------------------------------------------
+
+  it("disposeAll: calls all disposers and clears the map", () => {
+    const lifecycle = makeLifecycle();
+    const disposeA = vi.fn();
+    const disposeB = vi.fn();
+    const disposers = new Map([["a", disposeA], ["b", disposeB]]);
+    const ctrl = createPluginHostServiceCleanup(lifecycle, disposers);
+
+    ctrl.disposeAll();
+
+    expect(disposeA).toHaveBeenCalledOnce();
+    expect(disposeB).toHaveBeenCalledOnce();
+    expect(disposers.size).toBe(0);
+  });
+
+  it("disposeAll: is a no-op when map is empty", () => {
+    const lifecycle = makeLifecycle();
+    const ctrl = createPluginHostServiceCleanup(lifecycle, new Map());
+    expect(() => ctrl.disposeAll()).not.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // teardown
+  // -------------------------------------------------------------------------
+
+  it("teardown: unregisters the lifecycle listeners", () => {
+    const lifecycle = makeLifecycle();
+    const ctrl = createPluginHostServiceCleanup(lifecycle, new Map());
+    ctrl.teardown();
+    expect(lifecycle.off).toHaveBeenCalledWith("plugin.worker_stopped", expect.any(Function));
+    expect(lifecycle.off).toHaveBeenCalledWith("plugin.unloaded", expect.any(Function));
+  });
+});

--- a/server/src/__tests__/plugin-manifest-validator.test.ts
+++ b/server/src/__tests__/plugin-manifest-validator.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import { pluginManifestValidator } from "../services/plugin-manifest-validator.js";
+import { PLUGIN_API_VERSION } from "@paperclipai/shared";
+
+// A minimal valid manifest that passes all schema checks.
+function validManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "my-plugin",
+    apiVersion: PLUGIN_API_VERSION,
+    version: "1.0.0",
+    displayName: "My Plugin",
+    description: "Does something useful",
+    author: "Acme Corp",
+    categories: ["connector"],
+    capabilities: ["issues.read"],
+    entrypoints: { worker: "dist/worker.js" },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getSupportedVersions
+// ---------------------------------------------------------------------------
+
+describe("getSupportedVersions", () => {
+  it("returns an array containing the current PLUGIN_API_VERSION", () => {
+    const v = pluginManifestValidator().getSupportedVersions();
+    expect(v).toContain(PLUGIN_API_VERSION);
+  });
+
+  it("returns a non-empty array", () => {
+    expect(pluginManifestValidator().getSupportedVersions().length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parse — success paths
+// ---------------------------------------------------------------------------
+
+describe("parse (success)", () => {
+  it("returns success=true for a minimal valid manifest", () => {
+    const result = pluginManifestValidator().parse(validManifest());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.manifest.id).toBe("my-plugin");
+    }
+  });
+
+  it("accepts optional minimumHostVersion in semver format", () => {
+    const result = pluginManifestValidator().parse(validManifest({ minimumHostVersion: "2.3.4" }));
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts multiple categories", () => {
+    const result = pluginManifestValidator().parse(
+      validManifest({ categories: ["connector", "workspace"] }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts optional ui entrypoint alongside ui.slots", () => {
+    const result = pluginManifestValidator().parse(
+      validManifest({
+        entrypoints: { worker: "dist/worker.js", ui: "dist/ui.js" },
+        ui: {
+          slots: [{ type: "page", id: "my-page", displayName: "My Page", exportName: "MyPage" }],
+        },
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parse — failure paths
+// ---------------------------------------------------------------------------
+
+describe("parse (failure)", () => {
+  it("returns success=false for null input", () => {
+    const result = pluginManifestValidator().parse(null);
+    expect(result.success).toBe(false);
+  });
+
+  it("returns success=false for a plain string", () => {
+    const result = pluginManifestValidator().parse("not a manifest");
+    expect(result.success).toBe(false);
+  });
+
+  it("returns success=false when apiVersion is wrong", () => {
+    const result = pluginManifestValidator().parse(validManifest({ apiVersion: 99 }));
+    expect(result.success).toBe(false);
+  });
+
+  it("returns success=false when id is empty", () => {
+    const result = pluginManifestValidator().parse(validManifest({ id: "" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("returns success=false when id has uppercase letters", () => {
+    const result = pluginManifestValidator().parse(validManifest({ id: "MyPlugin" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("returns success=false when version is not semver", () => {
+    const result = pluginManifestValidator().parse(validManifest({ version: "not-semver" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("returns success=false when categories is empty", () => {
+    const result = pluginManifestValidator().parse(validManifest({ categories: [] }));
+    expect(result.success).toBe(false);
+  });
+
+  it("returns success=false when categories contains an unknown value", () => {
+    const result = pluginManifestValidator().parse(
+      validManifest({ categories: ["unknown-category"] }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("returns success=false when capabilities is empty", () => {
+    const result = pluginManifestValidator().parse(validManifest({ capabilities: [] }));
+    expect(result.success).toBe(false);
+  });
+
+  it("returns success=false when entrypoints.worker is missing", () => {
+    const result = pluginManifestValidator().parse(
+      validManifest({ entrypoints: { ui: "dist/ui.js" } }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("returns errors string describing each issue", () => {
+    const result = pluginManifestValidator().parse({ apiVersion: PLUGIN_API_VERSION });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(typeof result.errors).toBe("string");
+      expect(result.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("includes path and message in details array", () => {
+    const result = pluginManifestValidator().parse(validManifest({ id: "" }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(Array.isArray(result.details)).toBe(true);
+      expect(result.details.length).toBeGreaterThan(0);
+      const detail = result.details[0];
+      expect(detail).toHaveProperty("path");
+      expect(detail).toHaveProperty("message");
+    }
+  });
+
+  it("superRefine: rejects ui.slots without entrypoints.ui", () => {
+    const result = pluginManifestValidator().parse(
+      validManifest({
+        // no entrypoints.ui — only worker entrypoint
+        ui: {
+          slots: [{ type: "page", id: "my-page", displayName: "My Page", exportName: "MyPage" }],
+        },
+      }),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors).toContain("entrypoints.ui");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseOrThrow
+// ---------------------------------------------------------------------------
+
+describe("parseOrThrow", () => {
+  it("returns the manifest on success", () => {
+    const manifest = pluginManifestValidator().parseOrThrow(validManifest());
+    expect(manifest.id).toBe("my-plugin");
+  });
+
+  it("throws an error on invalid input", () => {
+    expect(() => pluginManifestValidator().parseOrThrow(null)).toThrow();
+  });
+
+  it("thrown error message contains 'Invalid plugin manifest'", () => {
+    expect(() => pluginManifestValidator().parseOrThrow({ apiVersion: 99 })).toThrow(
+      /Invalid plugin manifest/,
+    );
+  });
+});

--- a/server/src/__tests__/plugin-stream-bus.test.ts
+++ b/server/src/__tests__/plugin-stream-bus.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { createPluginStreamBus } from "../services/plugin-stream-bus.js";
+import type { StreamEventType } from "../services/plugin-stream-bus.js";
+
+describe("createPluginStreamBus", () => {
+  it("delivers a published event to a matching subscriber", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    bus.subscribe("plug-a", "ch-1", "co-1", listener);
+    bus.publish("plug-a", "ch-1", "co-1", { data: "hello" });
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith({ data: "hello" }, "message");
+  });
+
+  it("defaults eventType to 'message' when not specified", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    bus.subscribe("p", "c", "co", listener);
+    bus.publish("p", "c", "co", "payload");
+    const [, eventType] = listener.mock.calls[0] as [unknown, StreamEventType];
+    expect(eventType).toBe("message");
+  });
+
+  it("passes a custom eventType through to the listener", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    bus.subscribe("p", "c", "co", listener);
+    bus.publish("p", "c", "co", "bye", "close");
+    const [, eventType] = listener.mock.calls[0] as [unknown, StreamEventType];
+    expect(eventType).toBe("close");
+  });
+
+  it("does NOT deliver to a subscriber for a different pluginId", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    bus.subscribe("plug-a", "ch-1", "co-1", listener);
+    bus.publish("plug-b", "ch-1", "co-1", "ignored");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("does NOT deliver to a subscriber for a different channel", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    bus.subscribe("p", "ch-1", "co", listener);
+    bus.publish("p", "ch-2", "co", "ignored");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("does NOT deliver to a subscriber for a different companyId", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    bus.subscribe("p", "ch", "co-1", listener);
+    bus.publish("p", "ch", "co-2", "ignored");
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("delivers to multiple subscribers on the same key", () => {
+    const bus = createPluginStreamBus();
+    const l1 = vi.fn();
+    const l2 = vi.fn();
+    bus.subscribe("p", "ch", "co", l1);
+    bus.subscribe("p", "ch", "co", l2);
+    bus.publish("p", "ch", "co", "event");
+    expect(l1).toHaveBeenCalledOnce();
+    expect(l2).toHaveBeenCalledOnce();
+  });
+
+  it("stops delivering after unsubscribe is called", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    const unsubscribe = bus.subscribe("p", "ch", "co", listener);
+    bus.publish("p", "ch", "co", "before");
+    unsubscribe();
+    bus.publish("p", "ch", "co", "after");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up the key set when the last subscriber unsubscribes", () => {
+    const bus = createPluginStreamBus();
+    const listener = vi.fn();
+    const unsubscribe = bus.subscribe("p", "ch", "co", listener);
+    unsubscribe();
+    // Subsequent publish should be a no-op (no error)
+    expect(() => bus.publish("p", "ch", "co", "event")).not.toThrow();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when publishing with no subscribers", () => {
+    const bus = createPluginStreamBus();
+    expect(() => bus.publish("p", "ch", "co", "event")).not.toThrow();
+  });
+});

--- a/server/src/__tests__/plugin-tool-registry.test.ts
+++ b/server/src/__tests__/plugin-tool-registry.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  createPluginToolRegistry,
+  TOOL_NAMESPACE_SEPARATOR,
+} from "../services/plugin-tool-registry.js";
+import { pluginManifestValidator } from "../services/plugin-manifest-validator.js";
+import { PLUGIN_API_VERSION } from "@paperclipai/shared";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import type { PluginToolRegistry } from "../services/plugin-tool-registry.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const mv = pluginManifestValidator();
+
+function makeTool(name: string, displayName?: string) {
+  return {
+    name,
+    displayName: displayName ?? name,
+    description: `Description for ${name}`,
+    parametersSchema: { type: "object" as const, properties: {}, required: [] },
+  };
+}
+
+function makeManifest(
+  pluginId: string,
+  toolNames: string[],
+  overrides: Record<string, unknown> = {},
+): PaperclipPluginManifestV1 {
+  return mv.parseOrThrow({
+    id: pluginId,
+    apiVersion: PLUGIN_API_VERSION,
+    version: "1.0.0",
+    displayName: `Plugin ${pluginId}`,
+    description: "Test plugin",
+    author: "Acme",
+    categories: ["connector"],
+    capabilities: toolNames.length > 0 ? ["agent.tools.register"] : ["issues.read"],
+    entrypoints: { worker: "dist/worker.js" },
+    tools: toolNames.map((name) => makeTool(name)),
+    ...overrides,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// TOOL_NAMESPACE_SEPARATOR
+// ---------------------------------------------------------------------------
+
+describe("TOOL_NAMESPACE_SEPARATOR", () => {
+  it("is a colon", () => {
+    expect(TOOL_NAMESPACE_SEPARATOR).toBe(":");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createPluginToolRegistry — registration
+// ---------------------------------------------------------------------------
+
+describe("registerPlugin", () => {
+  let registry: PluginToolRegistry;
+
+  beforeEach(() => {
+    registry = createPluginToolRegistry();
+  });
+
+  it("registers tools from a manifest with tools", () => {
+    const m = makeManifest("acme.linear", ["search-issues"]);
+    registry.registerPlugin("acme.linear", m);
+    expect(registry.toolCount()).toBe(1);
+  });
+
+  it("registers multiple tools from the same manifest", () => {
+    const m = makeManifest("acme.linear", ["search-issues", "create-issue"]);
+    registry.registerPlugin("acme.linear", m);
+    expect(registry.toolCount()).toBe(2);
+  });
+
+  it("namespaces tools as pluginId:toolName", () => {
+    const m = makeManifest("acme.linear", ["search-issues"]);
+    registry.registerPlugin("acme.linear", m);
+    const tool = registry.getTool("acme.linear:search-issues");
+    expect(tool).not.toBeNull();
+    expect(tool!.namespacedName).toBe("acme.linear:search-issues");
+  });
+
+  it("replaces previously registered tools on re-registration (idempotent)", () => {
+    const m1 = makeManifest("acme.linear", ["tool-a", "tool-b"]);
+    registry.registerPlugin("acme.linear", m1);
+    const m2 = makeManifest("acme.linear", ["tool-c"]);
+    registry.registerPlugin("acme.linear", m2);
+    expect(registry.toolCount()).toBe(1);
+    expect(registry.getTool("acme.linear:tool-a")).toBeNull();
+    expect(registry.getTool("acme.linear:tool-c")).not.toBeNull();
+  });
+
+  it("stores pluginDbId separately from pluginId", () => {
+    const m = makeManifest("acme.linear", ["search-issues"]);
+    registry.registerPlugin("acme.linear", m, "db-uuid-123");
+    const tool = registry.getTool("acme.linear:search-issues");
+    expect(tool!.pluginDbId).toBe("db-uuid-123");
+    expect(tool!.pluginId).toBe("acme.linear");
+  });
+
+  it("falls back to pluginId for pluginDbId when not provided", () => {
+    const m = makeManifest("acme.linear", ["search-issues"]);
+    registry.registerPlugin("acme.linear", m);
+    expect(registry.getTool("acme.linear:search-issues")!.pluginDbId).toBe("acme.linear");
+  });
+
+  it("does nothing (no-op) when manifest has no tools", () => {
+    const m = makeManifest("acme.linear", []);
+    registry.registerPlugin("acme.linear", m);
+    expect(registry.toolCount()).toBe(0);
+  });
+
+  it("supports multiple plugins registered independently", () => {
+    registry.registerPlugin("plugin-a", makeManifest("plugin-a", ["tool-1"]));
+    registry.registerPlugin("plugin-b", makeManifest("plugin-b", ["tool-2"]));
+    expect(registry.toolCount()).toBe(2);
+    expect(registry.toolCount("plugin-a")).toBe(1);
+    expect(registry.toolCount("plugin-b")).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unregisterPlugin
+// ---------------------------------------------------------------------------
+
+describe("unregisterPlugin", () => {
+  let registry: PluginToolRegistry;
+
+  beforeEach(() => {
+    registry = createPluginToolRegistry();
+  });
+
+  it("removes all tools for the specified plugin", () => {
+    registry.registerPlugin("acme.linear", makeManifest("acme.linear", ["a", "b"]));
+    registry.unregisterPlugin("acme.linear");
+    expect(registry.toolCount()).toBe(0);
+  });
+
+  it("does not affect tools from other plugins", () => {
+    registry.registerPlugin("plugin-a", makeManifest("plugin-a", ["tool-a"]));
+    registry.registerPlugin("plugin-b", makeManifest("plugin-b", ["tool-b"]));
+    registry.unregisterPlugin("plugin-a");
+    expect(registry.toolCount()).toBe(1);
+    expect(registry.getTool("plugin-b:tool-b")).not.toBeNull();
+  });
+
+  it("is a no-op for a plugin that was never registered", () => {
+    expect(() => registry.unregisterPlugin("unknown-plugin")).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTool / getToolByPlugin
+// ---------------------------------------------------------------------------
+
+describe("getTool", () => {
+  let registry: PluginToolRegistry;
+
+  beforeEach(() => {
+    registry = createPluginToolRegistry();
+    registry.registerPlugin("acme.linear", makeManifest("acme.linear", ["search-issues"]));
+  });
+
+  it("returns the tool for a valid namespaced name", () => {
+    const tool = registry.getTool("acme.linear:search-issues");
+    expect(tool).not.toBeNull();
+    expect(tool!.name).toBe("search-issues");
+  });
+
+  it("returns null for an unregistered tool", () => {
+    expect(registry.getTool("acme.linear:unknown-tool")).toBeNull();
+  });
+
+  it("returns null for a completely different plugin", () => {
+    expect(registry.getTool("other.plugin:search-issues")).toBeNull();
+  });
+});
+
+describe("getToolByPlugin", () => {
+  let registry: PluginToolRegistry;
+
+  beforeEach(() => {
+    registry = createPluginToolRegistry();
+    registry.registerPlugin("acme.linear", makeManifest("acme.linear", ["search-issues"]));
+  });
+
+  it("returns the tool when pluginId and toolName are both correct", () => {
+    const tool = registry.getToolByPlugin("acme.linear", "search-issues");
+    expect(tool).not.toBeNull();
+    expect(tool!.namespacedName).toBe("acme.linear:search-issues");
+  });
+
+  it("returns null when toolName is not registered for the plugin", () => {
+    expect(registry.getToolByPlugin("acme.linear", "unknown")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listTools
+// ---------------------------------------------------------------------------
+
+describe("listTools", () => {
+  let registry: PluginToolRegistry;
+
+  beforeEach(() => {
+    registry = createPluginToolRegistry();
+    registry.registerPlugin("plugin-a", makeManifest("plugin-a", ["a1", "a2"]));
+    registry.registerPlugin("plugin-b", makeManifest("plugin-b", ["b1"]));
+  });
+
+  it("returns all tools when no filter is provided", () => {
+    const tools = registry.listTools();
+    expect(tools).toHaveLength(3);
+  });
+
+  it("returns only tools for the specified plugin when filtered", () => {
+    const tools = registry.listTools({ pluginId: "plugin-a" });
+    expect(tools).toHaveLength(2);
+    expect(tools.every((t) => t.pluginId === "plugin-a")).toBe(true);
+  });
+
+  it("returns an empty array when filtering for an unregistered plugin", () => {
+    expect(registry.listTools({ pluginId: "unknown-plugin" })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseNamespacedName
+// ---------------------------------------------------------------------------
+
+describe("parseNamespacedName", () => {
+  const registry = createPluginToolRegistry();
+
+  it("parses a valid namespaced name", () => {
+    const result = registry.parseNamespacedName("acme.linear:search-issues");
+    expect(result).toEqual({ pluginId: "acme.linear", toolName: "search-issues" });
+  });
+
+  it("returns null when there is no colon separator", () => {
+    expect(registry.parseNamespacedName("no-separator")).toBeNull();
+  });
+
+  it("returns null when the colon is at the start (empty pluginId)", () => {
+    expect(registry.parseNamespacedName(":tool-name")).toBeNull();
+  });
+
+  it("returns null when the colon is at the end (empty toolName)", () => {
+    expect(registry.parseNamespacedName("plugin-id:")).toBeNull();
+  });
+
+  it("uses the last colon as separator when the pluginId contains colons", () => {
+    // edge case: "a:b:c" → pluginId="a:b", toolName="c"
+    const result = registry.parseNamespacedName("a:b:c");
+    expect(result).not.toBeNull();
+    expect(result!.toolName).toBe("c");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildNamespacedName
+// ---------------------------------------------------------------------------
+
+describe("buildNamespacedName", () => {
+  const registry = createPluginToolRegistry();
+
+  it("combines pluginId and toolName with the colon separator", () => {
+    expect(registry.buildNamespacedName("acme.linear", "search-issues"))
+      .toBe("acme.linear:search-issues");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toolCount
+// ---------------------------------------------------------------------------
+
+describe("toolCount", () => {
+  let registry: PluginToolRegistry;
+
+  beforeEach(() => {
+    registry = createPluginToolRegistry();
+  });
+
+  it("returns 0 when no plugins are registered", () => {
+    expect(registry.toolCount()).toBe(0);
+  });
+
+  it("returns the correct total after registrations", () => {
+    registry.registerPlugin("a", makeManifest("a", ["t1", "t2"]));
+    registry.registerPlugin("b", makeManifest("b", ["t3"]));
+    expect(registry.toolCount()).toBe(3);
+  });
+
+  it("returns the count scoped to a specific plugin", () => {
+    registry.registerPlugin("a", makeManifest("a", ["t1", "t2"]));
+    registry.registerPlugin("b", makeManifest("b", ["t3"]));
+    expect(registry.toolCount("a")).toBe(2);
+    expect(registry.toolCount("b")).toBe(1);
+  });
+
+  it("returns 0 for a plugin that was unregistered", () => {
+    registry.registerPlugin("a", makeManifest("a", ["t1"]));
+    registry.unregisterPlugin("a");
+    expect(registry.toolCount("a")).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// executeTool — error paths (no workerManager)
+// ---------------------------------------------------------------------------
+
+describe("executeTool (no workerManager)", () => {
+  it("throws for an invalid tool name format", async () => {
+    const registry = createPluginToolRegistry();
+    await expect(registry.executeTool("no-separator", {}, {} as never)).rejects.toThrow(
+      /Invalid tool name/,
+    );
+  });
+
+  it("throws when the tool is not registered", async () => {
+    const registry = createPluginToolRegistry();
+    await expect(
+      registry.executeTool("plugin:unknown-tool", {}, {} as never),
+    ).rejects.toThrow();
+  });
+
+  it("throws 'no worker manager' when tool exists but no workerManager is configured", async () => {
+    const registry = createPluginToolRegistry();
+    registry.registerPlugin("my-plugin", makeManifest("my-plugin", ["do-thing"]));
+    await expect(
+      registry.executeTool("my-plugin:do-thing", {}, {} as never),
+    ).rejects.toThrow(/no worker manager/i);
+  });
+});

--- a/server/src/__tests__/project-workspace-runtime-config.test.ts
+++ b/server/src/__tests__/project-workspace-runtime-config.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import {
+  readProjectWorkspaceRuntimeConfig,
+  mergeProjectWorkspaceRuntimeConfig,
+} from "../services/project-workspace-runtime-config.js";
+
+// ---------------------------------------------------------------------------
+// readProjectWorkspaceRuntimeConfig
+// ---------------------------------------------------------------------------
+
+describe("readProjectWorkspaceRuntimeConfig", () => {
+  it("returns null for null metadata", () => {
+    expect(readProjectWorkspaceRuntimeConfig(null)).toBeNull();
+  });
+
+  it("returns null for undefined metadata", () => {
+    expect(readProjectWorkspaceRuntimeConfig(undefined)).toBeNull();
+  });
+
+  it("returns null when metadata has no runtimeConfig key", () => {
+    expect(readProjectWorkspaceRuntimeConfig({ other: "value" })).toBeNull();
+  });
+
+  it("returns null when runtimeConfig is not a plain object", () => {
+    expect(readProjectWorkspaceRuntimeConfig({ runtimeConfig: "string" })).toBeNull();
+    expect(readProjectWorkspaceRuntimeConfig({ runtimeConfig: 42 })).toBeNull();
+    expect(readProjectWorkspaceRuntimeConfig({ runtimeConfig: null })).toBeNull();
+    expect(readProjectWorkspaceRuntimeConfig({ runtimeConfig: [] })).toBeNull();
+  });
+
+  it("returns null when runtimeConfig is an empty object (both fields are null)", () => {
+    // workspaceRuntime is not a record → null; desiredState is missing → null
+    expect(readProjectWorkspaceRuntimeConfig({ runtimeConfig: {} })).toBeNull();
+  });
+
+  it("returns config with desiredState='running' when set", () => {
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { desiredState: "running" },
+    });
+    expect(result).toEqual({ workspaceRuntime: null, desiredState: "running" });
+  });
+
+  it("returns config with desiredState='stopped' when set", () => {
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { desiredState: "stopped" },
+    });
+    expect(result).toEqual({ workspaceRuntime: null, desiredState: "stopped" });
+  });
+
+  it("normalises unknown desiredState values to null", () => {
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { desiredState: "paused", workspaceRuntime: { key: "v" } },
+    });
+    expect(result?.desiredState).toBeNull();
+    expect(result?.workspaceRuntime).toEqual({ key: "v" });
+  });
+
+  it("returns config with workspaceRuntime when set", () => {
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { workspaceRuntime: { port: 3000 } },
+    });
+    expect(result).toEqual({ workspaceRuntime: { port: 3000 }, desiredState: null });
+  });
+
+  it("clones the workspaceRuntime object (does not share reference)", () => {
+    const original = { port: 3000 };
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { workspaceRuntime: original },
+    });
+    expect(result?.workspaceRuntime).not.toBe(original);
+    expect(result?.workspaceRuntime).toEqual(original);
+  });
+
+  it("returns null when workspaceRuntime is an array", () => {
+    // arrays are not plain records
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { workspaceRuntime: [1, 2, 3] },
+    });
+    // workspaceRuntime becomes null; desiredState is also absent → null
+    expect(result).toBeNull();
+  });
+
+  it("returns config with both fields populated", () => {
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { workspaceRuntime: { a: 1 }, desiredState: "running" },
+    });
+    expect(result).toEqual({ workspaceRuntime: { a: 1 }, desiredState: "running" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeProjectWorkspaceRuntimeConfig
+// ---------------------------------------------------------------------------
+
+describe("mergeProjectWorkspaceRuntimeConfig", () => {
+  it("removes runtimeConfig when patch is null and returns null for empty metadata", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { runtimeConfig: { desiredState: "running" } },
+      null,
+    );
+    expect(result).toBeNull();
+  });
+
+  it("removes runtimeConfig when patch is null but preserves other metadata fields", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { runtimeConfig: { desiredState: "running" }, theme: "dark" },
+      null,
+    );
+    expect(result).toEqual({ theme: "dark" });
+    expect(result).not.toHaveProperty("runtimeConfig");
+  });
+
+  it("merges desiredState into empty metadata", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(null, { desiredState: "running" });
+    expect(result).toEqual({ runtimeConfig: { workspaceRuntime: null, desiredState: "running" } });
+  });
+
+  it("merges workspaceRuntime into empty metadata", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(null, { workspaceRuntime: { port: 8080 } });
+    expect(result).toEqual({
+      runtimeConfig: { workspaceRuntime: { port: 8080 }, desiredState: null },
+    });
+  });
+
+  it("merges patch over existing runtimeConfig", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { runtimeConfig: { desiredState: "running", workspaceRuntime: { port: 3000 } } },
+      { desiredState: "stopped" },
+    );
+    expect(result).toEqual({
+      runtimeConfig: { desiredState: "stopped", workspaceRuntime: { port: 3000 } },
+    });
+  });
+
+  it("preserves unchanged fields when patching only one field", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { runtimeConfig: { desiredState: "stopped", workspaceRuntime: { a: 1 } } },
+      { workspaceRuntime: { a: 2 } },
+    );
+    expect(result).toEqual({
+      runtimeConfig: { desiredState: "stopped", workspaceRuntime: { a: 2 } },
+    });
+  });
+
+  it("removes runtimeConfig when patch clears both fields to null", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { runtimeConfig: { desiredState: "running" } },
+      { desiredState: null, workspaceRuntime: null },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("normalises invalid desiredState in patch to null, removes runtimeConfig if all null", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { runtimeConfig: { desiredState: "running" } },
+      { desiredState: "invalid" as never },
+    );
+    // desiredState becomes null, workspaceRuntime is null → runtimeConfig removed
+    expect(result).toBeNull();
+  });
+
+  it("preserves other metadata keys alongside updated runtimeConfig", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { theme: "light", runtimeConfig: { desiredState: "stopped" } },
+      { desiredState: "running" },
+    );
+    expect(result).toEqual({
+      theme: "light",
+      runtimeConfig: { desiredState: "running", workspaceRuntime: null },
+    });
+  });
+
+  it("clones workspaceRuntime from patch (no shared reference)", () => {
+    const runtime = { port: 9000 };
+    const result = mergeProjectWorkspaceRuntimeConfig(null, { workspaceRuntime: runtime });
+    const stored = (result?.runtimeConfig as Record<string, unknown>)?.workspaceRuntime;
+    expect(stored).not.toBe(runtime);
+    expect(stored).toEqual(runtime);
+  });
+
+  it("handles null metadata with null patch — returns null", () => {
+    expect(mergeProjectWorkspaceRuntimeConfig(null, null)).toBeNull();
+  });
+
+  it("handles undefined metadata gracefully", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(undefined, { desiredState: "running" });
+    expect(result).toEqual({
+      runtimeConfig: { workspaceRuntime: null, desiredState: "running" },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds **793+ new passing unit tests** across previously-uncovered modules in the **server**, **shared**, **adapter-utils**, and **mcp-server** packages. All tests are pure-function or in-memory (no DB) — fast, reliable, zero external dependencies.

### Server service modules (327 new tests, 17 modules)

| Module | Tests | Coverage focus |
|---|---|---|
| \`feedback-redaction\` | 35 | 9 regex-based redaction patterns, stableStringify, sha256Digest |
| \`company-export-readme\` | 20 | generateOrgChartMermaid, generateReadme (HTML escaping, org chart edges) |
| \`default-agent-instructions\` | 6 | Role resolution (ceo vs default), file loading |
| \`board-auth-utils\` | 20 | Token hashing, timing-safe comparison, TTL expiry helpers |
| \`plugin-manifest-validator\` | 22 | Safe/throwing parse, superRefine cross-field rules |
| \`project-workspace-runtime-config\` | 24 | read/merge with all null/invalid edge cases |
| \`agent-permissions-service\` | 14 | Role-based defaults, normalization fallback |
| \`cron-parser\` | 37 | Full cron expression parser: ranges, steps, lists, next-tick scheduling |
| \`plugin-capability-validator\` | 30 | All 9 public methods; operation gating, UI slot, manifest validation |
| \`plugin-config-validator\` | 8 | Ajv-based JSON Schema validation, secret-ref format, multiple errors |
| \`plugin-tool-registry\` | 33 | In-memory tool registry: CRUD, namespacing, filtering, error paths |
| \`issue-assignment-wakeup\` | 8 | Wakeup forwarding, early-exit conditions, error swallow/rethrow |
| \`live-events\` | 11 | EventEmitter pub/sub: delivery, isolation, unsubscribe |
| \`plugin-host-service-cleanup\` | 9 | Lifecycle listener teardown, dispose-on-crash vs dispose-on-unload |
| \`plugin-stream-bus\` | 10 | In-memory SSE pub/sub: delivery, isolation, unsubscribe |
| \`plugin-event-bus\` | 24 | Typed in-process event bus: pattern matching, EventFilter, scoped emit, error isolation |
| \`plugin-capability-scoped-invoker\` | 8 | PluginSandboxError, capability-gated invoke (pass/block/sync) |

### Shared validator schemas + modules (362 new tests, 7 test files)

| Test file | Tests | Coverage focus |
|---|---|---|
| \`shared-validators.test.ts\` | 92 | cost, finance, approval, budget, secret, access |
| \`more-validators.test.ts\` | 61 | routine, company, project |
| \`final-validators.test.ts\` | 69 | agent, work-product, goal, asset, instance |
| \`issue-validators.test.ts\` | 47 | issue (execution principal cross-field rules, doc key regex, label hex color) |
| \`portability-validators.test.ts\` | 39 | portability source/target discriminated unions, file entry, collision strategy |
| \`plugin-validators.test.ts\` | 31 | jsonSchemaSchema refine, job cron validation, UI slot superRefine |
| \`execution-workspace-validators.test.ts\` | 37 | executionWorkspaceConfig strict, closeAction strict, adapter-skills schemas |
| \`network-bind.test.ts\` | 36 | isLoopbackHost, isAllInterfacesHost, inferBindModeFromHost, resolveRuntimeBind |
| \`execution-workspace-guards.test.ts\` | 20 | isClosedIsolatedExecutionWorkspace (mode/status/closedAt), message formatting |

### adapter-utils package (46 new tests, 2 modules)

| Module | Tests | Coverage focus |
|---|---|---|
| \`session-compaction\` | 31 | Policy resolution (adapter_default/agent_override/legacy_fallback), readOverride string coercion |
| \`heartbeat-context\` | 15 | assembleHeartbeatInvocation: fragment assembly, metricKey, memoryClass propagation |

### mcp-server package (19 new tests, 2 modules)

| Module | Tests | Coverage focus |
|---|---|---|
| \`format\` | 8 | formatTextResponse (string/JSON), formatErrorResponse (Error, PaperclipApiError) |
| \`config\` | 11 | normalizeApiUrl (slash stripping, /api append), readConfigFromEnv (required/optional fields) |

Also cherry-picks the \`db.\$client.end()\` cleanup fix from PR #76 into test setup to prevent postgres.js null-write race condition on teardown.

## Test plan
- [x] All 793+ tests pass locally (no DB, <2s for all packages combined)
- [x] No external dependencies — all tests are pure unit tests
- [x] CI green on \`verify\` and \`score\` (composite: 81.6, 2229 total tests)