### PR TITLE
feat(observability): Add structured logging to heartbeat run lifecycle

### DIFF
--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2151,6 +2151,22 @@ export function heartbeatService(db: Db) {
       .then((rows) => rows[0] ?? null);
 
     if (updated) {
+      // Structured logging for all status transitions
+      const logLevel = status === "failed" ? "error" : status === "succeeded" ? "info" : "debug";
+      const logData = {
+        runId: updated.id,
+        agentId: updated.agentId,
+        status: updated.status,
+        invocationSource: updated.invocationSource,
+        triggerDetail: updated.triggerDetail,
+        ...(updated.error ? { error: updated.error } : {}),
+        ...(updated.errorCode ? { errorCode: updated.errorCode } : {}),
+        ...(updated.startedAt ? { startedAt: new Date(updated.startedAt).toISOString() } : {}),
+        ...(updated.finishedAt ? { finishedAt: new Date(updated.finishedAt).toISOString() } : {}),
+      };
+
+      logger[logLevel](logData, `heartbeat run status → ${status}`);
+
       publishLiveEvent({
         companyId: updated.companyId,
         type: "heartbeat.run.status",
@@ -2702,6 +2718,19 @@ export function heartbeatService(db: Db) {
       .returning()
       .then((rows) => rows[0] ?? null);
     if (!claimed) return null;
+
+    // Structured logging for run claim
+    const taskId = readNonEmptyString(context.issueId) || readNonEmptyString(context.taskId);
+    logger.info(
+      {
+        runId: claimed.id,
+        agentId: claimed.agentId,
+        invocationSource: claimed.invocationSource,
+        ...(taskId ? { taskId } : {}),
+        ...(claimed.triggerDetail ? { triggerDetail: claimed.triggerDetail } : {}),
+      },
+      "heartbeat run claimed and started"
+    );
 
     publishLiveEvent({
       companyId: claimed.companyId,
@@ -3990,6 +4019,25 @@ export function heartbeatService(db: Db) {
       } else {
         outcome = "failed";
       }
+
+      // Structured logging for adapter execution completion
+      const taskId = issueContext?.id || readNonEmptyString(context.issueId) || readNonEmptyString(context.taskId);
+      logger.info(
+        {
+          runId: run.id,
+          agentId: agent.id,
+          outcome,
+          exitCode: adapterResult.exitCode ?? 0,
+          ...(taskId ? { taskId } : {}),
+          ...(adapterResult.errorMessage ? { errorMessage: adapterResult.errorMessage } : {}),
+          ...(adapterResult.errorCode ? { errorCode: adapterResult.errorCode } : {}),
+          ...(rawUsage?.inputTokens ? { inputTokens: rawUsage.inputTokens } : {}),
+          ...(rawUsage?.cachedInputTokens ? { cachedInputTokens: rawUsage.cachedInputTokens } : {}),
+          ...(rawUsage?.outputTokens ? { outputTokens: rawUsage.outputTokens } : {}),
+          ...(adapterResult.costUsd ? { costUsd: adapterResult.costUsd } : {}),
+        },
+        `adapter execution completed: ${outcome}`
+      );
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
       if (handle) {


### PR DESCRIPTION
## Summary

Adds comprehensive structured JSON logging to heartbeat runs for improved observability and debugging of stuck/failing agents.

Fixes ANGA-810

## Changes

**Three Critical Logging Points Added:**

1. **setRunStatus** - Logs all status transitions
   - Adaptive log level: `error` for failed, `info` for succeeded, `debug` for intermediate states
   - Fields: runId, agentId, status, invocationSource, error/errorCode, timestamps
   
2. **claimQueuedRun** - Logs when queued run starts executing  
   - Fields: runId, agentId, taskId, invocationSource, triggerDetail
   
3. **Adapter completion** - Logs execution outcomes
   - Fields: outcome, exitCode, taskId, tokens (input/cached/output), costUsd
   - Provides visibility into resource usage

## Integration

- ✅ Uses existing **pino** structured logger infrastructure
- ✅ Logs sent to console, file, and **Loki** (when PAPERCLIP_LOKI_URL configured)
- ✅ `runId` already promoted to Loki label for filtering
- ✅ JSON format enables querying/aggregation in observability stack

## Benefits

- 🔍 Track agent execution pipeline health
- 🐛 Debug stuck runs (see where they stop in lifecycle)
- 📊 Monitor resource usage (tokens, cost per run)
- 📈 Aggregate metrics across agents/tasks
- ⚡ Faster incident response with structured queryable data

## Testing

- ✅ Server builds successfully
- ✅ TypeScript type checking passes
- 🔄 Ready for manual testing (run agents and verify logs in Loki)

🤖 Generated with [Claude Code](https://claude.com/claude-code)