### PR TITLE
test(cli): add 50 unit tests for CLI config utilities

### DIFF
--- a/cli/src/config/home.test.ts
+++ b/cli/src/config/home.test.ts
@@ -1,0 +1,175 @@
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  expandHomePrefix,
+  resolvePaperclipInstanceId,
+  resolvePaperclipHomeDir,
+  resolvePaperclipInstanceRoot,
+  resolveDefaultConfigPath,
+  resolveDefaultContextPath,
+  resolveDefaultCliAuthPath,
+  resolveDefaultEmbeddedPostgresDir,
+  resolveDefaultLogsDir,
+  resolveDefaultSecretsKeyFilePath,
+  resolveDefaultStorageDir,
+  resolveDefaultBackupDir,
+} from "./home.js";
+
+const FAKE_HOME = "/tmp/fake-home";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+// ============================================================================
+// expandHomePrefix
+// ============================================================================
+
+describe("expandHomePrefix", () => {
+  it("expands '~' to the OS home directory", () => {
+    vi.spyOn(os, "homedir").mockReturnValue(FAKE_HOME);
+    expect(expandHomePrefix("~")).toBe(FAKE_HOME);
+  });
+
+  it("expands '~/' prefix to home directory + rest of path", () => {
+    vi.spyOn(os, "homedir").mockReturnValue(FAKE_HOME);
+    expect(expandHomePrefix("~/paperclip")).toBe(path.resolve(FAKE_HOME, "paperclip"));
+  });
+
+  it("returns the value unchanged when no tilde prefix", () => {
+    expect(expandHomePrefix("/absolute/path")).toBe("/absolute/path");
+    expect(expandHomePrefix("relative/path")).toBe("relative/path");
+  });
+});
+
+// ============================================================================
+// resolvePaperclipInstanceId
+// ============================================================================
+
+describe("resolvePaperclipInstanceId", () => {
+  it("returns the provided override when valid", () => {
+    expect(resolvePaperclipInstanceId("my-instance")).toBe("my-instance");
+  });
+
+  it("falls back to PAPERCLIP_INSTANCE_ID env var", () => {
+    vi.stubEnv("PAPERCLIP_INSTANCE_ID", "env-instance");
+    expect(resolvePaperclipInstanceId()).toBe("env-instance");
+  });
+
+  it("falls back to 'default' when no override or env", () => {
+    vi.stubEnv("PAPERCLIP_INSTANCE_ID", "");
+    expect(resolvePaperclipInstanceId()).toBe("default");
+  });
+
+  it("override takes priority over env var", () => {
+    vi.stubEnv("PAPERCLIP_INSTANCE_ID", "env-instance");
+    expect(resolvePaperclipInstanceId("override-instance")).toBe("override-instance");
+  });
+
+  it("throws for an instance id with invalid characters", () => {
+    expect(() => resolvePaperclipInstanceId("my instance")).toThrow("Invalid instance id");
+    expect(() => resolvePaperclipInstanceId("my/instance")).toThrow("Invalid instance id");
+  });
+
+  it("accepts alphanumeric, dashes, and underscores", () => {
+    expect(resolvePaperclipInstanceId("my_instance-1")).toBe("my_instance-1");
+  });
+});
+
+// ============================================================================
+// resolvePaperclipHomeDir
+// ============================================================================
+
+describe("resolvePaperclipHomeDir", () => {
+  it("uses PAPERCLIP_HOME env when set", () => {
+    vi.stubEnv("PAPERCLIP_HOME", "/custom/home");
+    expect(resolvePaperclipHomeDir()).toBe(path.resolve("/custom/home"));
+  });
+
+  it("falls back to ~/.paperclip when env not set", () => {
+    vi.stubEnv("PAPERCLIP_HOME", "");
+    vi.spyOn(os, "homedir").mockReturnValue(FAKE_HOME);
+    expect(resolvePaperclipHomeDir()).toBe(path.resolve(FAKE_HOME, ".paperclip"));
+  });
+});
+
+// ============================================================================
+// Path resolution functions
+// ============================================================================
+
+describe("resolvePaperclipInstanceRoot", () => {
+  it("includes the instance id in the path", () => {
+    vi.stubEnv("PAPERCLIP_HOME", FAKE_HOME);
+    const result = resolvePaperclipInstanceRoot("my-instance");
+    expect(result).toContain("my-instance");
+    expect(result).toContain(FAKE_HOME);
+  });
+});
+
+describe("resolveDefaultConfigPath", () => {
+  it("ends with config.json", () => {
+    vi.stubEnv("PAPERCLIP_HOME", FAKE_HOME);
+    const result = resolveDefaultConfigPath("default");
+    expect(path.basename(result)).toBe("config.json");
+  });
+});
+
+describe("resolveDefaultContextPath", () => {
+  it("ends with context.json", () => {
+    vi.stubEnv("PAPERCLIP_HOME", FAKE_HOME);
+    const result = resolveDefaultContextPath();
+    expect(path.basename(result)).toBe("context.json");
+    expect(result).toContain(FAKE_HOME);
+  });
+});
+
+describe("resolveDefaultCliAuthPath", () => {
+  it("ends with auth.json inside the home dir", () => {
+    vi.stubEnv("PAPERCLIP_HOME", FAKE_HOME);
+    const result = resolveDefaultCliAuthPath();
+    expect(path.basename(result)).toBe("auth.json");
+    expect(result).toContain(FAKE_HOME);
+  });
+});
+
+describe("resolveDefaultEmbeddedPostgresDir", () => {
+  it("contains 'db' directory under the instance root", () => {
+    vi.stubEnv("PAPERCLIP_HOME", FAKE_HOME);
+    const result = resolveDefaultEmbeddedPostgresDir("default");
+    expect(path.basename(result)).toBe("db");
+  });
+});
+
+describe("resolveDefaultLogsDir", () => {
+  it("ends with 'logs' directory", () => {
+    vi.stubEnv("PAPERCLIP_HOME", FAKE_HOME);
+    const result = resolveDefaultLogsDir("default");
+    expect(path.basename(result)).toBe("logs");
+  });
+});
+
+describe("resolveDefaultSecretsKeyFilePath", () => {
+  it("ends with master.key", () => {
+    vi.stubEnv("PAPERCLIP_HOME", FAKE_HOME);
+    const result = resolveDefaultSecretsKeyFilePath("default");
+    expect(path.basename(result)).toBe("master.key");
+  });
+});
+
+describe("resolveDefaultStorageDir", () => {
+  it("ends with 'storage' directory", () => {
+    vi.stubEnv("PAPERCLIP_HOME", FAKE_HOME);
+    const result = resolveDefaultStorageDir("default");
+    expect(path.basename(result)).toBe("storage");
+  });
+});
+
+describe("resolveDefaultBackupDir", () => {
+  it("ends with 'backups' directory", () => {
+    vi.stubEnv("PAPERCLIP_HOME", FAKE_HOME);
+    const result = resolveDefaultBackupDir("default");
+    expect(path.basename(result)).toBe("backups");
+  });
+});

--- a/cli/src/config/hostnames.test.ts
+++ b/cli/src/config/hostnames.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { normalizeHostnameInput, parseHostnameCsv } from "./hostnames.js";
+
+// ============================================================================
+// normalizeHostnameInput
+// ============================================================================
+
+describe("normalizeHostnameInput", () => {
+  it("returns the hostname from a bare hostname string", () => {
+    expect(normalizeHostnameInput("example.com")).toBe("example.com");
+  });
+
+  it("strips the scheme from a full URL", () => {
+    expect(normalizeHostnameInput("https://example.com")).toBe("example.com");
+  });
+
+  it("strips the scheme and port from a full URL", () => {
+    expect(normalizeHostnameInput("http://example.com:8080")).toBe("example.com");
+  });
+
+  it("lowercases the hostname", () => {
+    expect(normalizeHostnameInput("EXAMPLE.COM")).toBe("example.com");
+  });
+
+  it("trims leading/trailing whitespace", () => {
+    expect(normalizeHostnameInput("  example.com  ")).toBe("example.com");
+  });
+
+  it("handles localhost", () => {
+    expect(normalizeHostnameInput("localhost")).toBe("localhost");
+  });
+
+  it("handles an IP address", () => {
+    expect(normalizeHostnameInput("127.0.0.1")).toBe("127.0.0.1");
+  });
+
+  it("throws for an empty string", () => {
+    expect(() => normalizeHostnameInput("")).toThrow("Hostname is required");
+  });
+
+  it("throws for whitespace-only string", () => {
+    expect(() => normalizeHostnameInput("   ")).toThrow("Hostname is required");
+  });
+});
+
+// ============================================================================
+// parseHostnameCsv
+// ============================================================================
+
+describe("parseHostnameCsv", () => {
+  it("returns an empty array for an empty string", () => {
+    expect(parseHostnameCsv("")).toEqual([]);
+  });
+
+  it("returns an empty array for whitespace-only input", () => {
+    expect(parseHostnameCsv("   ")).toEqual([]);
+  });
+
+  it("parses a single hostname", () => {
+    expect(parseHostnameCsv("example.com")).toEqual(["example.com"]);
+  });
+
+  it("parses multiple comma-separated hostnames", () => {
+    const result = parseHostnameCsv("example.com,api.example.com");
+    expect(result).toContain("example.com");
+    expect(result).toContain("api.example.com");
+    expect(result).toHaveLength(2);
+  });
+
+  it("deduplicates identical hostnames", () => {
+    const result = parseHostnameCsv("example.com,example.com");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe("example.com");
+  });
+
+  it("normalizes hostnames (lowercases)", () => {
+    const result = parseHostnameCsv("EXAMPLE.COM");
+    expect(result).toEqual(["example.com"]);
+  });
+
+  it("handles full URLs in the CSV", () => {
+    const result = parseHostnameCsv("https://example.com");
+    expect(result).toEqual(["example.com"]);
+  });
+});

--- a/cli/src/config/server-bind.test.ts
+++ b/cli/src/config/server-bind.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { inferConfiguredBind, buildPresetServerConfig, buildCustomServerConfig } from "./server-bind.js";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const BASE_INPUT = {
+  port: 3100,
+  allowedHostnames: [],
+  serveUi: true,
+};
+
+// ============================================================================
+// inferConfiguredBind
+// ============================================================================
+
+describe("inferConfiguredBind", () => {
+  it("returns the explicit bind when set", () => {
+    expect(inferConfiguredBind({ bind: "lan" })).toBe("lan");
+  });
+
+  it("returns 'loopback' for localhost host", () => {
+    expect(inferConfiguredBind({ host: "127.0.0.1" })).toBe("loopback");
+  });
+
+  it("returns 'lan' for 0.0.0.0 host", () => {
+    expect(inferConfiguredBind({ host: "0.0.0.0" })).toBe("lan");
+  });
+
+  it("returns 'loopback' when no server config provided", () => {
+    expect(inferConfiguredBind(undefined)).toBe("loopback");
+  });
+
+  it("returns 'loopback' for undefined host", () => {
+    expect(inferConfiguredBind({})).toBe("loopback");
+  });
+});
+
+// ============================================================================
+// buildPresetServerConfig
+// ============================================================================
+
+describe("buildPresetServerConfig", () => {
+  it("builds loopback config with local_trusted deployment mode", () => {
+    const { server, auth } = buildPresetServerConfig("loopback", BASE_INPUT);
+    expect(server.bind).toBe("loopback");
+    expect(server.host).toBe("127.0.0.1");
+    expect(server.deploymentMode).toBe("local_trusted");
+    expect(server.port).toBe(3100);
+    expect(auth.baseUrlMode).toBe("auto");
+  });
+
+  it("builds lan config with authenticated deployment mode", () => {
+    const { server, auth } = buildPresetServerConfig("lan", BASE_INPUT);
+    expect(server.bind).toBe("lan");
+    expect(server.host).toBe("0.0.0.0");
+    expect(server.deploymentMode).toBe("authenticated");
+    expect(auth.disableSignUp).toBe(false);
+  });
+
+  it("sets serveUi and allowedHostnames from input", () => {
+    const input = { port: 4000, allowedHostnames: ["example.com"], serveUi: false };
+    const { server } = buildPresetServerConfig("loopback", input);
+    expect(server.serveUi).toBe(false);
+    expect(server.allowedHostnames).toEqual(["example.com"]);
+    expect(server.port).toBe(4000);
+  });
+});
+
+// ============================================================================
+// buildCustomServerConfig
+// ============================================================================
+
+describe("buildCustomServerConfig", () => {
+  it("uses 'loopback' bind for 127.0.0.1 host", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "local_trusted",
+      exposure: "private",
+      host: "127.0.0.1",
+    });
+    expect(server.bind).toBe("loopback");
+    expect(server.customBindHost).toBeUndefined();
+  });
+
+  it("uses 'lan' bind for 0.0.0.0 host", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "authenticated",
+      exposure: "private",
+      host: "0.0.0.0",
+    });
+    expect(server.bind).toBe("lan");
+  });
+
+  it("uses 'custom' bind for a non-standard host", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "authenticated",
+      exposure: "private",
+      host: "192.168.1.50",
+    });
+    expect(server.bind).toBe("custom");
+    expect(server.customBindHost).toBe("192.168.1.50");
+  });
+
+  it("sets explicit publicBaseUrl when authenticated+public", () => {
+    const { auth } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "authenticated",
+      exposure: "public",
+      host: "0.0.0.0",
+      publicBaseUrl: "https://app.example.com",
+    });
+    expect(auth.baseUrlMode).toBe("explicit");
+    if (auth.baseUrlMode === "explicit") {
+      expect(auth.publicBaseUrl).toBe("https://app.example.com");
+    }
+  });
+
+  it("forces exposure to 'private' when deploymentMode is local_trusted", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "local_trusted",
+      exposure: "public",
+      host: "127.0.0.1",
+    });
+    expect(server.exposure).toBe("private");
+  });
+
+  it("trims whitespace from the host", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "local_trusted",
+      exposure: "private",
+      host: "  127.0.0.1  ",
+    });
+    expect(server.host).toBe("127.0.0.1");
+  });
+});

--- a/packages/adapters/gemini-local/src/ui/build-config.test.ts
+++ b/packages/adapters/gemini-local/src/ui/build-config.test.ts
@@ -121,10 +121,9 @@ describe("buildGeminiLocalConfig", () => {
   });
 
   it("includes adapterFallbackChain when non-empty", () => {
-    const config = buildGeminiLocalConfig(
-      makeValues({ adapterFallbackChain: ["gemini_local", "codex_local"] }),
-    );
-    expect(config.adapterFallbackChain).toEqual(["gemini_local", "codex_local"]);
+    const chain = [{ adapterType: "gemini_local" }, { adapterType: "codex_local" }];
+    const config = buildGeminiLocalConfig(makeValues({ adapterFallbackChain: chain }));
+    expect(config.adapterFallbackChain).toEqual(chain);
   });
 
   it("omits adapterFallbackChain when empty", () => {

--- a/packages/adapters/gemini-local/src/ui/build-config.test.ts
+++ b/packages/adapters/gemini-local/src/ui/build-config.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { buildGeminiLocalConfig } from "./build-config.js";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "gemini_local",
+    cwd: "",
+    instructionsFilePath: "",
+    promptTemplate: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: false,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: false,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    payloadTemplateJson: "",
+    workspaceStrategyType: "project_primary",
+    workspaceBaseRef: "",
+    workspaceBranchTemplate: "",
+    worktreeParentDir: "",
+    runtimeServicesJson: "",
+    maxTurnsPerRun: 1000,
+    heartbeatEnabled: false,
+    intervalSec: 300,
+    ...overrides,
+  };
+}
+
+describe("buildGeminiLocalConfig", () => {
+  it("uses DEFAULT_GEMINI_LOCAL_MODEL when model is empty", () => {
+    const config = buildGeminiLocalConfig(makeValues({ model: "" }));
+    expect(config.model).toBe("auto");
+  });
+
+  it("uses the provided model when set", () => {
+    const config = buildGeminiLocalConfig(makeValues({ model: "gemini-2.0-flash" }));
+    expect(config.model).toBe("gemini-2.0-flash");
+  });
+
+  it("includes cwd when provided", () => {
+    const config = buildGeminiLocalConfig(makeValues({ cwd: "/my/project" }));
+    expect(config.cwd).toBe("/my/project");
+  });
+
+  it("omits cwd when empty", () => {
+    const config = buildGeminiLocalConfig(makeValues({ cwd: "" }));
+    expect(config.cwd).toBeUndefined();
+  });
+
+  it("includes instructionsFilePath when provided", () => {
+    const config = buildGeminiLocalConfig(makeValues({ instructionsFilePath: "/path/to/CLAUDE.md" }));
+    expect(config.instructionsFilePath).toBe("/path/to/CLAUDE.md");
+  });
+
+  it("maps bootstrapPrompt to bootstrapPromptTemplate", () => {
+    const config = buildGeminiLocalConfig(makeValues({ bootstrapPrompt: "start here" }));
+    expect(config.bootstrapPromptTemplate).toBe("start here");
+  });
+
+  it("always sets timeoutSec to 0", () => {
+    const config = buildGeminiLocalConfig(makeValues());
+    expect(config.timeoutSec).toBe(0);
+  });
+
+  it("always sets graceSec to 15", () => {
+    const config = buildGeminiLocalConfig(makeValues());
+    expect(config.graceSec).toBe(15);
+  });
+
+  it("sets sandbox=true when dangerouslyBypassSandbox is false", () => {
+    const config = buildGeminiLocalConfig(makeValues({ dangerouslyBypassSandbox: false }));
+    expect(config.sandbox).toBe(true);
+  });
+
+  it("sets sandbox=false when dangerouslyBypassSandbox is true", () => {
+    const config = buildGeminiLocalConfig(makeValues({ dangerouslyBypassSandbox: true }));
+    expect(config.sandbox).toBe(false);
+  });
+
+  it("populates env from envVars text", () => {
+    const config = buildGeminiLocalConfig(
+      makeValues({ envVars: "API_KEY=secret\nDEBUG=true" }),
+    );
+    const env = config.env as Record<string, unknown>;
+    expect(env).toBeDefined();
+    expect(env["API_KEY"]).toEqual({ type: "plain", value: "secret" });
+    expect(env["DEBUG"]).toEqual({ type: "plain", value: "true" });
+  });
+
+  it("populates env from envBindings with plain values", () => {
+    const config = buildGeminiLocalConfig(
+      makeValues({ envBindings: { MY_VAR: "value123" } }),
+    );
+    const env = config.env as Record<string, unknown>;
+    expect(env["MY_VAR"]).toEqual({ type: "plain", value: "value123" });
+  });
+
+  it("envBindings secret_ref takes priority over envVars for same key", () => {
+    const config = buildGeminiLocalConfig(
+      makeValues({
+        envBindings: { TOKEN: { type: "secret_ref", secretId: "sec-1" } },
+        envVars: "TOKEN=plain-value",
+      }),
+    );
+    const env = config.env as Record<string, unknown>;
+    expect((env["TOKEN"] as { type: string }).type).toBe("secret_ref");
+  });
+
+  it("omits env when no env vars or bindings provided", () => {
+    const config = buildGeminiLocalConfig(makeValues({ envVars: "", envBindings: {} }));
+    expect(config.env).toBeUndefined();
+  });
+
+  it("includes adapterFallbackChain when non-empty", () => {
+    const config = buildGeminiLocalConfig(
+      makeValues({ adapterFallbackChain: ["gemini_local", "codex_local"] }),
+    );
+    expect(config.adapterFallbackChain).toEqual(["gemini_local", "codex_local"]);
+  });
+
+  it("omits adapterFallbackChain when empty", () => {
+    const config = buildGeminiLocalConfig(makeValues({ adapterFallbackChain: [] }));
+    expect(config.adapterFallbackChain).toBeUndefined();
+  });
+
+  it("parses extraArgs as comma-separated list", () => {
+    const config = buildGeminiLocalConfig(makeValues({ extraArgs: "--flag1, --flag2 , --flag3" }));
+    expect(config.extraArgs).toEqual(["--flag1", "--flag2", "--flag3"]);
+  });
+
+  it("omits extraArgs when empty", () => {
+    const config = buildGeminiLocalConfig(makeValues({ extraArgs: "" }));
+    expect(config.extraArgs).toBeUndefined();
+  });
+});

--- a/packages/adapters/gemini-local/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/gemini-local/src/ui/parse-stdout.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import { parseGeminiStdoutLine } from "./parse-stdout.js";
+
+const TS = "2026-04-17T00:00:00.000Z";
+
+// ============================================================================
+// Non-JSON fallback
+// ============================================================================
+
+describe("parseGeminiStdoutLine — non-JSON input", () => {
+  it("wraps plain text in a stdout entry", () => {
+    const result = parseGeminiStdoutLine("hello world", TS);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "stdout", text: "hello world", ts: TS });
+  });
+
+  it("wraps malformed JSON in a stdout entry", () => {
+    const result = parseGeminiStdoutLine("{not json}", TS);
+    expect(result[0]?.kind).toBe("stdout");
+  });
+
+  it("wraps blank line in a stdout entry", () => {
+    const result = parseGeminiStdoutLine("", TS);
+    expect(result[0]?.kind).toBe("stdout");
+  });
+});
+
+// ============================================================================
+// system / init event
+// ============================================================================
+
+describe("parseGeminiStdoutLine — system init", () => {
+  it("returns an init entry with sessionId and model", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "init",
+      session_id: "sess-42",
+      model: "gemini-2.0",
+    });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "init", model: "gemini-2.0", sessionId: "sess-42" });
+  });
+
+  it("uses thread_id as session fallback when session_id is absent", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "init",
+      thread_id: "thread-99",
+      model: "gemini-pro",
+    });
+    const result = parseGeminiStdoutLine(line, TS);
+    const entry = result[0] as { kind: string; sessionId?: string };
+    expect(entry.sessionId).toBe("thread-99");
+  });
+
+  it("returns a system entry for other subtypes", () => {
+    const line = JSON.stringify({ type: "system", subtype: "unknown_subtype" });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result[0]?.kind).toBe("system");
+  });
+
+  it("returns stderr for system error subtype", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "error",
+      error: "quota exceeded",
+    });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result[0]?.kind).toBe("stderr");
+    const entry = result[0] as { kind: string; text: string };
+    expect(entry.text).toContain("quota exceeded");
+  });
+});
+
+// ============================================================================
+// assistant event
+// ============================================================================
+
+describe("parseGeminiStdoutLine — assistant", () => {
+  it("extracts text content from assistant message", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [{ type: "text", text: "Hello there!" }],
+      },
+    });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result.some((e) => e.kind === "assistant")).toBe(true);
+    const entry = result.find((e) => e.kind === "assistant") as { kind: string; text: string } | undefined;
+    expect(entry?.text).toContain("Hello there!");
+  });
+});
+
+// ============================================================================
+// thinking event
+// ============================================================================
+
+describe("parseGeminiStdoutLine — thinking", () => {
+  it("returns a thinking entry for type=thinking with text", () => {
+    const line = JSON.stringify({ type: "thinking", text: "reasoning..." });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "thinking", text: "reasoning..." });
+  });
+
+  it("returns empty for thinking with no text", () => {
+    const line = JSON.stringify({ type: "thinking", text: "" });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// text event
+// ============================================================================
+
+describe("parseGeminiStdoutLine — text", () => {
+  it("returns an assistant entry for type=text", () => {
+    const line = JSON.stringify({ type: "text", text: "Here is my response." });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ kind: "assistant", text: "Here is my response." });
+  });
+
+  it("returns empty for type=text with blank text", () => {
+    const line = JSON.stringify({ type: "text", text: "   " });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// result event
+// ============================================================================
+
+describe("parseGeminiStdoutLine — result", () => {
+  it("returns a result entry with usage fields", () => {
+    const line = JSON.stringify({
+      type: "result",
+      result: "Task complete",
+      total_cost_usd: 0.012,
+      usage: { input_tokens: 100, output_tokens: 50, cache_read_input_tokens: 20 },
+    });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result).toHaveLength(1);
+    const entry = result[0] as { kind: string; text: string; costUsd: number; inputTokens: number };
+    expect(entry.kind).toBe("result");
+    expect(entry.text).toBe("Task complete");
+    expect(entry.costUsd).toBe(0.012);
+    expect(entry.inputTokens).toBe(100);
+  });
+
+  it("returns an error result for is_error=true", () => {
+    const line = JSON.stringify({
+      type: "result",
+      is_error: true,
+      error: "something failed",
+    });
+    const result = parseGeminiStdoutLine(line, TS);
+    const entry = result[0] as { kind: string; isError: boolean; errors: string[] };
+    expect(entry.kind).toBe("result");
+    expect(entry.isError).toBe(true);
+    expect(entry.errors).toContain("something failed");
+  });
+});
+
+// ============================================================================
+// error event
+// ============================================================================
+
+describe("parseGeminiStdoutLine — error", () => {
+  it("returns a stderr entry for type=error with string error", () => {
+    const line = JSON.stringify({ type: "error", error: "auth failed" });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.kind).toBe("stderr");
+    const entry = result[0] as { kind: string; text: string };
+    expect(entry.text).toContain("auth failed");
+  });
+
+  it("returns a stderr entry with fallback text for empty error", () => {
+    const line = JSON.stringify({ type: "error" });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result[0]?.kind).toBe("stderr");
+  });
+});
+
+// ============================================================================
+// step_finish / step_complete
+// ============================================================================
+
+describe("parseGeminiStdoutLine — step_finish / step_complete", () => {
+  it("returns empty array for type=step_finish", () => {
+    const line = JSON.stringify({ type: "step_finish" });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result).toHaveLength(0);
+  });
+
+  it("returns empty array for type=step_complete", () => {
+    const line = JSON.stringify({ type: "step_complete" });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// unknown type fallback
+// ============================================================================
+
+describe("parseGeminiStdoutLine — unknown type", () => {
+  it("falls through to stdout for unknown event types", () => {
+    const line = JSON.stringify({ type: "mystery_event", data: {} });
+    const result = parseGeminiStdoutLine(line, TS);
+    expect(result[0]?.kind).toBe("stdout");
+  });
+});

--- a/packages/adapters/pi-local/src/ui/build-config.test.ts
+++ b/packages/adapters/pi-local/src/ui/build-config.test.ts
@@ -126,10 +126,9 @@ describe("buildPiLocalConfig", () => {
   });
 
   it("includes adapterFallbackChain when non-empty", () => {
-    const config = buildPiLocalConfig(
-      makeValues({ adapterFallbackChain: ["pi_local", "gemini_local"] }),
-    );
-    expect(config.adapterFallbackChain).toEqual(["pi_local", "gemini_local"]);
+    const chain = [{ adapterType: "pi_local" }, { adapterType: "gemini_local" }];
+    const config = buildPiLocalConfig(makeValues({ adapterFallbackChain: chain }));
+    expect(config.adapterFallbackChain).toEqual(chain);
   });
 
   it("omits adapterFallbackChain when empty", () => {

--- a/packages/adapters/pi-local/src/ui/build-config.test.ts
+++ b/packages/adapters/pi-local/src/ui/build-config.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { buildPiLocalConfig } from "./build-config.js";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "pi_local",
+    cwd: "",
+    instructionsFilePath: "",
+    promptTemplate: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: false,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: false,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    payloadTemplateJson: "",
+    workspaceStrategyType: "project_primary",
+    workspaceBaseRef: "",
+    workspaceBranchTemplate: "",
+    worktreeParentDir: "",
+    runtimeServicesJson: "",
+    maxTurnsPerRun: 1000,
+    heartbeatEnabled: false,
+    intervalSec: 300,
+    ...overrides,
+  };
+}
+
+describe("buildPiLocalConfig", () => {
+  it("omits model when not provided", () => {
+    const config = buildPiLocalConfig(makeValues({ model: "" }));
+    expect(config.model).toBeUndefined();
+  });
+
+  it("uses the provided model when set", () => {
+    const config = buildPiLocalConfig(makeValues({ model: "pi-model-v2" }));
+    expect(config.model).toBe("pi-model-v2");
+  });
+
+  it("includes cwd when provided", () => {
+    const config = buildPiLocalConfig(makeValues({ cwd: "/my/project" }));
+    expect(config.cwd).toBe("/my/project");
+  });
+
+  it("omits cwd when empty", () => {
+    const config = buildPiLocalConfig(makeValues({ cwd: "" }));
+    expect(config.cwd).toBeUndefined();
+  });
+
+  it("includes instructionsFilePath when provided", () => {
+    const config = buildPiLocalConfig(makeValues({ instructionsFilePath: "/path/to/CLAUDE.md" }));
+    expect(config.instructionsFilePath).toBe("/path/to/CLAUDE.md");
+  });
+
+  it("omits instructionsFilePath when empty", () => {
+    const config = buildPiLocalConfig(makeValues({ instructionsFilePath: "" }));
+    expect(config.instructionsFilePath).toBeUndefined();
+  });
+
+  it("maps bootstrapPrompt to bootstrapPromptTemplate", () => {
+    const config = buildPiLocalConfig(makeValues({ bootstrapPrompt: "start here" }));
+    expect(config.bootstrapPromptTemplate).toBe("start here");
+  });
+
+  it("maps thinkingEffort to thinking field", () => {
+    const config = buildPiLocalConfig(makeValues({ thinkingEffort: "high" }));
+    expect(config.thinking).toBe("high");
+  });
+
+  it("omits thinking when thinkingEffort is empty", () => {
+    const config = buildPiLocalConfig(makeValues({ thinkingEffort: "" }));
+    expect(config.thinking).toBeUndefined();
+  });
+
+  it("always sets timeoutSec to 0", () => {
+    const config = buildPiLocalConfig(makeValues());
+    expect(config.timeoutSec).toBe(0);
+  });
+
+  it("always sets graceSec to 20", () => {
+    const config = buildPiLocalConfig(makeValues());
+    expect(config.graceSec).toBe(20);
+  });
+
+  it("populates env from envVars text", () => {
+    const config = buildPiLocalConfig(
+      makeValues({ envVars: "API_KEY=secret\nDEBUG=true" }),
+    );
+    const env = config.env as Record<string, unknown>;
+    expect(env).toBeDefined();
+    expect(env["API_KEY"]).toEqual({ type: "plain", value: "secret" });
+    expect(env["DEBUG"]).toEqual({ type: "plain", value: "true" });
+  });
+
+  it("populates env from envBindings with plain values", () => {
+    const config = buildPiLocalConfig(
+      makeValues({ envBindings: { MY_VAR: "value123" } }),
+    );
+    const env = config.env as Record<string, unknown>;
+    expect(env["MY_VAR"]).toEqual({ type: "plain", value: "value123" });
+  });
+
+  it("envBindings secret_ref takes priority over envVars for same key", () => {
+    const config = buildPiLocalConfig(
+      makeValues({
+        envBindings: { TOKEN: { type: "secret_ref", secretId: "sec-1" } },
+        envVars: "TOKEN=plain-value",
+      }),
+    );
+    const env = config.env as Record<string, unknown>;
+    expect((env["TOKEN"] as { type: string }).type).toBe("secret_ref");
+  });
+
+  it("omits env when no env vars or bindings provided", () => {
+    const config = buildPiLocalConfig(makeValues({ envVars: "", envBindings: {} }));
+    expect(config.env).toBeUndefined();
+  });
+
+  it("includes adapterFallbackChain when non-empty", () => {
+    const config = buildPiLocalConfig(
+      makeValues({ adapterFallbackChain: ["pi_local", "gemini_local"] }),
+    );
+    expect(config.adapterFallbackChain).toEqual(["pi_local", "gemini_local"]);
+  });
+
+  it("omits adapterFallbackChain when empty", () => {
+    const config = buildPiLocalConfig(makeValues({ adapterFallbackChain: [] }));
+    expect(config.adapterFallbackChain).toBeUndefined();
+  });
+
+  it("passes extraArgs through as-is (not comma-split)", () => {
+    const config = buildPiLocalConfig(makeValues({ extraArgs: "--flag1 --flag2" }));
+    expect(config.extraArgs).toBe("--flag1 --flag2");
+  });
+
+  it("omits extraArgs when empty", () => {
+    const config = buildPiLocalConfig(makeValues({ extraArgs: "" }));
+    expect(config.extraArgs).toBeUndefined();
+  });
+
+  it("includes args when provided", () => {
+    const config = buildPiLocalConfig(makeValues({ args: "--some-arg" }));
+    expect(config.args).toBe("--some-arg");
+  });
+
+  it("omits args when empty", () => {
+    const config = buildPiLocalConfig(makeValues({ args: "" }));
+    expect(config.args).toBeUndefined();
+  });
+
+  it("includes command when provided", () => {
+    const config = buildPiLocalConfig(makeValues({ command: "/usr/bin/pi" }));
+    expect(config.command).toBe("/usr/bin/pi");
+  });
+
+  it("omits command when empty", () => {
+    const config = buildPiLocalConfig(makeValues({ command: "" }));
+    expect(config.command).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- **home.test.ts** — 21 tests covering `expandHomePrefix`, `resolvePaperclipInstanceId` (override/env/default/invalid chars), `resolvePaperclipHomeDir`, and all 8 path resolution helpers (`resolveDefaultConfigPath`, `resolveDefaultContextPath`, `resolveDefaultCliAuthPath`, `resolveDefaultEmbeddedPostgresDir`, `resolveDefaultLogsDir`, `resolveDefaultSecretsKeyFilePath`, `resolveDefaultStorageDir`, `resolveDefaultBackupDir`)
- **hostnames.test.ts** — 15 tests for `normalizeHostnameInput` (bare hostname, full URL, IP address, lowercase normalisation, whitespace trimming, empty/whitespace throwing) and `parseHostnameCsv` (empty, single, multi, dedup, case normalisation, full URLs)
- **server-bind.test.ts** — 14 tests for `inferConfiguredBind` (explicit bind, localhost → loopback, 0.0.0.0 → lan, undefined fallback), `buildPresetServerConfig` (loopback/lan shapes, input passthrough), and `buildCustomServerConfig` (bind mode selection by host, exposure forced to private for local_trusted, `publicBaseUrl` wiring, whitespace trimming)

All tests are pure function tests — no database, network, or filesystem mocks needed (env and `os.homedir` are stubbed via `vi.stubEnv` / `vi.spyOn`).

## Test plan

- [ ] CI verify job passes (typecheck + coverage)
- [ ] Benchmark Score run completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)