### PR TITLE
test(server,shared): 67 unit tests for log-redaction, attachment-types, and sidebar-preferences validator

### DIFF
--- a/packages/shared/src/validators/sidebar-preferences.test.ts
+++ b/packages/shared/src/validators/sidebar-preferences.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { sidebarOrderPreferenceSchema, upsertSidebarOrderPreferenceSchema } from "./sidebar-preferences.js";
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const VALID_UUID_2 = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+// ============================================================================
+// sidebarOrderPreferenceSchema
+// ============================================================================
+
+describe("sidebarOrderPreferenceSchema", () => {
+  it("accepts a valid object with UUID orderedIds and null updatedAt", () => {
+    const result = sidebarOrderPreferenceSchema.safeParse({
+      orderedIds: [VALID_UUID],
+      updatedAt: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an empty orderedIds array", () => {
+    const result = sidebarOrderPreferenceSchema.safeParse({
+      orderedIds: [],
+      updatedAt: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts multiple UUIDs in orderedIds", () => {
+    const result = sidebarOrderPreferenceSchema.safeParse({
+      orderedIds: [VALID_UUID, VALID_UUID_2],
+      updatedAt: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("coerces ISO date string to Date for updatedAt", () => {
+    const result = sidebarOrderPreferenceSchema.safeParse({
+      orderedIds: [],
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.updatedAt).toBeInstanceOf(Date);
+    }
+  });
+
+  it("rejects non-UUID strings in orderedIds", () => {
+    const result = sidebarOrderPreferenceSchema.safeParse({
+      orderedIds: ["not-a-uuid"],
+      updatedAt: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing orderedIds", () => {
+    const result = sidebarOrderPreferenceSchema.safeParse({ updatedAt: null });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing updatedAt", () => {
+    const result = sidebarOrderPreferenceSchema.safeParse({ orderedIds: [] });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ============================================================================
+// upsertSidebarOrderPreferenceSchema
+// ============================================================================
+
+describe("upsertSidebarOrderPreferenceSchema", () => {
+  it("accepts valid UUID array", () => {
+    const result = upsertSidebarOrderPreferenceSchema.safeParse({
+      orderedIds: [VALID_UUID],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts empty orderedIds", () => {
+    const result = upsertSidebarOrderPreferenceSchema.safeParse({ orderedIds: [] });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-UUID orderedIds", () => {
+    const result = upsertSidebarOrderPreferenceSchema.safeParse({
+      orderedIds: ["bad-id"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing orderedIds field", () => {
+    const result = upsertSidebarOrderPreferenceSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});

--- a/server/src/attachment-types.test.ts
+++ b/server/src/attachment-types.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  parseAllowedTypes,
+  matchesContentType,
+  normalizeContentType,
+  isInlineAttachmentContentType,
+  DEFAULT_ALLOWED_TYPES,
+  INLINE_ATTACHMENT_TYPES,
+} from "./attachment-types.js";
+
+// ============================================================================
+// parseAllowedTypes
+// ============================================================================
+
+describe("parseAllowedTypes", () => {
+  it("returns a copy of DEFAULT_ALLOWED_TYPES for undefined input", () => {
+    const result = parseAllowedTypes(undefined);
+    expect(result).toEqual([...DEFAULT_ALLOWED_TYPES]);
+  });
+
+  it("returns a copy of DEFAULT_ALLOWED_TYPES for empty string", () => {
+    const result = parseAllowedTypes("");
+    expect(result).toEqual([...DEFAULT_ALLOWED_TYPES]);
+  });
+
+  it("returns a copy of DEFAULT_ALLOWED_TYPES for whitespace-only string", () => {
+    const result = parseAllowedTypes("  ,  ,  ");
+    expect(result).toEqual([...DEFAULT_ALLOWED_TYPES]);
+  });
+
+  it("parses a single MIME type", () => {
+    expect(parseAllowedTypes("image/png")).toEqual(["image/png"]);
+  });
+
+  it("parses multiple comma-separated MIME types", () => {
+    expect(parseAllowedTypes("image/png,application/pdf")).toEqual(["image/png", "application/pdf"]);
+  });
+
+  it("trims whitespace around entries", () => {
+    expect(parseAllowedTypes("image/png , application/pdf")).toEqual(["image/png", "application/pdf"]);
+  });
+
+  it("lowercases all entries", () => {
+    expect(parseAllowedTypes("Image/PNG,Application/PDF")).toEqual(["image/png", "application/pdf"]);
+  });
+
+  it("parses wildcard patterns", () => {
+    expect(parseAllowedTypes("image/*,text/*")).toEqual(["image/*", "text/*"]);
+  });
+});
+
+// ============================================================================
+// matchesContentType
+// ============================================================================
+
+describe("matchesContentType", () => {
+  it("matches exact content type", () => {
+    expect(matchesContentType("image/png", ["image/png"])).toBe(true);
+  });
+
+  it("returns false for non-matching exact type", () => {
+    expect(matchesContentType("image/png", ["image/jpeg"])).toBe(false);
+  });
+
+  it("matches wildcard image/* against image/png", () => {
+    expect(matchesContentType("image/png", ["image/*"])).toBe(true);
+  });
+
+  it("matches wildcard image/* against image/jpeg", () => {
+    expect(matchesContentType("image/jpeg", ["image/*"])).toBe(true);
+  });
+
+  it("does not match image/* against application/pdf", () => {
+    expect(matchesContentType("application/pdf", ["image/*"])).toBe(false);
+  });
+
+  it("matches glob wildcard * for any type", () => {
+    expect(matchesContentType("application/octet-stream", ["*"])).toBe(true);
+  });
+
+  it("matches wildcard suffix pattern .*", () => {
+    expect(
+      matchesContentType(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ["application/vnd.openxmlformats-officedocument.*"],
+      ),
+    ).toBe(true);
+  });
+
+  it("is case-insensitive for content type", () => {
+    expect(matchesContentType("Image/PNG", ["image/png"])).toBe(true);
+  });
+
+  it("returns false for empty allowed list", () => {
+    expect(matchesContentType("image/png", [])).toBe(false);
+  });
+
+  it("returns true when multiple patterns and one matches", () => {
+    expect(matchesContentType("text/plain", ["image/*", "text/*"])).toBe(true);
+  });
+});
+
+// ============================================================================
+// normalizeContentType
+// ============================================================================
+
+describe("normalizeContentType", () => {
+  it("lowercases content type", () => {
+    expect(normalizeContentType("Image/PNG")).toBe("image/png");
+  });
+
+  it("trims whitespace", () => {
+    expect(normalizeContentType("  image/png  ")).toBe("image/png");
+  });
+
+  it("returns application/octet-stream for null", () => {
+    expect(normalizeContentType(null)).toBe("application/octet-stream");
+  });
+
+  it("returns application/octet-stream for undefined", () => {
+    expect(normalizeContentType(undefined)).toBe("application/octet-stream");
+  });
+
+  it("returns application/octet-stream for empty string", () => {
+    expect(normalizeContentType("")).toBe("application/octet-stream");
+  });
+
+  it("returns application/octet-stream for whitespace-only string", () => {
+    expect(normalizeContentType("   ")).toBe("application/octet-stream");
+  });
+
+  it("passes through a valid content type unchanged (lowercased)", () => {
+    expect(normalizeContentType("application/json")).toBe("application/json");
+  });
+});
+
+// ============================================================================
+// isInlineAttachmentContentType
+// ============================================================================
+
+describe("isInlineAttachmentContentType", () => {
+  it("returns true for image/png (matches image/*)", () => {
+    expect(isInlineAttachmentContentType("image/png")).toBe(true);
+  });
+
+  it("returns true for image/jpeg (matches image/*)", () => {
+    expect(isInlineAttachmentContentType("image/jpeg")).toBe(true);
+  });
+
+  it("returns true for application/pdf", () => {
+    expect(isInlineAttachmentContentType("application/pdf")).toBe(true);
+  });
+
+  it("returns true for text/plain", () => {
+    expect(isInlineAttachmentContentType("text/plain")).toBe(true);
+  });
+
+  it("returns true for text/markdown", () => {
+    expect(isInlineAttachmentContentType("text/markdown")).toBe(true);
+  });
+
+  it("returns true for application/json", () => {
+    expect(isInlineAttachmentContentType("application/json")).toBe(true);
+  });
+
+  it("returns false for application/octet-stream", () => {
+    expect(isInlineAttachmentContentType("application/octet-stream")).toBe(false);
+  });
+
+  it("returns false for application/zip", () => {
+    expect(isInlineAttachmentContentType("application/zip")).toBe(false);
+  });
+
+  it("INLINE_ATTACHMENT_TYPES constant includes image/*", () => {
+    expect(INLINE_ATTACHMENT_TYPES).toContain("image/*");
+  });
+});

--- a/server/src/log-redaction.test.ts
+++ b/server/src/log-redaction.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { maskUserNameForLogs, redactCurrentUserText, redactCurrentUserValue } from "./log-redaction.js";
+
+// ============================================================================
+// maskUserNameForLogs
+// ============================================================================
+
+describe("maskUserNameForLogs", () => {
+  it("masks all but the first character", () => {
+    expect(maskUserNameForLogs("alice")).toBe("a****");
+  });
+
+  it("preserves the first character", () => {
+    const result = maskUserNameForLogs("bob");
+    expect(result.startsWith("b")).toBe(true);
+  });
+
+  it("masks a single-character username with one asterisk", () => {
+    expect(maskUserNameForLogs("a")).toBe("a*");
+  });
+
+  it("returns fallback for empty string", () => {
+    expect(maskUserNameForLogs("")).toBe("*");
+  });
+
+  it("returns fallback for whitespace-only string", () => {
+    expect(maskUserNameForLogs("   ")).toBe("*");
+  });
+
+  it("accepts a custom fallback", () => {
+    expect(maskUserNameForLogs("", "[redacted]")).toBe("[redacted]");
+  });
+
+  it("trims leading/trailing whitespace before masking", () => {
+    expect(maskUserNameForLogs("  alice  ")).toBe("a****");
+  });
+
+  it("produces the correct number of asterisks", () => {
+    const result = maskUserNameForLogs("charlie");
+    expect(result).toBe("c******");
+  });
+});
+
+// ============================================================================
+// redactCurrentUserText — tested with explicit opts to avoid OS dependency
+// ============================================================================
+
+describe("redactCurrentUserText", () => {
+  it("returns empty string unchanged", () => {
+    expect(redactCurrentUserText("", { userNames: ["alice"], homeDirs: ["/home/alice"] })).toBe("");
+  });
+
+  it("returns input unchanged when enabled=false", () => {
+    const input = "/home/alice/project";
+    expect(redactCurrentUserText(input, { enabled: false })).toBe(input);
+  });
+
+  it("replaces home directory with masked version", () => {
+    const result = redactCurrentUserText("/home/alice/project", {
+      userNames: ["alice"],
+      homeDirs: ["/home/alice"],
+    });
+    expect(result).not.toContain("/home/alice");
+    expect(result).toContain("/home/");
+  });
+
+  it("replaces standalone username with masked version", () => {
+    const result = redactCurrentUserText("Hello alice, how are you?", {
+      userNames: ["alice"],
+      homeDirs: [],
+    });
+    expect(result).not.toContain("alice");
+    expect(result).toContain("a****");
+  });
+
+  it("does not replace username that is part of a longer word", () => {
+    const result = redactCurrentUserText("invalice or alices", {
+      userNames: ["alice"],
+      homeDirs: [],
+    });
+    // "invalice" contains "alice" as substring preceded by letter — should NOT be replaced
+    // "alices" contains "alice" followed by letter — should NOT be replaced
+    expect(result).toBe("invalice or alices");
+  });
+
+  it("handles Windows-style home directory paths", () => {
+    const result = redactCurrentUserText("C:\\Users\\alice\\Documents", {
+      userNames: ["alice"],
+      homeDirs: ["C:\\Users\\alice"],
+    });
+    expect(result).not.toContain("C:\\Users\\alice");
+  });
+
+  it("redacts home directory using masked username, not replacing alice literally", () => {
+    const result = redactCurrentUserText("path /home/alice/file", {
+      userNames: ["alice"],
+      homeDirs: ["/home/alice"],
+    });
+    // The home path is replaced with a masked version of the last segment
+    expect(result).not.toContain("/home/alice/");
+    expect(result).toContain("a****");
+  });
+
+  it("handles multiple usernames, replacing all occurrences", () => {
+    const result = redactCurrentUserText("alice and bob are users", {
+      userNames: ["alice", "bob"],
+      homeDirs: [],
+    });
+    expect(result).not.toContain("alice");
+    expect(result).not.toContain("bob");
+  });
+});
+
+// ============================================================================
+// redactCurrentUserValue — typed recursive redaction
+// ============================================================================
+
+describe("redactCurrentUserValue", () => {
+  const opts = { userNames: ["alice"], homeDirs: ["/home/alice"] };
+
+  it("returns non-string primitives unchanged", () => {
+    expect(redactCurrentUserValue(42, opts)).toBe(42);
+    expect(redactCurrentUserValue(true, opts)).toBe(true);
+    expect(redactCurrentUserValue(null, opts)).toBeNull();
+  });
+
+  it("redacts strings", () => {
+    const result = redactCurrentUserValue("path: /home/alice/code", opts);
+    expect(result).not.toContain("/home/alice");
+  });
+
+  it("recursively redacts strings in arrays", () => {
+    const result = redactCurrentUserValue(["/home/alice/a", "/home/alice/b"], opts);
+    expect(result[0]).not.toContain("/home/alice");
+    expect(result[1]).not.toContain("/home/alice");
+  });
+
+  it("recursively redacts strings in plain objects", () => {
+    const result = redactCurrentUserValue({ path: "/home/alice/project" }, opts);
+    expect(result.path).not.toContain("/home/alice");
+  });
+
+  it("recursively redacts nested objects", () => {
+    const result = redactCurrentUserValue(
+      { outer: { inner: "/home/alice/deep" } },
+      opts,
+    );
+    expect(result.outer.inner).not.toContain("/home/alice");
+  });
+
+  it("does not redact class instances (non-plain objects)", () => {
+    class MyClass {
+      value = "/home/alice/path";
+    }
+    const instance = new MyClass();
+    const result = redactCurrentUserValue(instance, opts);
+    // Should return the instance unchanged since it's not a plain object
+    expect(result).toBe(instance);
+  });
+});


### PR DESCRIPTION
Adds unit tests for three modules with no prior test coverage.

## Changes

**server/src/log-redaction.test.ts** (22 tests):
- `maskUserNameForLogs` — character masking, fallback for empty string, custom fallback, whitespace trimming
- `redactCurrentUserText` — home directory replacement, username replacement, word-boundary awareness, Windows paths, multiple usernames; all tested with explicit `userNames`/`homeDirs` opts for OS independence
- `redactCurrentUserValue` — recursive redaction of strings, arrays, plain objects, and nested objects; non-plain objects returned unchanged

**server/src/attachment-types.test.ts** (34 tests):
- `parseAllowedTypes` — undefined/empty fallback to DEFAULT_ALLOWED_TYPES, CSV parsing, trimming, lowercasing, wildcard patterns
- `matchesContentType` — exact match, wildcard image/\*, wildcard .\*, global \*, case-insensitive, empty allowed list, multi-pattern
- `normalizeContentType` — lowercasing, trimming, null/undefined/empty fallback to application/octet-stream
- `isInlineAttachmentContentType` — image/\*, pdf, text/plain, text/markdown, application/json, non-inline types

**packages/shared/src/validators/sidebar-preferences.test.ts** (11 tests):
- `sidebarOrderPreferenceSchema` — UUID array validation, date coercion, null updatedAt, rejects non-UUIDs and missing fields
- `upsertSidebarOrderPreferenceSchema` — UUID array validation, empty array, rejects invalid IDs

All 67 tests pass locally.