### PR TITLE
test(server): 31 unit tests for deriveIssueUserContext and selectCurrentRuntimeServiceRows

### DIFF
--- a/server/src/__tests__/issue-user-context.test.ts
+++ b/server/src/__tests__/issue-user-context.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import { deriveIssueUserContext } from "../services/issues.js";
+
+// Minimal issue shape matching IssueUserContextInput
+function makeIssue(overrides: {
+  createdByUserId?: string | null;
+  assigneeUserId?: string | null;
+  createdAt?: Date | string;
+  updatedAt?: Date | string;
+} = {}) {
+  return {
+    createdByUserId: overrides.createdByUserId ?? null,
+    assigneeUserId: overrides.assigneeUserId ?? null,
+    createdAt: overrides.createdAt ?? new Date("2024-01-01T00:00:00Z"),
+    updatedAt: overrides.updatedAt ?? new Date("2024-01-01T00:00:00Z"),
+  };
+}
+
+describe("deriveIssueUserContext", () => {
+  const USER_A = "user-a";
+  const USER_B = "user-b";
+
+  // ── null / empty stats ──────────────────────────────────────────────────
+
+  it("returns no touch when stats is null and user has no relation to the issue", () => {
+    const result = deriveIssueUserContext(makeIssue(), USER_A, null);
+    expect(result.myLastTouchAt).toBeNull();
+    expect(result.lastExternalCommentAt).toBeNull();
+    expect(result.isUnreadForMe).toBe(false);
+  });
+
+  it("returns no touch when stats is undefined", () => {
+    const result = deriveIssueUserContext(makeIssue(), USER_A, undefined);
+    expect(result.myLastTouchAt).toBeNull();
+  });
+
+  // ── createdByUserId touch ───────────────────────────────────────────────
+
+  it("sets myLastTouchAt to createdAt when user created the issue (no stats)", () => {
+    const createdAt = new Date("2024-03-01T10:00:00Z");
+    const result = deriveIssueUserContext(
+      makeIssue({ createdByUserId: USER_A, createdAt }),
+      USER_A,
+      null,
+    );
+    expect(result.myLastTouchAt).toEqual(createdAt);
+  });
+
+  it("does NOT set createdAt touch when a different user created the issue", () => {
+    const result = deriveIssueUserContext(
+      makeIssue({ createdByUserId: USER_B }),
+      USER_A,
+      null,
+    );
+    expect(result.myLastTouchAt).toBeNull();
+  });
+
+  // ── assigneeUserId touch ────────────────────────────────────────────────
+
+  it("sets myLastTouchAt to updatedAt when user is the assignee (no stats)", () => {
+    const updatedAt = new Date("2024-03-15T12:00:00Z");
+    const result = deriveIssueUserContext(
+      makeIssue({ assigneeUserId: USER_A, updatedAt }),
+      USER_A,
+      null,
+    );
+    expect(result.myLastTouchAt).toEqual(updatedAt);
+  });
+
+  it("does NOT set updatedAt touch when a different user is the assignee", () => {
+    const result = deriveIssueUserContext(
+      makeIssue({ assigneeUserId: USER_B }),
+      USER_A,
+      null,
+    );
+    expect(result.myLastTouchAt).toBeNull();
+  });
+
+  // ── stats-based touches ─────────────────────────────────────────────────
+
+  it("uses myLastCommentAt from stats as the touch timestamp", () => {
+    const myLastCommentAt = new Date("2024-05-01T08:00:00Z");
+    const result = deriveIssueUserContext(makeIssue(), USER_A, {
+      myLastCommentAt,
+      myLastReadAt: null,
+      lastExternalCommentAt: null,
+    });
+    expect(result.myLastTouchAt).toEqual(myLastCommentAt);
+  });
+
+  it("uses myLastReadAt from stats when no comment timestamp", () => {
+    const myLastReadAt = new Date("2024-05-02T09:00:00Z");
+    const result = deriveIssueUserContext(makeIssue(), USER_A, {
+      myLastCommentAt: null,
+      myLastReadAt,
+      lastExternalCommentAt: null,
+    });
+    expect(result.myLastTouchAt).toEqual(myLastReadAt);
+  });
+
+  it("picks the most recent among all touch timestamps", () => {
+    const commentAt = new Date("2024-06-01T10:00:00Z");
+    const readAt = new Date("2024-05-01T10:00:00Z");
+    const createdAt = new Date("2024-04-01T10:00:00Z");
+    const result = deriveIssueUserContext(
+      makeIssue({ createdByUserId: USER_A, createdAt }),
+      USER_A,
+      { myLastCommentAt: commentAt, myLastReadAt: readAt, lastExternalCommentAt: null },
+    );
+    expect(result.myLastTouchAt).toEqual(commentAt);
+  });
+
+  it("picks createdAt as most recent touch when it is the latest", () => {
+    const createdAt = new Date("2024-07-01T10:00:00Z");
+    const readAt = new Date("2024-06-01T10:00:00Z");
+    const result = deriveIssueUserContext(
+      makeIssue({ createdByUserId: USER_A, createdAt }),
+      USER_A,
+      { myLastCommentAt: null, myLastReadAt: readAt, lastExternalCommentAt: null },
+    );
+    expect(result.myLastTouchAt).toEqual(createdAt);
+  });
+
+  // ── isUnreadForMe ───────────────────────────────────────────────────────
+
+  it("marks issue as unread when external comment is newer than last touch", () => {
+    const touchAt = new Date("2024-04-01T00:00:00Z");
+    const externalAt = new Date("2024-04-02T00:00:00Z"); // after touch
+    const result = deriveIssueUserContext(makeIssue(), USER_A, {
+      myLastCommentAt: touchAt,
+      myLastReadAt: null,
+      lastExternalCommentAt: externalAt,
+    });
+    expect(result.isUnreadForMe).toBe(true);
+  });
+
+  it("marks issue as read when external comment is older than last touch", () => {
+    const touchAt = new Date("2024-04-02T00:00:00Z");
+    const externalAt = new Date("2024-04-01T00:00:00Z"); // before touch
+    const result = deriveIssueUserContext(makeIssue(), USER_A, {
+      myLastCommentAt: touchAt,
+      myLastReadAt: null,
+      lastExternalCommentAt: externalAt,
+    });
+    expect(result.isUnreadForMe).toBe(false);
+  });
+
+  it("is NOT unread when there is no external comment", () => {
+    const result = deriveIssueUserContext(makeIssue(), USER_A, {
+      myLastCommentAt: new Date("2024-04-01T00:00:00Z"),
+      myLastReadAt: null,
+      lastExternalCommentAt: null,
+    });
+    expect(result.isUnreadForMe).toBe(false);
+  });
+
+  it("is NOT unread when there is no last touch (user has no relation and no stats)", () => {
+    const result = deriveIssueUserContext(makeIssue(), USER_A, {
+      myLastCommentAt: null,
+      myLastReadAt: null,
+      lastExternalCommentAt: new Date("2024-04-01T00:00:00Z"),
+    });
+    expect(result.isUnreadForMe).toBe(false);
+  });
+
+  // ── ISO string dates ────────────────────────────────────────────────────
+
+  it("handles ISO string dates from stats", () => {
+    const touchStr = "2024-04-01T00:00:00Z";
+    const externalStr = "2024-04-02T00:00:00Z";
+    const result = deriveIssueUserContext(makeIssue(), USER_A, {
+      myLastCommentAt: touchStr,
+      myLastReadAt: null,
+      lastExternalCommentAt: externalStr,
+    });
+    expect(result.isUnreadForMe).toBe(true);
+    expect(result.myLastTouchAt).toEqual(new Date(touchStr));
+    expect(result.lastExternalCommentAt).toEqual(new Date(externalStr));
+  });
+
+  it("handles ISO string dates for issue createdAt", () => {
+    const createdAtStr = "2024-03-01T10:00:00Z";
+    const result = deriveIssueUserContext(
+      makeIssue({ createdByUserId: USER_A, createdAt: createdAtStr }),
+      USER_A,
+      null,
+    );
+    expect(result.myLastTouchAt).toEqual(new Date(createdAtStr));
+  });
+
+  // ── combined creator + assignee ─────────────────────────────────────────
+
+  it("uses updatedAt when user is both creator and assignee and updatedAt is later", () => {
+    const createdAt = new Date("2024-02-01T00:00:00Z");
+    const updatedAt = new Date("2024-03-01T00:00:00Z");
+    const result = deriveIssueUserContext(
+      makeIssue({ createdByUserId: USER_A, assigneeUserId: USER_A, createdAt, updatedAt }),
+      USER_A,
+      null,
+    );
+    expect(result.myLastTouchAt).toEqual(updatedAt);
+  });
+
+  it("uses createdAt when user is both creator and assignee and createdAt is later", () => {
+    const updatedAt = new Date("2024-01-01T00:00:00Z");
+    const createdAt = new Date("2024-03-01T00:00:00Z");
+    const result = deriveIssueUserContext(
+      makeIssue({ createdByUserId: USER_A, assigneeUserId: USER_A, createdAt, updatedAt }),
+      USER_A,
+      null,
+    );
+    expect(result.myLastTouchAt).toEqual(createdAt);
+  });
+});

--- a/server/src/__tests__/workspace-runtime-read-model.test.ts
+++ b/server/src/__tests__/workspace-runtime-read-model.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { selectCurrentRuntimeServiceRows } from "../services/workspace-runtime-read-model.js";
+
+// Helper: create a minimal row object for testing purposes.
+// WorkspaceRuntimeServiceRow is the full Drizzle inferred type — we construct
+// the minimal shape needed for identity-key logic using any-cast so tests
+// don't need to supply every Drizzle column.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeRow(fields: {
+  id: string;
+  reuseKey?: string | null;
+  scopeType?: string;
+  scopeId?: string | null;
+  projectWorkspaceId?: string | null;
+  executionWorkspaceId?: string | null;
+  serviceName?: string;
+  command?: string | null;
+  cwd?: string | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+}) {
+  return {
+    id: fields.id,
+    reuseKey: fields.reuseKey ?? null,
+    scopeType: fields.scopeType ?? "project_workspace",
+    scopeId: fields.scopeId ?? null,
+    projectWorkspaceId: fields.projectWorkspaceId ?? null,
+    executionWorkspaceId: fields.executionWorkspaceId ?? null,
+    serviceName: fields.serviceName ?? "web",
+    command: fields.command ?? null,
+    cwd: fields.cwd ?? null,
+    // Remaining Drizzle required columns — not read by selectCurrentRuntimeServiceRows
+    companyId: "company-1",
+    projectId: null,
+    issueId: null,
+    status: "running",
+    lifecycle: "started",
+    url: null,
+    port: null,
+    provider: "local_process",
+    providerRef: null,
+    ownerAgentId: null,
+    startedByRunId: null,
+    stoppedAt: null,
+    stopPolicy: null,
+    healthStatus: "unknown",
+    lastUsedAt: new Date(),
+    startedAt: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe("selectCurrentRuntimeServiceRows", () => {
+  it("returns empty array for empty input", () => {
+    expect(selectCurrentRuntimeServiceRows([])).toEqual([]);
+  });
+
+  it("returns single row unchanged", () => {
+    const row = makeRow({ id: "row-1" });
+    const result = selectCurrentRuntimeServiceRows([row]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("row-1");
+  });
+
+  it("returns both rows when they have different identity keys", () => {
+    const row1 = makeRow({ id: "row-1", serviceName: "web" });
+    const row2 = makeRow({ id: "row-2", serviceName: "api" });
+    const result = selectCurrentRuntimeServiceRows([row1, row2]);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.id).sort()).toEqual(["row-1", "row-2"]);
+  });
+
+  it("deduplicates rows with the same identity key (keeps first occurrence)", () => {
+    const row1 = makeRow({ id: "row-1", serviceName: "web", scopeType: "project_workspace" });
+    const row2 = makeRow({ id: "row-2", serviceName: "web", scopeType: "project_workspace" });
+    const result = selectCurrentRuntimeServiceRows([row1, row2]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("row-1");
+  });
+
+  it("deduplicates by reuseKey when set (ignores other fields)", () => {
+    const row1 = makeRow({ id: "row-1", reuseKey: "shared-key", serviceName: "web" });
+    const row2 = makeRow({ id: "row-2", reuseKey: "shared-key", serviceName: "api" });
+    const result = selectCurrentRuntimeServiceRows([row1, row2]);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe("row-1");
+  });
+
+  it("treats rows with different reuseKeys as distinct even with same other fields", () => {
+    const row1 = makeRow({ id: "row-1", reuseKey: "key-a", serviceName: "web" });
+    const row2 = makeRow({ id: "row-2", reuseKey: "key-b", serviceName: "web" });
+    const result = selectCurrentRuntimeServiceRows([row1, row2]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("distinguishes rows by projectWorkspaceId", () => {
+    const row1 = makeRow({ id: "row-1", projectWorkspaceId: "ws-1", serviceName: "web" });
+    const row2 = makeRow({ id: "row-2", projectWorkspaceId: "ws-2", serviceName: "web" });
+    const result = selectCurrentRuntimeServiceRows([row1, row2]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("distinguishes rows by executionWorkspaceId", () => {
+    const row1 = makeRow({ id: "row-1", executionWorkspaceId: "ew-1", serviceName: "web" });
+    const row2 = makeRow({ id: "row-2", executionWorkspaceId: "ew-2", serviceName: "web" });
+    const result = selectCurrentRuntimeServiceRows([row1, row2]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("distinguishes rows by cwd", () => {
+    const row1 = makeRow({ id: "row-1", cwd: "/path/a", serviceName: "web" });
+    const row2 = makeRow({ id: "row-2", cwd: "/path/b", serviceName: "web" });
+    const result = selectCurrentRuntimeServiceRows([row1, row2]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("distinguishes rows by command", () => {
+    const row1 = makeRow({ id: "row-1", command: "node server.js", serviceName: "web" });
+    const row2 = makeRow({ id: "row-2", command: "node worker.js", serviceName: "web" });
+    const result = selectCurrentRuntimeServiceRows([row1, row2]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("row with reuseKey and row without are kept separately", () => {
+    const row1 = makeRow({ id: "row-1", reuseKey: "some-key" });
+    const row2 = makeRow({ id: "row-2", reuseKey: null });
+    const result = selectCurrentRuntimeServiceRows([row1, row2]);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.id).sort()).toEqual(["row-1", "row-2"]);
+  });
+
+  it("preserves insertion order of first-seen rows", () => {
+    const row1 = makeRow({ id: "row-1", serviceName: "alpha" });
+    const row2 = makeRow({ id: "row-2", serviceName: "beta" });
+    const row3 = makeRow({ id: "row-3", serviceName: "gamma" });
+    const result = selectCurrentRuntimeServiceRows([row3, row1, row2]);
+    expect(result.map((r) => r.id)).toEqual(["row-3", "row-1", "row-2"]);
+  });
+
+  it("handles 3 rows where first two share an identity", () => {
+    const row1 = makeRow({ id: "row-1", serviceName: "web" });
+    const row2 = makeRow({ id: "row-2", serviceName: "web" }); // duplicate of row1
+    const row3 = makeRow({ id: "row-3", serviceName: "api" });
+    const result = selectCurrentRuntimeServiceRows([row1, row2, row3]);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.id)).toEqual(["row-1", "row-3"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 18 unit tests for `deriveIssueUserContext` in `server/src/services/issues.ts`
  - Tests unread state calculation based on user's last touch vs latest external comment
  - Covers creator/assignee touch timestamps, ISO string dates, combined scenarios
- Adds 13 unit tests for `selectCurrentRuntimeServiceRows` in `server/src/services/workspace-runtime-read-model.ts`
  - Tests deduplication by reuseKey vs composite identity key
  - Verifies first-seen row is kept, insertion order preserved, edge cases

## Test plan

- [x] All 31 tests pass locally with `pnpm vitest run`
- [x] TypeScript typecheck passes (`pnpm --filter @paperclipai/server typecheck`)
- [ ] CI verify job passes