### PR TITLE
test(adapters): 108 unit tests for CLI stream event formatters

### DIFF
--- a/packages/adapters/codex-local/src/cli/format-event.test.ts
+++ b/packages/adapters/codex-local/src/cli/format-event.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { printCodexStreamEvent } from "./format-event.js";
+
+// printCodexStreamEvent parses Codex JSON stream events and writes to console.log.
+// Tests verify routing logic and content extraction by spying on console.log.
+
+describe("printCodexStreamEvent", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  // ── edge cases ────────────────────────────────────────────────────────────
+
+  it("does nothing for empty string", () => {
+    printCodexStreamEvent("", false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for whitespace-only string", () => {
+    printCodexStreamEvent("   \t\n  ", false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs raw text when input is not valid JSON", () => {
+    printCodexStreamEvent("raw log output", false);
+    expect(logSpy).toHaveBeenCalledWith("raw log output");
+  });
+
+  it("logs raw line for unknown event types", () => {
+    const raw = JSON.stringify({ type: "unknown_codex_event" });
+    printCodexStreamEvent(raw, false);
+    expect(logSpy).toHaveBeenCalledWith(raw);
+  });
+
+  // ── thread.started ────────────────────────────────────────────────────────
+
+  it("logs thread started without details when fields are missing", () => {
+    printCodexStreamEvent(JSON.stringify({ type: "thread.started" }), false);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Codex thread started");
+  });
+
+  it("logs thread started with thread_id and model when provided", () => {
+    printCodexStreamEvent(
+      JSON.stringify({ type: "thread.started", thread_id: "t-123", model: "codex-2" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const msg = logSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("session: t-123");
+    expect(msg).toContain("model: codex-2");
+  });
+
+  // ── turn.started ──────────────────────────────────────────────────────────
+
+  it("logs turn started", () => {
+    printCodexStreamEvent(JSON.stringify({ type: "turn.started" }), false);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("turn started");
+  });
+
+  // ── item.started ──────────────────────────────────────────────────────────
+
+  it("logs command_execution item.started with command", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.started",
+        item: { type: "command_execution", command: "npm test" },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_call: command_execution");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("npm test");
+  });
+
+  it("logs command_execution item.started without extra line when command is empty", () => {
+    printCodexStreamEvent(
+      JSON.stringify({ type: "item.started", item: { type: "command_execution" } }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_call: command_execution");
+  });
+
+  it("logs tool_use item.started with name and input", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.started",
+        item: { type: "tool_use", name: "read_file", input: { path: "/tmp/test.ts" } },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_call: read_file");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("/tmp/test.ts");
+  });
+
+  it("logs generic item.started for unrecognized item types", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.started",
+        item: { type: "unknown_item", id: "i-1", status: "active" },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("item.started");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("unknown_item");
+  });
+
+  // ── item.completed ────────────────────────────────────────────────────────
+
+  it("logs assistant message for agent_message item.completed", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "agent_message", text: "Task complete!" },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("assistant:");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Task complete!");
+  });
+
+  it("does not log assistant message when text is empty", () => {
+    printCodexStreamEvent(
+      JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "" } }),
+      false,
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs thinking text for reasoning item.completed", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "reasoning", text: "Let me analyze this..." },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("thinking:");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Let me analyze this...");
+  });
+
+  it("logs successful command_execution item.completed with output", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          command: "ls",
+          status: "completed",
+          exit_code: 0,
+          aggregated_output: "file.ts\nindex.ts\n",
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_result: command_execution");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("command=\"ls\"");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("file.ts");
+  });
+
+  it("logs error-style command_execution when exit_code is non-zero", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          command: "failing-cmd",
+          status: "completed",
+          exit_code: 1,
+          aggregated_output: "error output",
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    // Both lines should be logged (error-styled)
+    expect(logSpy.mock.calls[0]?.[0]).toContain("command_execution");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("error output");
+  });
+
+  it("logs file_change with preview for item.completed", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          type: "file_change",
+          changes: [
+            { kind: "create", path: "src/new-file.ts" },
+            { kind: "update", path: "src/index.ts" },
+          ],
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const msg = logSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("file_change:");
+    expect(msg).toContain("src/new-file.ts");
+  });
+
+  it("logs file_change with 'none' when changes array is empty", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "file_change", changes: [] },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("none");
+  });
+
+  it("logs tool_result item.completed with content", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "tool_result", content: "tool output here", is_error: false },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_result");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("tool output here");
+  });
+
+  it("logs error-style tool_result when is_error is true", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "tool_result", content: "failed", is_error: true },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_result (error)");
+  });
+
+  it("logs error item.completed with string message", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "item.completed",
+        item: { type: "error", message: "Something broke" },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error: Something broke");
+  });
+
+  // ── turn.completed ────────────────────────────────────────────────────────
+
+  it("logs token usage for turn.completed", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 200, output_tokens: 80, cached_input_tokens: 50 },
+        total_cost_usd: 0.0015,
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const msg = logSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("in=200");
+    expect(msg).toContain("out=80");
+    expect(msg).toContain("cached=50");
+    expect(msg).toContain("cost=$0.001500");
+  });
+
+  it("logs error info for turn.completed when is_error is true", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 50, output_tokens: 10 },
+        total_cost_usd: 0,
+        is_error: true,
+        subtype: "max_tokens",
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[1]?.[0]).toContain("subtype=max_tokens");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("is_error=true");
+  });
+
+  it("logs errors array in turn.completed when present", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "turn.completed",
+        usage: {},
+        total_cost_usd: 0,
+        is_error: true,
+        subtype: "error",
+        errors: ["rate limit exceeded"],
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(3);
+    expect(logSpy.mock.calls[2]?.[0]).toContain("rate limit exceeded");
+  });
+
+  // ── turn.failed ───────────────────────────────────────────────────────────
+
+  it("logs turn failed with error message", () => {
+    printCodexStreamEvent(
+      JSON.stringify({
+        type: "turn.failed",
+        error: "Connection timeout",
+        usage: { input_tokens: 30, output_tokens: 5, cached_input_tokens: 0 },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("turn failed: Connection timeout");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("in=30");
+  });
+
+  it("logs turn failed without message when error is absent", () => {
+    printCodexStreamEvent(
+      JSON.stringify({ type: "turn.failed", usage: {} }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("turn failed");
+    expect(logSpy.mock.calls[0]?.[0]).not.toContain(": ");
+  });
+
+  // ── error ─────────────────────────────────────────────────────────────────
+
+  it("logs error for error event with string message", () => {
+    printCodexStreamEvent(
+      JSON.stringify({ type: "error", message: "auth failed" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error: auth failed");
+  });
+
+  it("logs error from object message.code when message and error are absent", () => {
+    printCodexStreamEvent(
+      JSON.stringify({ type: "error", message: { code: "ERR_AUTH" } }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error: ERR_AUTH");
+  });
+
+  it("logs JSON fallback for error event with no explicit message fields", () => {
+    // When message and error are absent, errorText falls back to JSON.stringify(parsed)
+    printCodexStreamEvent(JSON.stringify({ type: "error" }), false);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error:");
+  });
+});

--- a/packages/adapters/gemini-local/src/cli/format-event.test.ts
+++ b/packages/adapters/gemini-local/src/cli/format-event.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { printGeminiStreamEvent } from "./format-event.js";
+
+// printGeminiStreamEvent parses Gemini JSON stream events and writes to console.log.
+// Tests verify routing logic and content extraction by spying on console.log.
+
+describe("printGeminiStreamEvent", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  // ── edge cases ────────────────────────────────────────────────────────────
+
+  it("does nothing for empty string", () => {
+    printGeminiStreamEvent("", false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for whitespace-only string", () => {
+    printGeminiStreamEvent("   \n\t  ", false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs raw text when input is not valid JSON", () => {
+    printGeminiStreamEvent("plain log line", false);
+    expect(logSpy).toHaveBeenCalledWith("plain log line");
+  });
+
+  it("logs raw line for unknown event types", () => {
+    const raw = JSON.stringify({ type: "unexpected_gemini_event" });
+    printGeminiStreamEvent(raw, false);
+    expect(logSpy).toHaveBeenCalledWith(raw);
+  });
+
+  // ── system events ─────────────────────────────────────────────────────────
+
+  it("logs Gemini init for system/init with session and model", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "system", subtype: "init", session_id: "s-abc", model: "gemini-2.5-pro" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const msg = logSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("Gemini init");
+    expect(msg).toContain("session: s-abc");
+    expect(msg).toContain("model: gemini-2.5-pro");
+  });
+
+  it("logs Gemini init without details when session_id and model are absent", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "system", subtype: "init" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Gemini init");
+    expect(logSpy.mock.calls[0]?.[0]).not.toContain("session:");
+  });
+
+  it("logs error for system/error event", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "system", subtype: "error", error: "auth failed" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error: auth failed");
+  });
+
+  it("logs system event line for unknown system subtype", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "system", subtype: "checkpoint" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("system: checkpoint");
+  });
+
+  it("logs system event line without subtype", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "system" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("system: event");
+  });
+
+  // ── assistant messages ────────────────────────────────────────────────────
+
+  it("logs assistant text for assistant event with string message", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "assistant", message: "Hello from Gemini!" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("assistant:");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Hello from Gemini!");
+  });
+
+  it("logs assistant text from message.text field", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "assistant", message: { text: "Direct text response" } }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Direct text response");
+  });
+
+  it("logs assistant text from output_text content part", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "output_text", text: "From content part" }],
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("From content part");
+  });
+
+  it("logs thinking from thinking content part", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "thinking", text: "Thinking hard..." }],
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("thinking: Thinking hard...");
+  });
+
+  it("logs tool_call from tool_call content part", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_call", name: "bash", input: { command: "pwd" } }],
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_call: bash");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("pwd");
+  });
+
+  it("logs tool_result from tool_result content part", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_result", output: "result text", is_error: false }],
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_result");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("result text");
+  });
+
+  it("logs error-style tool_result when is_error is true in content part", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [{ type: "tool_result", output: "errored", is_error: true }],
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_result (error)");
+  });
+
+  // ── user messages ─────────────────────────────────────────────────────────
+
+  it("logs user text for user event with string message", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "user", message: "User prompt here" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("user:");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("User prompt here");
+  });
+
+  // ── thinking ─────────────────────────────────────────────────────────────
+
+  it("logs thinking from top-level thinking event", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "thinking", text: "Top-level reasoning" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("thinking: Top-level reasoning");
+  });
+
+  it("logs thinking from thinking event with delta", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "thinking", delta: { text: "Delta reasoning" } }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("thinking: Delta reasoning");
+  });
+
+  it("does not log for empty thinking text", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "thinking", text: "" }),
+      false,
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  // ── tool_call ─────────────────────────────────────────────────────────────
+
+  it("logs tool_call started with args for known tool", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({
+        type: "tool_call",
+        subtype: "started",
+        tool_call: { bash: { args: { command: "echo hi" } } },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_call: bash");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("echo hi");
+  });
+
+  it("logs tool_result completed for completed tool_call", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({
+        type: "tool_call",
+        subtype: "completed",
+        tool_call: { read_file: { result: "file content" } },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_result");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("file content");
+  });
+
+  it("logs error-style for failed tool_call", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({
+        type: "tool_call",
+        subtype: "completed",
+        is_error: true,
+        tool_call: { bash: { result: "command not found" } },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_result (error)");
+  });
+
+  it("logs generic tool_call line when tool_call field is missing", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "tool_call", subtype: "started" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_call");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("started");
+  });
+
+  // ── result ────────────────────────────────────────────────────────────────
+
+  it("logs token usage for result event", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({
+        type: "result",
+        usage: { input_tokens: 300, output_tokens: 120, cached_input_tokens: 80 },
+        total_cost_usd: 0.003,
+      }),
+      false,
+    );
+    // printUsage logs line 1; subtype defaults to "result" so result line is always logged too
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    const usageLine = logSpy.mock.calls[0]?.[0] as string;
+    expect(usageLine).toContain("in=300");
+    expect(usageLine).toContain("out=120");
+    expect(usageLine).toContain("cached=80");
+  });
+
+  it("logs result subtype when is_error or subtype present", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({
+        type: "result",
+        subtype: "max_tokens",
+        is_error: false,
+        usage: {},
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[1]?.[0]).toContain("subtype=max_tokens");
+  });
+
+  // ── error ─────────────────────────────────────────────────────────────────
+
+  it("logs error message for top-level error event", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "error", error: "connection lost" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error: connection lost");
+  });
+
+  it("logs error from message field when error is absent", () => {
+    printGeminiStreamEvent(
+      JSON.stringify({ type: "error", message: "request failed" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error: request failed");
+  });
+
+  it("does not log for error event with no extractable message", () => {
+    printGeminiStreamEvent(JSON.stringify({ type: "error" }), false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/adapters/opencode-local/src/cli/format-event.test.ts
+++ b/packages/adapters/opencode-local/src/cli/format-event.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { printOpenCodeStreamEvent } from "./format-event.js";
+
+// printOpenCodeStreamEvent parses JSON stream events and writes to console.log.
+// Tests verify routing logic and content extraction by spying on console.log.
+
+describe("printOpenCodeStreamEvent", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  // ── edge cases ────────────────────────────────────────────────────────────
+
+  it("does nothing for empty string", () => {
+    printOpenCodeStreamEvent("", false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for whitespace-only string", () => {
+    printOpenCodeStreamEvent("   \n\t  ", false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs raw text when input is not JSON", () => {
+    printOpenCodeStreamEvent("plain text output", false);
+    expect(logSpy).toHaveBeenCalledWith("plain text output");
+  });
+
+  it("logs raw text when JSON is an array (not a record)", () => {
+    printOpenCodeStreamEvent(JSON.stringify([1, 2, 3]), false);
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify([1, 2, 3]));
+  });
+
+  it("logs raw line for unknown event types", () => {
+    const raw = JSON.stringify({ type: "unknown_event", data: "test" });
+    printOpenCodeStreamEvent(raw, false);
+    // Falls through to console.log(line)
+    expect(logSpy).toHaveBeenCalledWith(raw);
+  });
+
+  // ── step_start ────────────────────────────────────────────────────────────
+
+  it("logs step started without sessionID when not provided", () => {
+    printOpenCodeStreamEvent(JSON.stringify({ type: "step_start" }), false);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("step started");
+    expect(logSpy.mock.calls[0]?.[0]).not.toContain("session:");
+  });
+
+  it("logs step started with sessionID when provided", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "step_start", sessionID: "sess-abc" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("step started");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("session: sess-abc");
+  });
+
+  // ── text ─────────────────────────────────────────────────────────────────
+
+  it("logs assistant message for text event with content", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "text", part: { text: "Hello, world!" } }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("assistant:");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Hello, world!");
+  });
+
+  it("does not log for text event with empty text", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "text", part: { text: "   " } }),
+      false,
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not log for text event with missing part", () => {
+    printOpenCodeStreamEvent(JSON.stringify({ type: "text" }), false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  // ── reasoning ────────────────────────────────────────────────────────────
+
+  it("logs thinking for reasoning event with content", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "reasoning", part: { text: "Let me think..." } }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("thinking:");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Let me think...");
+  });
+
+  it("does not log for reasoning event with empty text", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "reasoning", part: { text: "" } }),
+      false,
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  // ── tool_use ─────────────────────────────────────────────────────────────
+
+  it("logs tool_call header for tool_use without status", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "tool_use", part: { tool: "read_file", callID: "call-1" } }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_call: read_file");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("call-1");
+  });
+
+  it("logs tool_call without callID when not provided", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "tool_use", part: { tool: "bash" } }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_call: bash");
+    expect(logSpy.mock.calls[0]?.[0]).not.toContain("(");
+  });
+
+  it("logs tool_result with status when state is present", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({
+        type: "tool_use",
+        part: {
+          tool: "write_file",
+          state: { status: "done", output: "file written" },
+        },
+      }),
+      false,
+    );
+    // Should log tool_call line + tool_result line + output line
+    expect(logSpy).toHaveBeenCalledTimes(3);
+    expect(logSpy.mock.calls[1]?.[0]).toContain("tool_result");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("status=done");
+    expect(logSpy.mock.calls[2]?.[0]).toContain("file written");
+  });
+
+  it("logs error-style tool_result when status is error", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({
+        type: "tool_use",
+        part: {
+          tool: "bash",
+          state: { status: "error", error: "command not found" },
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(3);
+    expect(logSpy.mock.calls[1]?.[0]).toContain("tool_result");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("status=error");
+    expect(logSpy.mock.calls[2]?.[0]).toContain("command not found");
+  });
+
+  it("includes metadata fields in tool_result output", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({
+        type: "tool_use",
+        part: {
+          tool: "search",
+          state: {
+            status: "done",
+            metadata: { exitCode: 0, duration: 150 },
+          },
+        },
+      }),
+      false,
+    );
+    const resultLine = logSpy.mock.calls[1]?.[0] as string;
+    expect(resultLine).toContain("exitCode=0");
+    expect(resultLine).toContain("duration=150");
+  });
+
+  // ── step_finish ───────────────────────────────────────────────────────────
+
+  it("logs step finished with reason and token counts", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({
+        type: "step_finish",
+        part: {
+          reason: "end_turn",
+          tokens: { input: 100, output: 50, reasoning: 10, cache: { read: 20 } },
+          cost: 0.0025,
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("step finished");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("reason=end_turn");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("in=100");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("out=60"); // output + reasoning
+    expect(logSpy.mock.calls[1]?.[0]).toContain("cached=20");
+  });
+
+  it("logs step finished with zero values when tokens are missing", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({
+        type: "step_finish",
+        part: { reason: "stop" },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("reason=stop");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("in=0");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("out=0");
+  });
+
+  it("logs step finished with fallback reason when part is missing", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "step_finish" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("reason=step");
+  });
+
+  // ── error ─────────────────────────────────────────────────────────────────
+
+  it("logs error message for error event with string error", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "error", error: "something went wrong" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error: something went wrong");
+  });
+
+  it("logs error message for error event with message field", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "error", message: "timeout reached" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error: timeout reached");
+  });
+
+  it("logs error from object error.message field", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "error", error: { message: "network error", code: "ERR_NET" } }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error: network error");
+  });
+
+  it("logs error from object data.message field when message is absent", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "error", error: { data: { message: "inner error" } } }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("error: inner error");
+  });
+
+  it("does not log when error event has no extractable message", () => {
+    printOpenCodeStreamEvent(
+      JSON.stringify({ type: "error" }),
+      false,
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/adapters/pi-local/src/cli/format-event.test.ts
+++ b/packages/adapters/pi-local/src/cli/format-event.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { printPiStreamEvent } from "./format-event.js";
+
+// printPiStreamEvent parses Pi JSON stream events and writes to console.log.
+// Tests verify routing logic and content extraction by spying on console.log.
+
+describe("printPiStreamEvent", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  // ── edge cases ────────────────────────────────────────────────────────────
+
+  it("does nothing for empty string", () => {
+    printPiStreamEvent("", false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing for whitespace-only string", () => {
+    printPiStreamEvent("   \n\t  ", false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs raw text when input is not valid JSON", () => {
+    printPiStreamEvent("not json at all", false);
+    expect(logSpy).toHaveBeenCalledWith("not json at all");
+  });
+
+  it("logs raw line when JSON parses to an array", () => {
+    const raw = JSON.stringify(["a", "b"]);
+    printPiStreamEvent(raw, false);
+    expect(logSpy).toHaveBeenCalledWith(raw);
+  });
+
+  it("logs raw line for unknown event type", () => {
+    const raw = JSON.stringify({ type: "some_unknown_type", data: 42 });
+    printPiStreamEvent(raw, false);
+    expect(logSpy).toHaveBeenCalledWith(raw);
+  });
+
+  // ── agent lifecycle ───────────────────────────────────────────────────────
+
+  it("logs Pi agent started for agent_start", () => {
+    printPiStreamEvent(JSON.stringify({ type: "agent_start" }), false);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Pi agent started");
+  });
+
+  it("logs Pi agent finished for agent_end", () => {
+    printPiStreamEvent(JSON.stringify({ type: "agent_end" }), false);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Pi agent finished");
+  });
+
+  it("logs Turn started for turn_start", () => {
+    printPiStreamEvent(JSON.stringify({ type: "turn_start" }), false);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Turn started");
+  });
+
+  // ── turn_end ──────────────────────────────────────────────────────────────
+
+  it("logs assistant content for turn_end with string content", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "turn_end",
+        message: { role: "assistant", content: "Hello from Pi!" },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("assistant:");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Hello from Pi!");
+  });
+
+  it("logs assistant content for turn_end with array content (text parts)", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "turn_end",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "First part. " },
+            { type: "text", text: "Second part." },
+          ],
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("First part.");
+    expect(logSpy.mock.calls[0]?.[0]).toContain("Second part.");
+  });
+
+  it("skips non-text parts in array content for turn_end", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "turn_end",
+        message: {
+          content: [
+            { type: "tool_use", name: "bash" },
+            { type: "text", text: "Done." },
+          ],
+        },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const msg = logSpy.mock.calls[0]?.[0] as string;
+    expect(msg).toContain("Done.");
+    expect(msg).not.toContain("bash");
+  });
+
+  it("does not log for turn_end when message is missing", () => {
+    printPiStreamEvent(JSON.stringify({ type: "turn_end" }), false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not log for turn_end when content extracts to empty string", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "turn_end",
+        message: { content: [{ type: "tool_use", name: "bash" }] },
+      }),
+      false,
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  // ── message_update ────────────────────────────────────────────────────────
+
+  it("logs delta text for message_update with text_delta type", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "partial output" },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("partial output");
+  });
+
+  it("does not log for message_update with non-text_delta type", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "message_update",
+        assistantMessageEvent: { type: "input_json_delta", delta: "{" },
+      }),
+      false,
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not log for message_update when assistantMessageEvent is missing", () => {
+    printPiStreamEvent(JSON.stringify({ type: "message_update" }), false);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not log for message_update with empty delta", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "" },
+      }),
+      false,
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  // ── tool_execution_start ──────────────────────────────────────────────────
+
+  it("logs tool_start with args for tool_execution_start", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "tool_execution_start",
+        toolName: "bash",
+        args: { command: "ls -la" },
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_start: bash");
+    expect(logSpy.mock.calls[1]?.[0]).toContain("ls -la");
+  });
+
+  it("logs only tool_start header when args are undefined", () => {
+    printPiStreamEvent(
+      JSON.stringify({ type: "tool_execution_start", toolName: "read_file" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_start: read_file");
+  });
+
+  it("logs tool_start with null args as null string", () => {
+    printPiStreamEvent(
+      JSON.stringify({ type: "tool_execution_start", toolName: "search", args: null }),
+      false,
+    );
+    // null is a valid JSON value, so it will be JSON.stringify'd to "null"
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_start: search");
+  });
+
+  it("uses empty string for missing toolName in tool_execution_start", () => {
+    printPiStreamEvent(
+      JSON.stringify({ type: "tool_execution_start" }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("tool_start: ");
+  });
+
+  // ── tool_execution_end ────────────────────────────────────────────────────
+
+  it("logs successful tool result for tool_execution_end with string result", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "tool_execution_end",
+        result: "file contents here",
+        isError: false,
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("file contents here");
+  });
+
+  it("logs error-style output for tool_execution_end with isError=true", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "tool_execution_end",
+        result: "permission denied",
+        isError: true,
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy.mock.calls[0]?.[0]).toContain("permission denied");
+  });
+
+  it("logs JSON-stringified result for non-string result", () => {
+    printPiStreamEvent(
+      JSON.stringify({
+        type: "tool_execution_end",
+        result: { output: "data", count: 3 },
+        isError: false,
+      }),
+      false,
+    );
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const logged = logSpy.mock.calls[0]?.[0] as string;
+    expect(logged).toContain("output");
+    expect(logged).toContain("data");
+  });
+
+  it("does not log for tool_execution_end with no result", () => {
+    printPiStreamEvent(
+      JSON.stringify({ type: "tool_execution_end" }),
+      false,
+    );
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 108 unit tests across 4 new test files for the CLI stream event formatter functions in all in-workspace adapters
- **codex-local** (29 tests): `thread.started`, `turn.started/completed/failed`, `item.started/completed` for command_execution/tool_use/agent_message/reasoning/file_change/tool_result/error event types
- **gemini-local** (29 tests): `system/init/error`, `assistant` content parts (output_text/thinking/tool_call/tool_result), `user`, `thinking`, `tool_call` routing with subtype, `result` usage logging, top-level `error`
- **opencode-local** (25 tests): `step_start/finish`, `text`, `reasoning`, `tool_use` with state/metadata/error variants, `error` extraction
- **pi-local** (25 tests): agent lifecycle events, `turn_end` with string/array content, `message_update` text_delta, `tool_execution_start/end`

## Test plan

- [x] All 108 tests pass locally (`vitest run`)
- [x] Tests use `vi.spyOn(console, 'log')` to verify routing without relying on ANSI color codes
- [x] Each adapter tested in its own vitest workspace project

🤖 Generated with [Claude Code](https://claude.com/claude-code)