### PR TITLE
test(ui): 40 unit tests for worktree-branding, adapter build-config, and parse-stdout

### DIFF
--- a/ui/src/adapters/http/build-config.test.ts
+++ b/ui/src/adapters/http/build-config.test.ts
@@ -22,6 +22,9 @@ function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigVa
     envBindings: {},
     url: "",
     bootstrapPrompt: "",
+    maxTurnsPerRun: 0,
+    heartbeatEnabled: false,
+    intervalSec: 60,
     ...overrides,
   };
 }

--- a/ui/src/adapters/http/build-config.test.ts
+++ b/ui/src/adapters/http/build-config.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { buildHttpConfig } from "./build-config.js";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+// Minimal CreateConfigValues shape needed for buildHttpConfig tests.
+function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "http",
+    cwd: "",
+    promptTemplate: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: false,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: false,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    ...overrides,
+  };
+}
+
+describe("buildHttpConfig", () => {
+  it("always includes method POST and timeoutMs 15000", () => {
+    const result = buildHttpConfig(makeValues());
+    expect(result.method).toBe("POST");
+    expect(result.timeoutMs).toBe(15000);
+  });
+
+  it("includes url when non-empty", () => {
+    const result = buildHttpConfig(makeValues({ url: "https://api.example.com/run" }));
+    expect(result.url).toBe("https://api.example.com/run");
+  });
+
+  it("omits url when empty string", () => {
+    const result = buildHttpConfig(makeValues({ url: "" }));
+    expect(Object.prototype.hasOwnProperty.call(result, "url")).toBe(false);
+  });
+
+  it("returns only method and timeoutMs when url is not set", () => {
+    const result = buildHttpConfig(makeValues());
+    expect(Object.keys(result).sort()).toEqual(["method", "timeoutMs"]);
+  });
+
+  it("returns url, method, and timeoutMs when url is set", () => {
+    const result = buildHttpConfig(makeValues({ url: "http://localhost:3000" }));
+    expect(Object.keys(result).sort()).toEqual(["method", "timeoutMs", "url"]);
+  });
+});

--- a/ui/src/adapters/http/parse-stdout.test.ts
+++ b/ui/src/adapters/http/parse-stdout.test.ts
@@ -14,17 +14,17 @@ describe("parseHttpStdoutLine", () => {
 
   it("preserves empty string as text", () => {
     const result = parseHttpStdoutLine("", "2024-01-01T00:00:00Z");
-    expect(result[0]?.text).toBe("");
+    expect(result[0]).toEqual({ kind: "stdout", ts: "2024-01-01T00:00:00Z", text: "" });
   });
 
   it("preserves the timestamp exactly", () => {
     const ts = "2026-04-17T21:00:00.123Z";
     const result = parseHttpStdoutLine("msg", ts);
-    expect(result[0]?.ts).toBe(ts);
+    expect(result[0]).toEqual({ kind: "stdout", ts, text: "msg" });
   });
 
   it("preserves special characters in text", () => {
     const result = parseHttpStdoutLine('{"key": "value"}', "ts");
-    expect(result[0]?.text).toBe('{"key": "value"}');
+    expect(result[0]).toEqual({ kind: "stdout", ts: "ts", text: '{"key": "value"}' });
   });
 });

--- a/ui/src/adapters/http/parse-stdout.test.ts
+++ b/ui/src/adapters/http/parse-stdout.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { parseHttpStdoutLine } from "./parse-stdout.js";
+
+describe("parseHttpStdoutLine", () => {
+  it("returns a single stdout TranscriptEntry", () => {
+    const result = parseHttpStdoutLine("hello world", "2024-01-01T00:00:00Z");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      kind: "stdout",
+      ts: "2024-01-01T00:00:00Z",
+      text: "hello world",
+    });
+  });
+
+  it("preserves empty string as text", () => {
+    const result = parseHttpStdoutLine("", "2024-01-01T00:00:00Z");
+    expect(result[0]?.text).toBe("");
+  });
+
+  it("preserves the timestamp exactly", () => {
+    const ts = "2026-04-17T21:00:00.123Z";
+    const result = parseHttpStdoutLine("msg", ts);
+    expect(result[0]?.ts).toBe(ts);
+  });
+
+  it("preserves special characters in text", () => {
+    const result = parseHttpStdoutLine('{"key": "value"}', "ts");
+    expect(result[0]?.text).toBe('{"key": "value"}');
+  });
+});

--- a/ui/src/adapters/process/build-config.test.ts
+++ b/ui/src/adapters/process/build-config.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { buildProcessConfig } from "./build-config.js";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+// Minimal CreateConfigValues shape needed for buildProcessConfig tests.
+function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "process",
+    cwd: "",
+    promptTemplate: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: false,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: false,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    ...overrides,
+  };
+}
+
+describe("buildProcessConfig", () => {
+  it("always includes timeoutSec 0 and graceSec 15", () => {
+    const result = buildProcessConfig(makeValues());
+    expect(result.timeoutSec).toBe(0);
+    expect(result.graceSec).toBe(15);
+  });
+
+  it("includes cwd when non-empty", () => {
+    const result = buildProcessConfig(makeValues({ cwd: "/home/user/project" }));
+    expect(result.cwd).toBe("/home/user/project");
+  });
+
+  it("omits cwd when empty string", () => {
+    const result = buildProcessConfig(makeValues({ cwd: "" }));
+    expect(Object.prototype.hasOwnProperty.call(result, "cwd")).toBe(false);
+  });
+
+  it("includes command when non-empty", () => {
+    const result = buildProcessConfig(makeValues({ command: "node server.js" }));
+    expect(result.command).toBe("node server.js");
+  });
+
+  it("omits command when empty string", () => {
+    const result = buildProcessConfig(makeValues({ command: "" }));
+    expect(Object.prototype.hasOwnProperty.call(result, "command")).toBe(false);
+  });
+
+  it("splits args on commas and trims whitespace", () => {
+    const result = buildProcessConfig(makeValues({ args: "--port, 3000,  --verbose" }));
+    expect(result.args).toEqual(["--port", "3000", "--verbose"]);
+  });
+
+  it("filters empty segments from args after splitting", () => {
+    const result = buildProcessConfig(makeValues({ args: "--flag,, ,--other" }));
+    expect(result.args).toEqual(["--flag", "--other"]);
+  });
+
+  it("omits args when args is empty string (falsy check)", () => {
+    const result = buildProcessConfig(makeValues({ args: "" }));
+    expect(Object.prototype.hasOwnProperty.call(result, "args")).toBe(false);
+  });
+
+  it("handles single arg without comma", () => {
+    const result = buildProcessConfig(makeValues({ args: "--debug" }));
+    expect(result.args).toEqual(["--debug"]);
+  });
+
+  it("returns full config with all fields when all values are set", () => {
+    const result = buildProcessConfig(
+      makeValues({ cwd: "/app", command: "python", args: "app.py, --mode, prod" }),
+    );
+    expect(result.cwd).toBe("/app");
+    expect(result.command).toBe("python");
+    expect(result.args).toEqual(["app.py", "--mode", "prod"]);
+    expect(result.timeoutSec).toBe(0);
+    expect(result.graceSec).toBe(15);
+  });
+});

--- a/ui/src/adapters/process/build-config.test.ts
+++ b/ui/src/adapters/process/build-config.test.ts
@@ -22,6 +22,9 @@ function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigVa
     envBindings: {},
     url: "",
     bootstrapPrompt: "",
+    maxTurnsPerRun: 0,
+    heartbeatEnabled: false,
+    intervalSec: 60,
     ...overrides,
   };
 }

--- a/ui/src/adapters/process/parse-stdout.test.ts
+++ b/ui/src/adapters/process/parse-stdout.test.ts
@@ -14,19 +14,19 @@ describe("parseProcessStdoutLine", () => {
 
   it("preserves empty string as text", () => {
     const result = parseProcessStdoutLine("", "ts");
-    expect(result[0]?.text).toBe("");
+    expect(result[0]).toEqual({ kind: "stdout", ts: "ts", text: "" });
   });
 
   it("preserves the timestamp exactly", () => {
     const ts = "2026-04-17T21:00:00.000Z";
     const result = parseProcessStdoutLine("line", ts);
-    expect(result[0]?.ts).toBe(ts);
+    expect(result[0]).toEqual({ kind: "stdout", ts, text: "line" });
   });
 
   it("handles multiline text as a single entry (no splitting)", () => {
     const text = "line one\nline two";
     const result = parseProcessStdoutLine(text, "ts");
     expect(result).toHaveLength(1);
-    expect(result[0]?.text).toBe(text);
+    expect(result[0]).toEqual({ kind: "stdout", ts: "ts", text });
   });
 });

--- a/ui/src/adapters/process/parse-stdout.test.ts
+++ b/ui/src/adapters/process/parse-stdout.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { parseProcessStdoutLine } from "./parse-stdout.js";
+
+describe("parseProcessStdoutLine", () => {
+  it("returns a single stdout TranscriptEntry", () => {
+    const result = parseProcessStdoutLine("process output", "2024-01-01T00:00:00Z");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      kind: "stdout",
+      ts: "2024-01-01T00:00:00Z",
+      text: "process output",
+    });
+  });
+
+  it("preserves empty string as text", () => {
+    const result = parseProcessStdoutLine("", "ts");
+    expect(result[0]?.text).toBe("");
+  });
+
+  it("preserves the timestamp exactly", () => {
+    const ts = "2026-04-17T21:00:00.000Z";
+    const result = parseProcessStdoutLine("line", ts);
+    expect(result[0]?.ts).toBe(ts);
+  });
+
+  it("handles multiline text as a single entry (no splitting)", () => {
+    const text = "line one\nline two";
+    const result = parseProcessStdoutLine(text, "ts");
+    expect(result).toHaveLength(1);
+    expect(result[0]?.text).toBe(text);
+  });
+});

--- a/ui/src/lib/worktree-branding.test.ts
+++ b/ui/src/lib/worktree-branding.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { getWorktreeUiBranding } from "./worktree-branding.js";
+
+// getWorktreeUiBranding reads from HTML meta tags via document.querySelector.
+// In tests we mock global.document to exercise the pure branding/color logic.
+
+// Helper to create a mock document that returns specific meta tag values.
+function mockDocument(data: Record<string, string | undefined>): void {
+  (global as Record<string, unknown>).document = {
+    querySelector: (selector: string) => {
+      const match = selector.match(/meta\[name="([^"]+)"\]/);
+      if (!match) return null;
+      const name = match[1]!;
+      const content = data[name];
+      if (content === undefined) return null;
+      return { getAttribute: (_attr: string) => content };
+    },
+  };
+}
+
+describe("getWorktreeUiBranding", () => {
+  const origDocument = (global as Record<string, unknown>).document;
+
+  afterEach(() => {
+    (global as Record<string, unknown>).document = origDocument;
+  });
+
+  // ── no document ───────────────────────────────────────────────────────────
+
+  it("returns null when document is undefined (node env)", () => {
+    // global.document is undefined in node environment by default
+    expect((global as Record<string, unknown>).document).toBeUndefined();
+    expect(getWorktreeUiBranding()).toBeNull();
+  });
+
+  // ── meta tag checks ───────────────────────────────────────────────────────
+
+  it("returns null when paperclip-worktree-enabled is not 'true'", () => {
+    mockDocument({ "paperclip-worktree-enabled": "false" });
+    expect(getWorktreeUiBranding()).toBeNull();
+  });
+
+  it("returns null when paperclip-worktree-enabled meta tag is absent", () => {
+    mockDocument({});
+    expect(getWorktreeUiBranding()).toBeNull();
+  });
+
+  it("returns null when name meta tag is missing even if enabled", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-color": "#336699",
+    });
+    expect(getWorktreeUiBranding()).toBeNull();
+  });
+
+  it("returns null when color meta tag is missing even if enabled", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "my-worktree",
+    });
+    expect(getWorktreeUiBranding()).toBeNull();
+  });
+
+  it("returns null when color is not a valid hex value", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "my-worktree",
+      "paperclip-worktree-color": "not-a-hex",
+    });
+    expect(getWorktreeUiBranding()).toBeNull();
+  });
+
+  // ── happy path ────────────────────────────────────────────────────────────
+
+  it("returns branding object with enabled=true when all required fields are set", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "feature-branch",
+      "paperclip-worktree-color": "#336699",
+    });
+    const result = getWorktreeUiBranding();
+    expect(result).not.toBeNull();
+    expect(result!.enabled).toBe(true);
+    expect(result!.name).toBe("feature-branch");
+    expect(result!.color).toBe("#336699");
+  });
+
+  it("normalizes 6-digit hex color to lowercase", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "test",
+      "paperclip-worktree-color": "#AABBCC",
+    });
+    const result = getWorktreeUiBranding();
+    expect(result!.color).toBe("#aabbcc");
+  });
+
+  it("normalizes 3-digit hex color to 6-digit lowercase", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "test",
+      "paperclip-worktree-color": "#abc",
+    });
+    const result = getWorktreeUiBranding();
+    expect(result!.color).toBe("#aabbcc");
+  });
+
+  it("accepts hex color without leading #", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "test",
+      "paperclip-worktree-color": "336699",
+    });
+    const result = getWorktreeUiBranding();
+    expect(result!.color).toBe("#336699");
+  });
+
+  // ── text color selection (WCAG contrast) ─────────────────────────────────
+
+  it("uses light text color (#f8fafc) for dark background", () => {
+    // Very dark background: #111111 has near-zero luminance → white text wins
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "dark",
+      "paperclip-worktree-color": "#111111",
+    });
+    const result = getWorktreeUiBranding();
+    expect(result!.textColor).toBe("#f8fafc");
+  });
+
+  it("uses dark text color (#111827) for light background", () => {
+    // Very light background: #eeeeee has near-max luminance → black text wins
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "light",
+      "paperclip-worktree-color": "#eeeeee",
+    });
+    const result = getWorktreeUiBranding();
+    expect(result!.textColor).toBe("#111827");
+  });
+
+  it("uses dark text for white background", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "white",
+      "paperclip-worktree-color": "#ffffff",
+    });
+    const result = getWorktreeUiBranding();
+    expect(result!.textColor).toBe("#111827");
+  });
+
+  it("uses light text for black background", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "black",
+      "paperclip-worktree-color": "#000000",
+    });
+    const result = getWorktreeUiBranding();
+    expect(result!.textColor).toBe("#f8fafc");
+  });
+
+  // ── explicit text color override ──────────────────────────────────────────
+
+  it("uses explicitly set text color when provided and valid", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "test",
+      "paperclip-worktree-color": "#336699",
+      "paperclip-worktree-text-color": "#ff0000",
+    });
+    const result = getWorktreeUiBranding();
+    expect(result!.textColor).toBe("#ff0000");
+  });
+
+  it("falls back to computed text color when explicit text color is invalid", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "test",
+      "paperclip-worktree-color": "#000000",
+      "paperclip-worktree-text-color": "not-valid",
+    });
+    const result = getWorktreeUiBranding();
+    // Invalid text color → falls back to computed contrast color (light for black bg)
+    expect(result!.textColor).toBe("#f8fafc");
+  });
+
+  // ── edge: color values without # ─────────────────────────────────────────
+
+  it("handles short 3-digit hex without # prefix", () => {
+    mockDocument({
+      "paperclip-worktree-enabled": "true",
+      "paperclip-worktree-name": "test",
+      "paperclip-worktree-color": "fff",
+    });
+    const result = getWorktreeUiBranding();
+    expect(result!.color).toBe("#ffffff");
+    expect(result!.textColor).toBe("#111827"); // dark text on white bg
+  });
+});


### PR DESCRIPTION
## Summary

- **worktree-branding** (17 tests): `getWorktreeUiBranding` — returns null when document is unavailable, when enabled flag is missing/false, when name or color meta tags are missing or invalid; normalizes 3-digit/6-digit/no-prefix hex colors; computes WCAG-compliant text color for dark vs light backgrounds; respects explicit text color override with fallback
- **http/build-config** (5 tests): `buildHttpConfig` — includes/omits url, always sets method=POST and timeoutMs=15000
- **process/build-config** (10 tests): `buildProcessConfig` — includes/omits cwd and command, splits args on commas with whitespace trim and empty filter
- **http/parse-stdout** (4 tests): `parseHttpStdoutLine` — wraps to stdout TranscriptEntry with correct kind/ts/text
- **process/parse-stdout** (4 tests): `parseProcessStdoutLine` — wraps to stdout TranscriptEntry with correct kind/ts/text

## Test plan

- [x] All 40 tests pass locally (`vitest run`)
- [x] `worktree-branding` tests use `global.document` mocking for DOM-dependent behavior in node env
- [x] All files are in the UI vitest workspace (covered in CI score)

🤖 Generated with [Claude Code](https://claude.com/claude-code)