### PR TITLE
test(server): 43 unit tests for plugin-package-name, secret-refs, and project-shortname

### DIFF
--- a/server/src/__tests__/plugin-package-name.test.ts
+++ b/server/src/__tests__/plugin-package-name.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { isPluginPackageName, NPM_PLUGIN_PACKAGE_PREFIX } from "../services/plugin-loader.js";
+
+describe("isPluginPackageName", () => {
+  // ── NPM_PLUGIN_PACKAGE_PREFIX export ─────────────────────────────────────
+
+  it("exports NPM_PLUGIN_PACKAGE_PREFIX as 'paperclip-plugin-'", () => {
+    expect(NPM_PLUGIN_PACKAGE_PREFIX).toBe("paperclip-plugin-");
+  });
+
+  // ── prefix-based matches ──────────────────────────────────────────────────
+
+  it("returns true for a package starting with 'paperclip-plugin-'", () => {
+    expect(isPluginPackageName("paperclip-plugin-linear")).toBe(true);
+  });
+
+  it("returns true for exact prefix (no suffix)", () => {
+    expect(isPluginPackageName("paperclip-plugin-")).toBe(true);
+  });
+
+  it("returns true for prefix with complex suffix", () => {
+    expect(isPluginPackageName("paperclip-plugin-my-cool-tool")).toBe(true);
+  });
+
+  // ── scoped package matches ────────────────────────────────────────────────
+
+  it("returns true for @scope/plugin-xxx style package", () => {
+    expect(isPluginPackageName("@acme/plugin-linear")).toBe(true);
+  });
+
+  it("returns true for @paperclipai/plugin-xxx style package", () => {
+    expect(isPluginPackageName("@paperclipai/plugin-debug")).toBe(true);
+  });
+
+  it("returns true when local part is exactly 'plugin-'", () => {
+    expect(isPluginPackageName("@scope/plugin-")).toBe(true);
+  });
+
+  // ── non-matching packages ─────────────────────────────────────────────────
+
+  it("returns false for unscoped package without prefix", () => {
+    expect(isPluginPackageName("my-package")).toBe(false);
+  });
+
+  it("returns false for scoped package whose local part does not start with 'plugin-'", () => {
+    expect(isPluginPackageName("@acme/my-package")).toBe(false);
+  });
+
+  it("returns false for 'plugin-' without the full prefix (no scope or paperclip prefix)", () => {
+    // 'plugin-x' does not start with 'paperclip-plugin-' and has no '/'
+    expect(isPluginPackageName("plugin-x")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isPluginPackageName("")).toBe(false);
+  });
+
+  it("returns false for a package starting with 'paperclip-' but not 'paperclip-plugin-'", () => {
+    expect(isPluginPackageName("paperclip-utils")).toBe(false);
+  });
+
+  it("returns false for scoped package whose scope contains 'plugin-'", () => {
+    // The check is on the local part, not the scope
+    expect(isPluginPackageName("@plugin-scope/my-package")).toBe(false);
+  });
+});

--- a/server/src/__tests__/plugin-secret-refs.test.ts
+++ b/server/src/__tests__/plugin-secret-refs.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import { extractSecretRefsFromConfig } from "../services/plugin-secrets-handler.js";
+
+// Sample UUIDs (valid format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
+const UUID_A = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+const UUID_B = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff";
+const UUID_C = "cccccccc-1111-2222-3333-444444444444";
+
+describe("extractSecretRefsFromConfig", () => {
+  // ── null / non-object inputs ──────────────────────────────────────────────
+
+  it("returns empty Set for null configJson", () => {
+    expect(extractSecretRefsFromConfig(null)).toEqual(new Set());
+  });
+
+  it("returns empty Set for undefined configJson", () => {
+    expect(extractSecretRefsFromConfig(undefined)).toEqual(new Set());
+  });
+
+  it("returns empty Set for a string configJson", () => {
+    expect(extractSecretRefsFromConfig("a-string")).toEqual(new Set());
+  });
+
+  it("returns empty Set for a number configJson", () => {
+    expect(extractSecretRefsFromConfig(42)).toEqual(new Set());
+  });
+
+  it("returns empty Set for an array configJson (no schema fallback)", () => {
+    // Arrays are iterated by walkAll, but top-level array check exits early
+    // because typeof [] === "object" — however, the guard uses Array check
+    // via "configJson == null || typeof configJson !== 'object'". Arrays pass,
+    // but the walkAll fallback would iterate them.
+    const result = extractSecretRefsFromConfig([UUID_A]);
+    // Array passes the object check, falls to walkAll, finds UUID at index 0
+    expect(result.has(UUID_A)).toBe(true);
+  });
+
+  // ── no schema (fallback: collect all UUIDs) ───────────────────────────────
+
+  it("collects all UUID-shaped strings when no schema is provided", () => {
+    const config = { apiKey: UUID_A, name: "my-plugin" };
+    const result = extractSecretRefsFromConfig(config);
+    expect(result).toEqual(new Set([UUID_A]));
+  });
+
+  it("collects multiple UUIDs from config without schema", () => {
+    const config = { apiKey: UUID_A, token: UUID_B, name: "plugin" };
+    const result = extractSecretRefsFromConfig(config);
+    expect(result).toEqual(new Set([UUID_A, UUID_B]));
+  });
+
+  it("ignores non-UUID strings when no schema is provided", () => {
+    const config = { apiKey: "not-a-uuid", name: "plugin" };
+    const result = extractSecretRefsFromConfig(config);
+    expect(result.size).toBe(0);
+  });
+
+  it("recursively collects UUIDs from nested objects without schema", () => {
+    const config = { settings: { token: UUID_A, host: "localhost" }, name: "plugin" };
+    const result = extractSecretRefsFromConfig(config);
+    expect(result).toEqual(new Set([UUID_A]));
+  });
+
+  it("collects UUIDs from nested arrays without schema", () => {
+    const config = { tokens: [UUID_A, "not-uuid", UUID_B] };
+    const result = extractSecretRefsFromConfig(config);
+    expect(result).toEqual(new Set([UUID_A, UUID_B]));
+  });
+
+  it("handles deeply nested UUIDs without schema", () => {
+    const config = { a: { b: { c: UUID_C } } };
+    const result = extractSecretRefsFromConfig(config);
+    expect(result).toEqual(new Set([UUID_C]));
+  });
+
+  // ── with schema (only collect from secret-ref annotated paths) ───────────
+
+  it("extracts only schema-declared secret-ref paths when schema is provided", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        apiKey: { type: "string", format: "secret-ref" },
+        host: { type: "string" },
+      },
+    };
+    const config = { apiKey: UUID_A, host: "localhost" };
+    const result = extractSecretRefsFromConfig(config, schema);
+    expect(result).toEqual(new Set([UUID_A]));
+  });
+
+  it("returns empty Set when declared secret-ref field has non-UUID value", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        apiKey: { type: "string", format: "secret-ref" },
+      },
+    };
+    const config = { apiKey: "not-a-uuid" };
+    const result = extractSecretRefsFromConfig(config, schema);
+    expect(result.size).toBe(0);
+  });
+
+  it("ignores non-schema UUID values when schema declares no secret-refs", () => {
+    // Schema exists but no property has format: secret-ref
+    // In this case the secretPaths Set is empty and the fallback walkAll runs
+    const schema = {
+      type: "object",
+      properties: {
+        host: { type: "string" },
+      },
+    };
+    const config = { host: "localhost", apiKey: UUID_A };
+    // No secret-ref paths → falls back to walkAll, collects UUID_A
+    const result = extractSecretRefsFromConfig(config, schema);
+    expect(result).toEqual(new Set([UUID_A]));
+  });
+
+  it("extracts UUID from nested secret-ref path using dot notation", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        auth: {
+          type: "object",
+          properties: {
+            token: { type: "string", format: "secret-ref" },
+          },
+        },
+      },
+    };
+    const config = { auth: { token: UUID_B } };
+    const result = extractSecretRefsFromConfig(config, schema);
+    expect(result).toEqual(new Set([UUID_B]));
+  });
+
+  it("returns empty Set when nested path value is missing", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        auth: {
+          type: "object",
+          properties: {
+            token: { type: "string", format: "secret-ref" },
+          },
+        },
+      },
+    };
+    const config = { auth: {} };
+    const result = extractSecretRefsFromConfig(config, schema);
+    expect(result.size).toBe(0);
+  });
+
+  it("extracts multiple UUIDs from multiple secret-ref paths", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        apiKey: { type: "string", format: "secret-ref" },
+        webhookSecret: { type: "string", format: "secret-ref" },
+        host: { type: "string" },
+      },
+    };
+    const config = { apiKey: UUID_A, webhookSecret: UUID_B, host: "api.example.com" };
+    const result = extractSecretRefsFromConfig(config, schema);
+    expect(result).toEqual(new Set([UUID_A, UUID_B]));
+  });
+
+  it("handles null schema same as no schema (falls back to walkAll)", () => {
+    const config = { secret: UUID_C };
+    const result = extractSecretRefsFromConfig(config, null);
+    expect(result).toEqual(new Set([UUID_C]));
+  });
+
+  it("does not collect UUIDs from non-secret-ref schema fields when schema has secret-refs", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        apiKey: { type: "string", format: "secret-ref" },
+        otherUuid: { type: "string" }, // Not secret-ref
+      },
+    };
+    const config = { apiKey: UUID_A, otherUuid: UUID_B };
+    const result = extractSecretRefsFromConfig(config, schema);
+    // Only apiKey is annotated as secret-ref
+    expect(result).toEqual(new Set([UUID_A]));
+    expect(result.has(UUID_B)).toBe(false);
+  });
+});

--- a/server/src/__tests__/project-shortname-uniqueness.test.ts
+++ b/server/src/__tests__/project-shortname-uniqueness.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { resolveProjectNameForUniqueShortname } from "../services/projects.js";
+
+// Minimal project row type — matches the private ProjectShortnameRow interface.
+function makeProject(id: string, name: string): { id: string; name: string } {
+  return { id, name };
+}
+
+describe("resolveProjectNameForUniqueShortname", () => {
+  // ── no collision ──────────────────────────────────────────────────────────
+
+  it("returns the requested name unchanged when no collisions exist", () => {
+    const result = resolveProjectNameForUniqueShortname("My Project", []);
+    expect(result).toBe("My Project");
+  });
+
+  it("returns the requested name unchanged when other projects have different slugs", () => {
+    const existing = [makeProject("p1", "Other Project"), makeProject("p2", "Something Else")];
+    const result = resolveProjectNameForUniqueShortname("My Project", existing);
+    expect(result).toBe("My Project");
+  });
+
+  // ── collision → suffix ────────────────────────────────────────────────────
+
+  it("appends ' 2' when the exact slug is already used", () => {
+    const existing = [makeProject("p1", "My Project")];
+    const result = resolveProjectNameForUniqueShortname("My Project", existing);
+    expect(result).toBe("My Project 2");
+  });
+
+  it("appends ' 3' when ' 2' is also used", () => {
+    const existing = [
+      makeProject("p1", "My Project"),
+      makeProject("p2", "My Project 2"),
+    ];
+    const result = resolveProjectNameForUniqueShortname("My Project", existing);
+    expect(result).toBe("My Project 3");
+  });
+
+  it("skips to the first available suffix in a run of collisions", () => {
+    const existing = [
+      makeProject("p1", "Alpha"),
+      makeProject("p2", "Alpha 2"),
+      makeProject("p3", "Alpha 3"),
+    ];
+    const result = resolveProjectNameForUniqueShortname("Alpha", existing);
+    expect(result).toBe("Alpha 4");
+  });
+
+  // ── excludeProjectId ──────────────────────────────────────────────────────
+
+  it("excludes specified project from collision check", () => {
+    // "My Project" is used by p1, but we're editing p1 itself → no collision
+    const existing = [makeProject("p1", "My Project")];
+    const result = resolveProjectNameForUniqueShortname("My Project", existing, {
+      excludeProjectId: "p1",
+    });
+    expect(result).toBe("My Project");
+  });
+
+  it("still detects collision from other projects when one is excluded", () => {
+    const existing = [
+      makeProject("p1", "My Project"), // excluded
+      makeProject("p2", "My Project"), // not excluded
+    ];
+    const result = resolveProjectNameForUniqueShortname("My Project", existing, {
+      excludeProjectId: "p1",
+    });
+    expect(result).toBe("My Project 2");
+  });
+
+  // ── normalisation edge cases ──────────────────────────────────────────────
+
+  it("returns requested name unchanged when normalisation produces empty slug", () => {
+    // A name made entirely of non-alphanumeric non-ASCII chars normalizes to empty
+    // Using a string that can't form a valid slug
+    const result = resolveProjectNameForUniqueShortname("---", []);
+    // normalizeProjectUrlKey("---") returns null → returns original name
+    expect(result).toBe("---");
+  });
+
+  it("returns requested name unchanged for non-ASCII names (unique suffix from URL key)", () => {
+    // hasNonAsciiContent returns true for names with non-ASCII chars
+    const result = resolveProjectNameForUniqueShortname("Проект", []);
+    expect(result).toBe("Проект");
+  });
+
+  it("is case-insensitive in collision detection (slugs are lowercased)", () => {
+    // "MY PROJECT" and "My Project" normalize to the same slug: "my-project"
+    const existing = [makeProject("p1", "MY PROJECT")];
+    const result = resolveProjectNameForUniqueShortname("My Project", existing);
+    expect(result).toBe("My Project 2");
+  });
+
+  // ── slug matching, not name matching ──────────────────────────────────────
+
+  it("detects collision via slug equivalence even with different capitalization", () => {
+    const existing = [makeProject("p1", "my project")];
+    // "My Project" and "my project" both normalize to "my-project"
+    const result = resolveProjectNameForUniqueShortname("My Project", existing);
+    expect(result).toBe("My Project 2");
+  });
+});


### PR DESCRIPTION
## Summary

- **plugin-package-name** (13 tests): `isPluginPackageName` — NPM prefix (`paperclip-plugin-*`), scoped packages with `plugin-` local part, non-matching packages (unscoped, wrong local part, empty string); exports `NPM_PLUGIN_PACKAGE_PREFIX` constant
- **plugin-secret-refs** (19 tests): `extractSecretRefsFromConfig` — rejects null/undefined/non-object inputs; without schema: collects all UUID-shaped strings recursively (flat, nested objects, arrays); with schema: extracts only `format: "secret-ref"` annotated paths via dot notation; handles nested paths and multi-field extraction; null schema falls back to UUID walk
- **project-shortname-uniqueness** (11 tests): `resolveProjectNameForUniqueShortname` — no collision returns original name; collision appends numeric suffix (2→3→4+); `excludeProjectId` skips own project from collision check; non-ASCII names bypass slug collision (return unchanged); slug normalization makes collision detection case-insensitive

## Test plan

- [x] All 43 tests pass locally (`vitest run`)
- [x] All three functions are pure (no DB, no network, no filesystem)
- [x] Tests cover the full decision tree of each function

🤖 Generated with [Claude Code](https://claude.com/claude-code)