### PR TITLE
test(coverage): 33 unit tests for telemetry events, CLI banner, and dev-watch-ignore

### DIFF
--- a/cli/src/utils/banner.test.ts
+++ b/cli/src/utils/banner.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { printPaperclipCliBanner } from "./banner.js";
+
+describe("printPaperclipCliBanner", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls console.log exactly once", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printPaperclipCliBanner();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("output includes box-drawing ASCII art characters", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printPaperclipCliBanner();
+    const output = spy.mock.calls[0]?.[0] as string;
+    // The banner renders PAPERCLIP using block/box-drawing glyphs, not literal text
+    expect(output).toContain("██████");
+  });
+
+  it("output contains the tagline text", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printPaperclipCliBanner();
+    const output = spy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("Open-source orchestration for zero-human companies");
+  });
+
+  it("output spans multiple lines (newlines present)", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printPaperclipCliBanner();
+    const output = spy.mock.calls[0]?.[0] as string;
+    expect(output.split("\n").length).toBeGreaterThan(5);
+  });
+
+  it("output starts and ends with empty lines for spacing", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printPaperclipCliBanner();
+    const output = spy.mock.calls[0]?.[0] as string;
+    const lines = output.split("\n");
+    expect(lines[0]).toBe("");
+    expect(lines[lines.length - 1]).toBe("");
+  });
+});

--- a/packages/shared/src/telemetry/events.test.ts
+++ b/packages/shared/src/telemetry/events.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  trackInstallStarted,
+  trackInstallCompleted,
+  trackCompanyImported,
+  trackProjectCreated,
+  trackRoutineCreated,
+  trackRoutineRun,
+  trackGoalCreated,
+  trackAgentCreated,
+  trackSkillImported,
+  trackAgentFirstHeartbeat,
+  trackAgentTaskCompleted,
+  trackErrorHandlerCrash,
+} from "./events.js";
+import type { TelemetryClient } from "./client.js";
+
+function makeClient(): TelemetryClient {
+  return {
+    track: vi.fn(),
+    hashPrivateRef: vi.fn((v: string) => `hashed:${v}`),
+  } as unknown as TelemetryClient;
+}
+
+describe("trackInstallStarted", () => {
+  it("calls track with install.started", () => {
+    const client = makeClient();
+    trackInstallStarted(client);
+    expect(client.track).toHaveBeenCalledWith("install.started");
+    expect(client.track).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("trackInstallCompleted", () => {
+  it("calls track with adapter_type dimension", () => {
+    const client = makeClient();
+    trackInstallCompleted(client, { adapterType: "codex" });
+    expect(client.track).toHaveBeenCalledWith("install.completed", { adapter_type: "codex" });
+  });
+});
+
+describe("trackCompanyImported", () => {
+  it("uses plain ref when isPrivate is false", () => {
+    const client = makeClient();
+    trackCompanyImported(client, { sourceType: "zip", sourceRef: "myref", isPrivate: false });
+    expect(client.hashPrivateRef).not.toHaveBeenCalled();
+    expect(client.track).toHaveBeenCalledWith("company.imported", {
+      source_type: "zip",
+      source_ref: "myref",
+      source_ref_hashed: false,
+    });
+  });
+
+  it("hashes ref when isPrivate is true", () => {
+    const client = makeClient();
+    trackCompanyImported(client, { sourceType: "git", sourceRef: "secret-ref", isPrivate: true });
+    expect(client.hashPrivateRef).toHaveBeenCalledWith("secret-ref");
+    expect(client.track).toHaveBeenCalledWith("company.imported", {
+      source_type: "git",
+      source_ref: "hashed:secret-ref",
+      source_ref_hashed: true,
+    });
+  });
+});
+
+describe("trackProjectCreated", () => {
+  it("calls track with project.created", () => {
+    const client = makeClient();
+    trackProjectCreated(client);
+    expect(client.track).toHaveBeenCalledWith("project.created");
+  });
+});
+
+describe("trackRoutineCreated", () => {
+  it("calls track with routine.created", () => {
+    const client = makeClient();
+    trackRoutineCreated(client);
+    expect(client.track).toHaveBeenCalledWith("routine.created");
+  });
+});
+
+describe("trackRoutineRun", () => {
+  it("calls track with source and status dimensions", () => {
+    const client = makeClient();
+    trackRoutineRun(client, { source: "schedule", status: "success" });
+    expect(client.track).toHaveBeenCalledWith("routine.run", {
+      source: "schedule",
+      status: "success",
+    });
+  });
+});
+
+describe("trackGoalCreated", () => {
+  it("omits goal_level dimension when dims not provided", () => {
+    const client = makeClient();
+    trackGoalCreated(client);
+    expect(client.track).toHaveBeenCalledWith("goal.created", undefined);
+  });
+
+  it("includes goal_level when provided", () => {
+    const client = makeClient();
+    trackGoalCreated(client, { goalLevel: "company" });
+    expect(client.track).toHaveBeenCalledWith("goal.created", { goal_level: "company" });
+  });
+
+  it("omits goal_level dimension when goalLevel is null", () => {
+    const client = makeClient();
+    trackGoalCreated(client, { goalLevel: null });
+    expect(client.track).toHaveBeenCalledWith("goal.created", undefined);
+  });
+});
+
+describe("trackAgentCreated", () => {
+  it("includes agent_role without agent_id when id not provided", () => {
+    const client = makeClient();
+    trackAgentCreated(client, { agentRole: "cto" });
+    expect(client.track).toHaveBeenCalledWith("agent.created", { agent_role: "cto" });
+  });
+
+  it("includes agent_id when provided", () => {
+    const client = makeClient();
+    trackAgentCreated(client, { agentRole: "developer", agentId: "abc-123" });
+    expect(client.track).toHaveBeenCalledWith("agent.created", {
+      agent_role: "developer",
+      agent_id: "abc-123",
+    });
+  });
+});
+
+describe("trackSkillImported", () => {
+  it("omits skill_ref when null", () => {
+    const client = makeClient();
+    trackSkillImported(client, { sourceType: "url", skillRef: null });
+    expect(client.track).toHaveBeenCalledWith("skill.imported", { source_type: "url" });
+  });
+
+  it("includes skill_ref when provided", () => {
+    const client = makeClient();
+    trackSkillImported(client, { sourceType: "git", skillRef: "paperclip/some-skill" });
+    expect(client.track).toHaveBeenCalledWith("skill.imported", {
+      source_type: "git",
+      skill_ref: "paperclip/some-skill",
+    });
+  });
+});
+
+describe("trackAgentFirstHeartbeat", () => {
+  it("includes agent_role without id when not provided", () => {
+    const client = makeClient();
+    trackAgentFirstHeartbeat(client, { agentRole: "developer" });
+    expect(client.track).toHaveBeenCalledWith("agent.first_heartbeat", {
+      agent_role: "developer",
+    });
+  });
+
+  it("includes agent_id when provided", () => {
+    const client = makeClient();
+    trackAgentFirstHeartbeat(client, { agentRole: "cto", agentId: "xyz" });
+    expect(client.track).toHaveBeenCalledWith("agent.first_heartbeat", {
+      agent_role: "cto",
+      agent_id: "xyz",
+    });
+  });
+});
+
+describe("trackAgentTaskCompleted", () => {
+  it("includes only agent_role when optional dims omitted", () => {
+    const client = makeClient();
+    trackAgentTaskCompleted(client, { agentRole: "developer" });
+    expect(client.track).toHaveBeenCalledWith("agent.task_completed", {
+      agent_role: "developer",
+    });
+  });
+
+  it("includes all optional dimensions when all provided", () => {
+    const client = makeClient();
+    trackAgentTaskCompleted(client, {
+      agentRole: "developer",
+      agentId: "xyz",
+      adapterType: "process",
+      model: "claude-3",
+    });
+    expect(client.track).toHaveBeenCalledWith("agent.task_completed", {
+      agent_role: "developer",
+      agent_id: "xyz",
+      adapter_type: "process",
+      model: "claude-3",
+    });
+  });
+});
+
+describe("trackErrorHandlerCrash", () => {
+  it("calls track with error_code dimension", () => {
+    const client = makeClient();
+    trackErrorHandlerCrash(client, { errorCode: "ENOENT" });
+    expect(client.track).toHaveBeenCalledWith("error.handler_crash", { error_code: "ENOENT" });
+  });
+});

--- a/server/src/dev-watch-ignore.test.ts
+++ b/server/src/dev-watch-ignore.test.ts
@@ -1,0 +1,68 @@
+import path from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { resolveServerDevWatchIgnorePaths } from "./dev-watch-ignore.js";
+
+const SERVER_ROOT = "/app/server";
+const TEST_HOME = "/home/testuser";
+
+describe("resolveServerDevWatchIgnorePaths", () => {
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    origHome = process.env.HOME;
+    process.env.HOME = TEST_HOME;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+  });
+
+  it("always includes the node_modules / bower_components glob pattern", () => {
+    const result = resolveServerDevWatchIgnorePaths(SERVER_ROOT);
+    expect(result).toContain("**/{node_modules,bower_components,vendor}/**");
+  });
+
+  it("always includes the .vite-temp glob pattern", () => {
+    const result = resolveServerDevWatchIgnorePaths(SERVER_ROOT);
+    expect(result).toContain("**/.vite-temp/**");
+  });
+
+  it("includes absolute path to ui/node_modules", () => {
+    const result = resolveServerDevWatchIgnorePaths(SERVER_ROOT);
+    const expected = path.resolve(SERVER_ROOT, "../ui/node_modules");
+    expect(result).toContain(expected);
+  });
+
+  it("includes globstar path for ui/node_modules", () => {
+    const result = resolveServerDevWatchIgnorePaths(SERVER_ROOT);
+    const base = path.resolve(SERVER_ROOT, "../ui/node_modules");
+    expect(result).toContain(`${base}/**`);
+  });
+
+  it("includes absolute path to ui/dist", () => {
+    const result = resolveServerDevWatchIgnorePaths(SERVER_ROOT);
+    const expected = path.resolve(SERVER_ROOT, "../ui/dist");
+    expect(result).toContain(expected);
+  });
+
+  it("includes globstar path for ui/dist", () => {
+    const result = resolveServerDevWatchIgnorePaths(SERVER_ROOT);
+    const base = path.resolve(SERVER_ROOT, "../ui/dist");
+    expect(result).toContain(`${base}/**`);
+  });
+
+  it("includes HOME-based adapter-plugins path", () => {
+    const result = resolveServerDevWatchIgnorePaths(SERVER_ROOT);
+    expect(result).toContain(`${TEST_HOME}/.paperclip/adapter-plugins`);
+  });
+
+  it("returns an array with no duplicate entries", () => {
+    const result = resolveServerDevWatchIgnorePaths(SERVER_ROOT);
+    expect(Array.isArray(result)).toBe(true);
+    expect(new Set(result).size).toBe(result.length);
+  });
+
+  it("works with a different serverRoot without throwing", () => {
+    expect(() => resolveServerDevWatchIgnorePaths("/opt/project/server")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- **`packages/shared/src/telemetry/events.test.ts`** (19 tests): Covers all 12 telemetry tracking functions using a minimal mock `TelemetryClient`. Tests verify correct event names, dimension key mappings (camelCase → snake_case), conditional field inclusion (optional `agentId`, `model`, etc.), private-ref hashing delegation, and null/undefined edge cases.

- **`cli/src/utils/banner.test.ts`** (5 tests): Spies on `console.log` to verify `printPaperclipCliBanner` calls it exactly once, includes box-drawing ASCII art characters, outputs the tagline string, spans multiple lines, and has surrounding blank lines for spacing.

- **`server/src/dev-watch-ignore.test.ts`** (9 tests): Verifies `resolveServerDevWatchIgnorePaths` always includes the two base glob patterns, produces absolute and globstar paths for all relative directories (`ui/node_modules`, `ui/dist`, etc.), respects `process.env.HOME` for the adapter-plugins path, and returns a deduplicated array.

## Test plan

- [ ] All 33 tests pass locally via `npx vitest run`
- [ ] TypeScript compiles without errors (no type casts that hide real issues)
- [ ] No side effects: all filesystem interactions in `dev-watch-ignore` gracefully handle non-existent paths via try/catch

🤖 Generated with [Claude Code](https://claude.com/claude-code)