### PR TITLE
test(coverage): 27 unit tests for CLI format-events and getAgentIcon

### DIFF
--- a/cli/src/adapters/http/format-event.test.ts
+++ b/cli/src/adapters/http/format-event.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { printHttpStdoutEvent } from "./format-event.js";
+
+describe("printHttpStdoutEvent", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs the raw line when non-empty", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printHttpStdoutEvent("hello world", false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("hello world");
+  });
+
+  it("does not log when the line is empty", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printHttpStdoutEvent("", false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not log when the line is whitespace-only", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printHttpStdoutEvent("   ", false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("trims leading and trailing whitespace before logging", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printHttpStdoutEvent("  trimmed  ", false);
+    expect(spy).toHaveBeenCalledWith("trimmed");
+  });
+
+  it("ignores the debug flag — always logs non-empty lines", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printHttpStdoutEvent("data", true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("data");
+  });
+
+  it("preserves JSON content without modification", () => {
+    const json = '{"type":"result","cost":0.001}';
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printHttpStdoutEvent(json, false);
+    expect(spy).toHaveBeenCalledWith(json);
+  });
+});

--- a/cli/src/adapters/process/format-event.test.ts
+++ b/cli/src/adapters/process/format-event.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { printProcessStdoutEvent } from "./format-event.js";
+
+describe("printProcessStdoutEvent", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs the raw line when non-empty", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printProcessStdoutEvent("process output", false);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("process output");
+  });
+
+  it("does not log when the line is empty", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printProcessStdoutEvent("", false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does not log when the line is whitespace-only", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printProcessStdoutEvent("   \t\n", false);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("trims leading and trailing whitespace before logging", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printProcessStdoutEvent("\n  trimmed content\n", false);
+    expect(spy).toHaveBeenCalledWith("trimmed content");
+  });
+
+  it("ignores the debug flag — always logs non-empty lines", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printProcessStdoutEvent("event data", true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("event data");
+  });
+
+  it("preserves special characters in the content", () => {
+    const content = '[error] process exited with code 1 — "SIGTERM"';
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    printProcessStdoutEvent(content, false);
+    expect(spy).toHaveBeenCalledWith(content);
+  });
+});

--- a/ui/src/lib/agent-icons.test.ts
+++ b/ui/src/lib/agent-icons.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { getAgentIcon, AGENT_ICONS } from "./agent-icons.js";
+
+describe("getAgentIcon", () => {
+  it("returns the Bot icon for null input", () => {
+    expect(getAgentIcon(null)).toBe(AGENT_ICONS.bot);
+  });
+
+  it("returns the Bot icon for undefined input", () => {
+    expect(getAgentIcon(undefined)).toBe(AGENT_ICONS.bot);
+  });
+
+  it("returns the Bot icon for an empty string", () => {
+    expect(getAgentIcon("")).toBe(AGENT_ICONS.bot);
+  });
+
+  it("returns the Bot icon for an unrecognized name", () => {
+    expect(getAgentIcon("not-a-real-icon")).toBe(AGENT_ICONS.bot);
+  });
+
+  it("returns the correct icon for 'bot'", () => {
+    expect(getAgentIcon("bot")).toBe(AGENT_ICONS.bot);
+  });
+
+  it("returns the correct icon for 'cpu'", () => {
+    expect(getAgentIcon("cpu")).toBe(AGENT_ICONS.cpu);
+  });
+
+  it("returns the correct icon for 'brain'", () => {
+    expect(getAgentIcon("brain")).toBe(AGENT_ICONS.brain);
+  });
+
+  it("returns the correct icon for 'rocket'", () => {
+    expect(getAgentIcon("rocket")).toBe(AGENT_ICONS.rocket);
+  });
+
+  it("returns the correct icon for 'crown'", () => {
+    expect(getAgentIcon("crown")).toBe(AGENT_ICONS.crown);
+  });
+
+  it("returns the correct icon for hyphenated names like 'git-branch'", () => {
+    expect(getAgentIcon("git-branch")).toBe(AGENT_ICONS["git-branch"]);
+  });
+
+  it("returns the correct icon for 'message-square'", () => {
+    expect(getAgentIcon("message-square")).toBe(AGENT_ICONS["message-square"]);
+  });
+
+  it("returns the correct icon for 'file-code'", () => {
+    expect(getAgentIcon("file-code")).toBe(AGENT_ICONS["file-code"]);
+  });
+
+  it("returns a non-null object (React component) for any known icon", () => {
+    const icon = getAgentIcon("zap");
+    expect(icon).toBeTruthy();
+    expect(icon).not.toBeNull();
+  });
+
+  it("returns a non-null object (React component) for the default icon", () => {
+    const icon = getAgentIcon(null);
+    expect(icon).toBeTruthy();
+    expect(icon).not.toBeNull();
+  });
+
+  it("all AGENT_ICONS values are non-null (React components)", () => {
+    for (const [name, icon] of Object.entries(AGENT_ICONS)) {
+      expect(icon, `${name} should be non-null`).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **`cli/src/adapters/http/format-event.test.ts`** (6 tests): Covers `printHttpStdoutEvent` — verifies trim-then-log behavior, that empty and whitespace-only input produce no output, that the debug flag is ignored, and that JSON strings are preserved verbatim.

- **`cli/src/adapters/process/format-event.test.ts`** (6 tests): Covers `printProcessStdoutEvent` with the same behavioral contract as the HTTP variant, extended with newline/tab whitespace and special character cases.

- **`ui/src/lib/agent-icons.test.ts`** (15 tests): Covers `getAgentIcon` — null, undefined, empty string, and unrecognized names all return the default Bot icon; valid names (including hyphenated names like `git-branch`) return the exact mapped Lucide icon by reference; all 43 `AGENT_ICONS` map values are confirmed non-null.

## Test plan

- [ ] All 27 tests pass locally via `npx vitest run`
- [ ] No DOM setup required — icons are imported as object references, vitest node environment is sufficient
- [ ] `afterEach(() => vi.restoreAllMocks())` prevents console spy leakage between tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)