### PR TITLE
test(server/cli/shared): 478+ unit tests for pure utility functions

### DIFF
--- a/cli/src/__tests__/hostnames.test.ts
+++ b/cli/src/__tests__/hostnames.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { normalizeHostnameInput, parseHostnameCsv } from "../config/hostnames.js";
+
+// ---------------------------------------------------------------------------
+// normalizeHostnameInput
+// ---------------------------------------------------------------------------
+
+describe("normalizeHostnameInput", () => {
+  it("returns the hostname for a plain hostname string", () => {
+    expect(normalizeHostnameInput("localhost")).toBe("localhost");
+  });
+
+  it("extracts the hostname from an http:// URL", () => {
+    expect(normalizeHostnameInput("http://example.com")).toBe("example.com");
+  });
+
+  it("extracts the hostname from an https:// URL", () => {
+    expect(normalizeHostnameInput("https://myapp.example.com")).toBe("myapp.example.com");
+  });
+
+  it("lowercases the hostname", () => {
+    expect(normalizeHostnameInput("Example.COM")).toBe("example.com");
+  });
+
+  it("trims whitespace from the input before processing", () => {
+    expect(normalizeHostnameInput("  example.com  ")).toBe("example.com");
+  });
+
+  it("returns the IP address for a raw IP input", () => {
+    expect(normalizeHostnameInput("127.0.0.1")).toBe("127.0.0.1");
+  });
+
+  it("throws for an empty string", () => {
+    expect(() => normalizeHostnameInput("")).toThrow();
+  });
+
+  it("throws for a whitespace-only string", () => {
+    expect(() => normalizeHostnameInput("   ")).toThrow();
+  });
+
+  it("throws for a URL with only a scheme and no host", () => {
+    expect(() => normalizeHostnameInput("://")).toThrow();
+  });
+
+  it("strips the port from a hostname:port input", () => {
+    expect(normalizeHostnameInput("example.com:3000")).toBe("example.com");
+  });
+
+  it("strips the port from a URL with a port", () => {
+    expect(normalizeHostnameInput("http://example.com:8080")).toBe("example.com");
+  });
+
+  it("strips the path from a URL", () => {
+    expect(normalizeHostnameInput("http://example.com/some/path")).toBe("example.com");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseHostnameCsv
+// ---------------------------------------------------------------------------
+
+describe("parseHostnameCsv", () => {
+  it("returns an empty array for an empty string", () => {
+    expect(parseHostnameCsv("")).toEqual([]);
+  });
+
+  it("returns an empty array for a whitespace-only string", () => {
+    expect(parseHostnameCsv("   ")).toEqual([]);
+  });
+
+  it("parses a single hostname", () => {
+    expect(parseHostnameCsv("example.com")).toEqual(["example.com"]);
+  });
+
+  it("parses multiple hostnames", () => {
+    expect(parseHostnameCsv("example.com,other.com")).toEqual(["example.com", "other.com"]);
+  });
+
+  it("deduplicates identical hostnames", () => {
+    expect(parseHostnameCsv("example.com,example.com")).toEqual(["example.com"]);
+  });
+
+  it("lowercases all hostnames", () => {
+    expect(parseHostnameCsv("Example.COM,Other.NET")).toEqual(["example.com", "other.net"]);
+  });
+
+  it("trims whitespace around individual hostnames", () => {
+    // normalizeHostnameInput trims per-part whitespace
+    expect(parseHostnameCsv(" example.com , other.com ")).toEqual(["example.com", "other.com"]);
+  });
+
+  it("parses URLs embedded in the CSV", () => {
+    expect(parseHostnameCsv("https://example.com,http://other.com")).toEqual(["example.com", "other.com"]);
+  });
+
+  it("throws when any hostname in the CSV is invalid", () => {
+    expect(() => parseHostnameCsv("example.com,://")).toThrow();
+  });
+});

--- a/cli/src/__tests__/server-bind.test.ts
+++ b/cli/src/__tests__/server-bind.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest";
+import { LOOPBACK_BIND_HOST, ALL_INTERFACES_BIND_HOST } from "@paperclipai/shared";
+import {
+  inferConfiguredBind,
+  buildPresetServerConfig,
+  buildCustomServerConfig,
+  resolveQuickstartServerConfig,
+} from "../config/server-bind.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const BASE_INPUT = {
+  port: 3000,
+  allowedHostnames: ["localhost"],
+  serveUi: true,
+};
+
+// ---------------------------------------------------------------------------
+// inferConfiguredBind
+// ---------------------------------------------------------------------------
+
+describe("inferConfiguredBind", () => {
+  it("returns the explicit bind mode when server.bind is set", () => {
+    expect(inferConfiguredBind({ bind: "loopback" })).toBe("loopback");
+    expect(inferConfiguredBind({ bind: "lan" })).toBe("lan");
+  });
+
+  it("infers loopback when server.host is 127.0.0.1", () => {
+    expect(inferConfiguredBind({ host: "127.0.0.1" })).toBe("loopback");
+  });
+
+  it("infers lan when server.host is 0.0.0.0", () => {
+    expect(inferConfiguredBind({ host: "0.0.0.0" })).toBe("lan");
+  });
+
+  it("returns loopback when server is undefined", () => {
+    expect(inferConfiguredBind(undefined)).toBe("loopback");
+  });
+
+  it("returns loopback when server is empty", () => {
+    expect(inferConfiguredBind({})).toBe("loopback");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPresetServerConfig
+// ---------------------------------------------------------------------------
+
+describe("buildPresetServerConfig", () => {
+  it("sets host to 127.0.0.1 for loopback bind", () => {
+    const { server } = buildPresetServerConfig("loopback", BASE_INPUT);
+    expect(server.host).toBe(LOOPBACK_BIND_HOST);
+  });
+
+  it("sets deploymentMode to local_trusted for loopback bind", () => {
+    const { server } = buildPresetServerConfig("loopback", BASE_INPUT);
+    expect(server.deploymentMode).toBe("local_trusted");
+  });
+
+  it("sets host to 0.0.0.0 for lan bind", () => {
+    const { server } = buildPresetServerConfig("lan", BASE_INPUT);
+    expect(server.host).toBe(ALL_INTERFACES_BIND_HOST);
+  });
+
+  it("sets deploymentMode to authenticated for lan bind", () => {
+    const { server } = buildPresetServerConfig("lan", BASE_INPUT);
+    expect(server.deploymentMode).toBe("authenticated");
+  });
+
+  it("preserves the port from input", () => {
+    const { server } = buildPresetServerConfig("loopback", BASE_INPUT);
+    expect(server.port).toBe(3000);
+  });
+
+  it("preserves the allowedHostnames from input", () => {
+    const { server } = buildPresetServerConfig("loopback", BASE_INPUT);
+    expect(server.allowedHostnames).toEqual(["localhost"]);
+  });
+
+  it("sets auth baseUrlMode to auto for preset configs", () => {
+    const { auth } = buildPresetServerConfig("loopback", BASE_INPUT);
+    expect(auth.baseUrlMode).toBe("auto");
+  });
+
+  it("sets bind field to the input bind mode", () => {
+    const { server } = buildPresetServerConfig("lan", BASE_INPUT);
+    expect(server.bind).toBe("lan");
+  });
+
+  it("sets exposure to private", () => {
+    const { server } = buildPresetServerConfig("loopback", BASE_INPUT);
+    expect(server.exposure).toBe("private");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCustomServerConfig
+// ---------------------------------------------------------------------------
+
+describe("buildCustomServerConfig", () => {
+  it("sets bind to loopback when host is 127.0.0.1", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "local_trusted",
+      exposure: "private",
+      host: "127.0.0.1",
+    });
+    expect(server.bind).toBe("loopback");
+  });
+
+  it("sets bind to lan when host is 0.0.0.0", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "authenticated",
+      exposure: "private",
+      host: "0.0.0.0",
+    });
+    expect(server.bind).toBe("lan");
+  });
+
+  it("sets bind to custom for a non-standard host", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "authenticated",
+      exposure: "private",
+      host: "192.168.1.5",
+    });
+    expect(server.bind).toBe("custom");
+    expect(server.customBindHost).toBe("192.168.1.5");
+  });
+
+  it("sets customBindHost to undefined for standard hosts", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "local_trusted",
+      exposure: "private",
+      host: "127.0.0.1",
+    });
+    expect(server.customBindHost).toBeUndefined();
+  });
+
+  it("trims whitespace from the host", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "local_trusted",
+      exposure: "private",
+      host: "  127.0.0.1  ",
+    });
+    expect(server.host).toBe("127.0.0.1");
+  });
+
+  it("sets auth baseUrlMode to explicit when authenticated + public", () => {
+    const { auth } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "authenticated",
+      exposure: "public",
+      host: "0.0.0.0",
+      publicBaseUrl: "https://app.example.com",
+    });
+    expect(auth.baseUrlMode).toBe("explicit");
+    expect(auth.publicBaseUrl).toBe("https://app.example.com");
+  });
+
+  it("sets auth baseUrlMode to auto for local_trusted configs", () => {
+    const { auth } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "local_trusted",
+      exposure: "private",
+      host: "127.0.0.1",
+    });
+    expect(auth.baseUrlMode).toBe("auto");
+  });
+
+  it("overrides exposure to private for local_trusted even if private passed", () => {
+    const { server } = buildCustomServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "local_trusted",
+      exposure: "private",
+      host: "127.0.0.1",
+    });
+    expect(server.exposure).toBe("private");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveQuickstartServerConfig
+// ---------------------------------------------------------------------------
+
+describe("resolveQuickstartServerConfig", () => {
+  it("uses loopback preset when bind=loopback is explicit", () => {
+    const { server } = resolveQuickstartServerConfig({ ...BASE_INPUT, bind: "loopback" });
+    expect(server.bind).toBe("loopback");
+    expect(server.host).toBe(LOOPBACK_BIND_HOST);
+  });
+
+  it("uses lan preset when bind=lan is explicit", () => {
+    const { server } = resolveQuickstartServerConfig({ ...BASE_INPUT, bind: "lan" });
+    expect(server.bind).toBe("lan");
+    expect(server.host).toBe(ALL_INTERFACES_BIND_HOST);
+  });
+
+  it("falls back to loopback when no bind or host is specified", () => {
+    const { server } = resolveQuickstartServerConfig(BASE_INPUT);
+    expect(server.bind).toBe("loopback");
+  });
+
+  it("infers from the host when host is provided but bind is not", () => {
+    const { server } = resolveQuickstartServerConfig({ ...BASE_INPUT, host: "0.0.0.0" });
+    expect(server.bind).toBe("lan");
+  });
+
+  it("uses lan preset for authenticated + private deployments without host", () => {
+    const { server } = resolveQuickstartServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "authenticated",
+      exposure: "private",
+    });
+    expect(server.bind).toBe("lan");
+  });
+
+  it("uses lan with 0.0.0.0 for authenticated + public deployments without host", () => {
+    const { server } = resolveQuickstartServerConfig({
+      ...BASE_INPUT,
+      deploymentMode: "authenticated",
+      exposure: "public",
+    });
+    expect(server.host).toBe(ALL_INTERFACES_BIND_HOST);
+  });
+
+  it("uses custom bind when bind=custom is explicit", () => {
+    const { server } = resolveQuickstartServerConfig({
+      ...BASE_INPUT,
+      bind: "custom",
+      host: "192.168.1.5",
+    });
+    expect(server.bind).toBe("custom");
+    expect(server.customBindHost).toBe("192.168.1.5");
+  });
+
+  it("preserves the port", () => {
+    const { server } = resolveQuickstartServerConfig({ ...BASE_INPUT, port: 9999 });
+    expect(server.port).toBe(9999);
+  });
+});

--- a/packages/shared/src/validators/company-portability.test.ts
+++ b/packages/shared/src/validators/company-portability.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from "vitest";
+import {
+  portabilityIncludeSchema,
+  portabilityEnvInputSchema,
+  portabilityFileEntrySchema,
+  portabilityCollisionStrategySchema,
+  portabilitySourceSchema,
+  portabilityTargetSchema,
+  portabilityAgentSelectionSchema,
+  companyPortabilityExportSchema,
+  companyPortabilityPreviewSchema,
+} from "./company-portability.js";
+
+// ---------------------------------------------------------------------------
+// portabilityIncludeSchema
+// ---------------------------------------------------------------------------
+
+describe("portabilityIncludeSchema", () => {
+  it("accepts an empty object (all fields optional)", () => {
+    expect(portabilityIncludeSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("accepts an object with all boolean fields set", () => {
+    const result = portabilityIncludeSchema.safeParse({
+      company: true,
+      agents: true,
+      projects: false,
+      issues: false,
+      skills: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when a field has a non-boolean value", () => {
+    expect(portabilityIncludeSchema.safeParse({ company: "yes" }).success).toBe(false);
+  });
+
+  it("accepts partial include (some fields set, some absent)", () => {
+    expect(portabilityIncludeSchema.safeParse({ agents: true }).success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// portabilityEnvInputSchema
+// ---------------------------------------------------------------------------
+
+describe("portabilityEnvInputSchema", () => {
+  const VALID_ENV_INPUT = {
+    key: "API_KEY",
+    description: "API key for the service",
+    agentSlug: null,
+    projectSlug: null,
+    kind: "secret",
+    requirement: "required",
+    defaultValue: null,
+    portability: "portable",
+  };
+
+  it("accepts a valid env input", () => {
+    expect(portabilityEnvInputSchema.safeParse(VALID_ENV_INPUT).success).toBe(true);
+  });
+
+  it("rejects when key is empty", () => {
+    expect(portabilityEnvInputSchema.safeParse({ ...VALID_ENV_INPUT, key: "" }).success).toBe(false);
+  });
+
+  it("rejects an invalid kind value", () => {
+    expect(portabilityEnvInputSchema.safeParse({ ...VALID_ENV_INPUT, kind: "encrypted" }).success).toBe(false);
+  });
+
+  it("accepts kind 'plain'", () => {
+    expect(portabilityEnvInputSchema.safeParse({ ...VALID_ENV_INPUT, kind: "plain" }).success).toBe(true);
+  });
+
+  it("rejects an invalid requirement value", () => {
+    expect(
+      portabilityEnvInputSchema.safeParse({ ...VALID_ENV_INPUT, requirement: "recommended" }).success,
+    ).toBe(false);
+  });
+
+  it("accepts requirement 'optional'", () => {
+    expect(
+      portabilityEnvInputSchema.safeParse({ ...VALID_ENV_INPUT, requirement: "optional" }).success,
+    ).toBe(true);
+  });
+
+  it("rejects an invalid portability value", () => {
+    expect(
+      portabilityEnvInputSchema.safeParse({ ...VALID_ENV_INPUT, portability: "global" }).success,
+    ).toBe(false);
+  });
+
+  it("accepts portability 'system_dependent'", () => {
+    expect(
+      portabilityEnvInputSchema.safeParse({ ...VALID_ENV_INPUT, portability: "system_dependent" }).success,
+    ).toBe(true);
+  });
+
+  it("accepts a non-null defaultValue string", () => {
+    expect(
+      portabilityEnvInputSchema.safeParse({ ...VALID_ENV_INPUT, defaultValue: "default" }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// portabilityFileEntrySchema
+// ---------------------------------------------------------------------------
+
+describe("portabilityFileEntrySchema", () => {
+  it("accepts a plain string file entry", () => {
+    expect(portabilityFileEntrySchema.safeParse("file content here").success).toBe(true);
+  });
+
+  it("accepts a base64 encoded file entry object", () => {
+    expect(
+      portabilityFileEntrySchema.safeParse({ encoding: "base64", data: "SGVsbG8=" }).success,
+    ).toBe(true);
+  });
+
+  it("accepts a base64 entry with a contentType", () => {
+    expect(
+      portabilityFileEntrySchema.safeParse({
+        encoding: "base64",
+        data: "SGVsbG8=",
+        contentType: "image/png",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects an object with an unknown encoding", () => {
+    expect(
+      portabilityFileEntrySchema.safeParse({ encoding: "utf8", data: "hello" }).success,
+    ).toBe(false);
+  });
+
+  it("rejects null", () => {
+    expect(portabilityFileEntrySchema.safeParse(null).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// portabilityCollisionStrategySchema
+// ---------------------------------------------------------------------------
+
+describe("portabilityCollisionStrategySchema", () => {
+  it("accepts 'rename'", () => {
+    expect(portabilityCollisionStrategySchema.safeParse("rename").success).toBe(true);
+  });
+
+  it("accepts 'skip'", () => {
+    expect(portabilityCollisionStrategySchema.safeParse("skip").success).toBe(true);
+  });
+
+  it("accepts 'replace'", () => {
+    expect(portabilityCollisionStrategySchema.safeParse("replace").success).toBe(true);
+  });
+
+  it("rejects an unknown strategy", () => {
+    expect(portabilityCollisionStrategySchema.safeParse("merge").success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// portabilitySourceSchema
+// ---------------------------------------------------------------------------
+
+describe("portabilitySourceSchema", () => {
+  it("accepts a github source", () => {
+    const result = portabilitySourceSchema.safeParse({
+      type: "github",
+      url: "https://github.com/acme/repo",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a github source with a non-URL", () => {
+    const result = portabilitySourceSchema.safeParse({
+      type: "github",
+      url: "not-a-url",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an inline source with files", () => {
+    const result = portabilitySourceSchema.safeParse({
+      type: "inline",
+      files: { "COMPANY.md": "company content" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an inline source with base64 file entries", () => {
+    const result = portabilitySourceSchema.safeParse({
+      type: "inline",
+      files: { "logo.png": { encoding: "base64", data: "abc==" } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown source type", () => {
+    expect(portabilitySourceSchema.safeParse({ type: "s3", bucket: "my-bucket" }).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// portabilityTargetSchema
+// ---------------------------------------------------------------------------
+
+describe("portabilityTargetSchema", () => {
+  it("accepts a new_company target", () => {
+    expect(
+      portabilityTargetSchema.safeParse({ mode: "new_company" }).success,
+    ).toBe(true);
+  });
+
+  it("accepts a new_company target with an optional name", () => {
+    expect(
+      portabilityTargetSchema.safeParse({ mode: "new_company", newCompanyName: "Acme" }).success,
+    ).toBe(true);
+  });
+
+  it("accepts an existing_company target with a valid UUID", () => {
+    expect(
+      portabilityTargetSchema.safeParse({
+        mode: "existing_company",
+        companyId: "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects existing_company with an invalid UUID", () => {
+    expect(
+      portabilityTargetSchema.safeParse({
+        mode: "existing_company",
+        companyId: "not-a-uuid",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects an unknown mode", () => {
+    expect(portabilityTargetSchema.safeParse({ mode: "clone" }).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// portabilityAgentSelectionSchema
+// ---------------------------------------------------------------------------
+
+describe("portabilityAgentSelectionSchema", () => {
+  it("accepts the literal 'all'", () => {
+    expect(portabilityAgentSelectionSchema.safeParse("all").success).toBe(true);
+  });
+
+  it("accepts an array of agent slug strings", () => {
+    expect(portabilityAgentSelectionSchema.safeParse(["cto", "pm"]).success).toBe(true);
+  });
+
+  it("rejects an empty array item (empty string)", () => {
+    expect(portabilityAgentSelectionSchema.safeParse([""]).success).toBe(false);
+  });
+
+  it("rejects a non-'all' string", () => {
+    expect(portabilityAgentSelectionSchema.safeParse("none").success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// companyPortabilityExportSchema
+// ---------------------------------------------------------------------------
+
+describe("companyPortabilityExportSchema", () => {
+  it("accepts an empty export request", () => {
+    expect(companyPortabilityExportSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("accepts an export request with include", () => {
+    expect(
+      companyPortabilityExportSchema.safeParse({ include: { agents: true } }).success,
+    ).toBe(true);
+  });
+
+  it("accepts an export request with agent slug filter", () => {
+    expect(
+      companyPortabilityExportSchema.safeParse({ agents: ["cto"] }).success,
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// companyPortabilityPreviewSchema
+// ---------------------------------------------------------------------------
+
+describe("companyPortabilityPreviewSchema", () => {
+  const VALID_PREVIEW = {
+    source: { type: "github", url: "https://github.com/acme/repo" },
+    target: { mode: "new_company" },
+  };
+
+  it("accepts a minimal valid preview request", () => {
+    expect(companyPortabilityPreviewSchema.safeParse(VALID_PREVIEW).success).toBe(true);
+  });
+
+  it("accepts a preview with include and collision strategy", () => {
+    expect(
+      companyPortabilityPreviewSchema.safeParse({
+        ...VALID_PREVIEW,
+        include: { agents: true },
+        collisionStrategy: "skip",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects when source is missing", () => {
+    expect(
+      companyPortabilityPreviewSchema.safeParse({ target: { mode: "new_company" } }).success,
+    ).toBe(false);
+  });
+
+  it("rejects when target is missing", () => {
+    expect(
+      companyPortabilityPreviewSchema.safeParse({
+        source: { type: "github", url: "https://github.com/acme/repo" },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/packages/shared/src/validators/plugin.test.ts
+++ b/packages/shared/src/validators/plugin.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect } from "vitest";
+import {
+  jsonSchemaSchema,
+  pluginJobDeclarationSchema,
+  pluginWebhookDeclarationSchema,
+  pluginToolDeclarationSchema,
+  pluginUiSlotDeclarationSchema,
+  installPluginSchema,
+  upsertPluginConfigSchema,
+} from "./plugin.js";
+
+// ---------------------------------------------------------------------------
+// jsonSchemaSchema
+// ---------------------------------------------------------------------------
+
+describe("jsonSchemaSchema", () => {
+  it("accepts an empty object (no fields required)", () => {
+    expect(jsonSchemaSchema.safeParse({}).success).toBe(true);
+  });
+
+  it("accepts an object with a 'type' field", () => {
+    expect(jsonSchemaSchema.safeParse({ type: "object", properties: {} }).success).toBe(true);
+  });
+
+  it("accepts an object with a '$ref' field", () => {
+    expect(jsonSchemaSchema.safeParse({ $ref: "#/definitions/Foo" }).success).toBe(true);
+  });
+
+  it("accepts an object with an 'oneOf' field", () => {
+    expect(jsonSchemaSchema.safeParse({ oneOf: [{ type: "string" }] }).success).toBe(true);
+  });
+
+  it("accepts an object with an 'anyOf' field", () => {
+    expect(jsonSchemaSchema.safeParse({ anyOf: [{ type: "string" }] }).success).toBe(true);
+  });
+
+  it("accepts an object with an 'allOf' field", () => {
+    expect(jsonSchemaSchema.safeParse({ allOf: [{ type: "object" }] }).success).toBe(true);
+  });
+
+  it("rejects a non-empty object missing type/$ref/composition keywords", () => {
+    expect(jsonSchemaSchema.safeParse({ description: "just a description" }).success).toBe(false);
+  });
+
+  it("rejects a non-object value (string)", () => {
+    expect(jsonSchemaSchema.safeParse("not-an-object").success).toBe(false);
+  });
+
+  it("rejects an array", () => {
+    expect(jsonSchemaSchema.safeParse([]).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pluginJobDeclarationSchema
+// ---------------------------------------------------------------------------
+
+describe("pluginJobDeclarationSchema", () => {
+  it("accepts a minimal valid job declaration (no schedule)", () => {
+    const result = pluginJobDeclarationSchema.safeParse({
+      jobKey: "daily-sync",
+      displayName: "Daily Sync",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a job with a valid cron schedule", () => {
+    const result = pluginJobDeclarationSchema.safeParse({
+      jobKey: "hourly",
+      displayName: "Hourly Job",
+      schedule: "0 * * * *",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a job with a wildcard schedule", () => {
+    const result = pluginJobDeclarationSchema.safeParse({
+      jobKey: "minutely",
+      displayName: "Minutely",
+      schedule: "* * * * *",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a job with an invalid cron schedule", () => {
+    const result = pluginJobDeclarationSchema.safeParse({
+      jobKey: "bad",
+      displayName: "Bad Job",
+      schedule: "not-a-cron",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a job with an empty jobKey", () => {
+    const result = pluginJobDeclarationSchema.safeParse({
+      jobKey: "",
+      displayName: "Job",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a job with an empty displayName", () => {
+    const result = pluginJobDeclarationSchema.safeParse({
+      jobKey: "my-job",
+      displayName: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a description field", () => {
+    const result = pluginJobDeclarationSchema.safeParse({
+      jobKey: "my-job",
+      displayName: "My Job",
+      description: "Does something",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pluginWebhookDeclarationSchema
+// ---------------------------------------------------------------------------
+
+describe("pluginWebhookDeclarationSchema", () => {
+  it("accepts a minimal valid webhook declaration", () => {
+    const result = pluginWebhookDeclarationSchema.safeParse({
+      endpointKey: "push",
+      displayName: "Push Event",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts an optional description", () => {
+    const result = pluginWebhookDeclarationSchema.safeParse({
+      endpointKey: "push",
+      displayName: "Push Event",
+      description: "Fired on push",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an empty endpointKey", () => {
+    const result = pluginWebhookDeclarationSchema.safeParse({
+      endpointKey: "",
+      displayName: "Push Event",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an empty displayName", () => {
+    const result = pluginWebhookDeclarationSchema.safeParse({
+      endpointKey: "push",
+      displayName: "",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pluginToolDeclarationSchema
+// ---------------------------------------------------------------------------
+
+describe("pluginToolDeclarationSchema", () => {
+  const VALID_TOOL = {
+    name: "search_issues",
+    displayName: "Search Issues",
+    description: "Search for issues by query",
+    parametersSchema: { type: "object", properties: {} },
+  };
+
+  it("accepts a valid tool declaration", () => {
+    expect(pluginToolDeclarationSchema.safeParse(VALID_TOOL).success).toBe(true);
+  });
+
+  it("rejects when name is empty", () => {
+    expect(pluginToolDeclarationSchema.safeParse({ ...VALID_TOOL, name: "" }).success).toBe(false);
+  });
+
+  it("rejects when displayName is empty", () => {
+    expect(pluginToolDeclarationSchema.safeParse({ ...VALID_TOOL, displayName: "" }).success).toBe(false);
+  });
+
+  it("rejects when description is empty", () => {
+    expect(pluginToolDeclarationSchema.safeParse({ ...VALID_TOOL, description: "" }).success).toBe(false);
+  });
+
+  it("rejects when parametersSchema is a string (not an object)", () => {
+    expect(
+      pluginToolDeclarationSchema.safeParse({ ...VALID_TOOL, parametersSchema: "string" }).success,
+    ).toBe(false);
+  });
+
+  it("rejects when parametersSchema is missing type/$ref/composition (non-empty)", () => {
+    expect(
+      pluginToolDeclarationSchema.safeParse({
+        ...VALID_TOOL,
+        parametersSchema: { description: "no type" },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pluginUiSlotDeclarationSchema
+// ---------------------------------------------------------------------------
+
+describe("pluginUiSlotDeclarationSchema", () => {
+  const VALID_SIDEBAR_SLOT = {
+    type: "sidebar",
+    id: "my-sidebar",
+    displayName: "My Sidebar",
+    exportName: "MySidebar",
+  };
+
+  const VALID_DETAIL_TAB_SLOT = {
+    type: "detailTab",
+    id: "my-tab",
+    displayName: "My Tab",
+    exportName: "MyTab",
+    entityTypes: ["issue"],
+  };
+
+  it("accepts a valid sidebar slot", () => {
+    expect(pluginUiSlotDeclarationSchema.safeParse(VALID_SIDEBAR_SLOT).success).toBe(true);
+  });
+
+  it("accepts a valid detailTab slot with entityTypes", () => {
+    expect(pluginUiSlotDeclarationSchema.safeParse(VALID_DETAIL_TAB_SLOT).success).toBe(true);
+  });
+
+  it("rejects a detailTab slot without entityTypes", () => {
+    const { entityTypes: _, ...withoutEntityTypes } = VALID_DETAIL_TAB_SLOT;
+    expect(pluginUiSlotDeclarationSchema.safeParse(withoutEntityTypes).success).toBe(false);
+  });
+
+  it("rejects a contextMenuItem slot without entityTypes", () => {
+    const result = pluginUiSlotDeclarationSchema.safeParse({
+      type: "contextMenuItem",
+      id: "my-menu",
+      displayName: "My Menu",
+      exportName: "MyMenu",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a page slot with a valid routePath", () => {
+    const result = pluginUiSlotDeclarationSchema.safeParse({
+      type: "page",
+      id: "my-page",
+      displayName: "My Page",
+      exportName: "MyPage",
+      routePath: "my-page",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a sidebar slot with a routePath (not supported)", () => {
+    const result = pluginUiSlotDeclarationSchema.safeParse({
+      ...VALID_SIDEBAR_SLOT,
+      routePath: "some-path",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a page slot with an invalid routePath (uppercase)", () => {
+    const result = pluginUiSlotDeclarationSchema.safeParse({
+      type: "page",
+      id: "my-page",
+      displayName: "My Page",
+      exportName: "MyPage",
+      routePath: "MyPage",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a projectSidebarItem slot without entityTypes including 'project'", () => {
+    const result = pluginUiSlotDeclarationSchema.safeParse({
+      type: "projectSidebarItem",
+      id: "proj-item",
+      displayName: "Proj Item",
+      exportName: "ProjItem",
+      entityTypes: ["issue"], // missing 'project'
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a projectSidebarItem slot with entityTypes including 'project'", () => {
+    const result = pluginUiSlotDeclarationSchema.safeParse({
+      type: "projectSidebarItem",
+      id: "proj-item",
+      displayName: "Proj Item",
+      exportName: "ProjItem",
+      entityTypes: ["project"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a commentAnnotation slot without entityTypes including 'comment'", () => {
+    const result = pluginUiSlotDeclarationSchema.safeParse({
+      type: "commentAnnotation",
+      id: "annotation",
+      displayName: "Annotation",
+      exportName: "Annotation",
+      entityTypes: ["issue"], // missing 'comment'
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a commentAnnotation slot with entityTypes including 'comment'", () => {
+    const result = pluginUiSlotDeclarationSchema.safeParse({
+      type: "commentAnnotation",
+      id: "annotation",
+      displayName: "Annotation",
+      exportName: "Annotation",
+      entityTypes: ["comment"],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// installPluginSchema
+// ---------------------------------------------------------------------------
+
+describe("installPluginSchema", () => {
+  it("accepts a minimal install request with just packageName", () => {
+    expect(installPluginSchema.safeParse({ packageName: "my-plugin" }).success).toBe(true);
+  });
+
+  it("accepts an install request with an optional version", () => {
+    expect(installPluginSchema.safeParse({ packageName: "my-plugin", version: "1.0.0" }).success).toBe(true);
+  });
+
+  it("accepts an install request with a packagePath", () => {
+    expect(installPluginSchema.safeParse({ packageName: "my-plugin", packagePath: "/path/to/pkg" }).success).toBe(true);
+  });
+
+  it("rejects an empty packageName", () => {
+    expect(installPluginSchema.safeParse({ packageName: "" }).success).toBe(false);
+  });
+
+  it("rejects a missing packageName", () => {
+    expect(installPluginSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertPluginConfigSchema
+// ---------------------------------------------------------------------------
+
+describe("upsertPluginConfigSchema", () => {
+  it("accepts a config with an empty configJson object", () => {
+    expect(upsertPluginConfigSchema.safeParse({ configJson: {} }).success).toBe(true);
+  });
+
+  it("accepts a config with arbitrary key-value pairs in configJson", () => {
+    expect(
+      upsertPluginConfigSchema.safeParse({ configJson: { key: "value", num: 42 } }).success,
+    ).toBe(true);
+  });
+
+  it("rejects when configJson is missing", () => {
+    expect(upsertPluginConfigSchema.safeParse({}).success).toBe(false);
+  });
+
+  it("rejects when configJson is not an object", () => {
+    expect(upsertPluginConfigSchema.safeParse({ configJson: "not-an-object" }).success).toBe(false);
+  });
+
+  it("rejects when configJson is an array", () => {
+    expect(upsertPluginConfigSchema.safeParse({ configJson: [] }).success).toBe(false);
+  });
+});

--- a/server/src/agent-auth-jwt.test.ts
+++ b/server/src/agent-auth-jwt.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createLocalAgentJwt, verifyLocalAgentJwt } from "./agent-auth-jwt.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const AGENT_ID = "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa";
+const COMPANY_ID = "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb";
+const ADAPTER_TYPE = "claude_local";
+const RUN_ID = "run-123";
+
+// ---------------------------------------------------------------------------
+// Setup: inject a test JWT secret via environment variable
+// ---------------------------------------------------------------------------
+
+const ORIGINAL_ENV = { ...process.env };
+
+function setJwtSecret(secret: string) {
+  process.env.PAPERCLIP_AGENT_JWT_SECRET = secret;
+}
+
+function clearJwtSecret() {
+  delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+  delete process.env.BETTER_AUTH_SECRET;
+}
+
+beforeEach(() => {
+  setJwtSecret("test-secret-for-unit-tests");
+});
+
+afterEach(() => {
+  Object.assign(process.env, ORIGINAL_ENV);
+  clearJwtSecret();
+  // Restore original env if keys were overridden
+  if (ORIGINAL_ENV.PAPERCLIP_AGENT_JWT_SECRET) {
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = ORIGINAL_ENV.PAPERCLIP_AGENT_JWT_SECRET;
+  }
+  if (ORIGINAL_ENV.BETTER_AUTH_SECRET) {
+    process.env.BETTER_AUTH_SECRET = ORIGINAL_ENV.BETTER_AUTH_SECRET;
+  }
+});
+
+// ---------------------------------------------------------------------------
+// createLocalAgentJwt
+// ---------------------------------------------------------------------------
+
+describe("createLocalAgentJwt", () => {
+  it("returns a non-null token when a JWT secret is set", () => {
+    const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, RUN_ID);
+    expect(token).not.toBeNull();
+  });
+
+  it("returns null when no JWT secret is configured", () => {
+    clearJwtSecret();
+    const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, RUN_ID);
+    expect(token).toBeNull();
+  });
+
+  it("returns a string with three dot-separated parts (header.claims.sig)", () => {
+    const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, RUN_ID);
+    expect(token!.split(".")).toHaveLength(3);
+  });
+
+  it("produces different tokens for different agentIds", () => {
+    const t1 = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, RUN_ID);
+    const t2 = createLocalAgentJwt("cccccccc-cccc-4ccc-cccc-cccccccccccc", COMPANY_ID, ADAPTER_TYPE, RUN_ID);
+    expect(t1).not.toBe(t2);
+  });
+
+  it("produces different tokens for different runIds", () => {
+    const t1 = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, "run-1");
+    const t2 = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, "run-2");
+    expect(t1).not.toBe(t2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyLocalAgentJwt
+// ---------------------------------------------------------------------------
+
+describe("verifyLocalAgentJwt", () => {
+  it("returns null for an empty string", () => {
+    expect(verifyLocalAgentJwt("")).toBeNull();
+  });
+
+  it("returns null for a malformed token (wrong number of parts)", () => {
+    expect(verifyLocalAgentJwt("header.claims")).toBeNull();
+    expect(verifyLocalAgentJwt("only-one-part")).toBeNull();
+  });
+
+  it("returns null for a token with an invalid signature", () => {
+    const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, RUN_ID)!;
+    const parts = token.split(".");
+    const tampered = `${parts[0]}.${parts[1]}.invalidsignature`;
+    expect(verifyLocalAgentJwt(tampered)).toBeNull();
+  });
+
+  it("returns claims for a valid token created by createLocalAgentJwt", () => {
+    const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, RUN_ID)!;
+    const claims = verifyLocalAgentJwt(token);
+    expect(claims).not.toBeNull();
+    expect(claims!.sub).toBe(AGENT_ID);
+    expect(claims!.company_id).toBe(COMPANY_ID);
+    expect(claims!.adapter_type).toBe(ADAPTER_TYPE);
+    expect(claims!.run_id).toBe(RUN_ID);
+  });
+
+  it("returns null when the JWT secret changes (signature mismatch)", () => {
+    const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, RUN_ID)!;
+    // Change the secret to simulate a key rotation
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = "different-secret";
+    expect(verifyLocalAgentJwt(token)).toBeNull();
+  });
+
+  it("returns null when no JWT secret is configured", () => {
+    const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, RUN_ID)!;
+    clearJwtSecret();
+    expect(verifyLocalAgentJwt(token)).toBeNull();
+  });
+
+  it("returns claims with exp and iat timestamps", () => {
+    const before = Math.floor(Date.now() / 1000);
+    const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, RUN_ID)!;
+    const after = Math.floor(Date.now() / 1000);
+    const claims = verifyLocalAgentJwt(token)!;
+    expect(claims.iat).toBeGreaterThanOrEqual(before);
+    expect(claims.iat).toBeLessThanOrEqual(after);
+    expect(claims.exp).toBeGreaterThan(claims.iat);
+  });
+
+  it("returns null for a token with tampered claims", () => {
+    const token = createLocalAgentJwt(AGENT_ID, COMPANY_ID, ADAPTER_TYPE, RUN_ID)!;
+    const parts = token.split(".");
+    // Modify the claims section to tamper with the agentId
+    const fakeClaims = Buffer.from(
+      JSON.stringify({ sub: "hacker", company_id: COMPANY_ID, adapter_type: ADAPTER_TYPE, run_id: RUN_ID, iat: 0, exp: 9999999999 }),
+    ).toString("base64url");
+    const tampered = `${parts[0]}.${fakeClaims}.${parts[2]}`;
+    expect(verifyLocalAgentJwt(tampered)).toBeNull();
+  });
+});

--- a/server/src/services/adapter-failure-taxonomy.test.ts
+++ b/server/src/services/adapter-failure-taxonomy.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { categorizeAdapterError } from "./adapter-failure-taxonomy.js";
+
+describe("categorizeAdapterError", () => {
+  it("returns 'unknown' for null errorCode", () => {
+    expect(categorizeAdapterError(null)).toBe("unknown");
+  });
+
+  it("returns 'unknown' for undefined errorCode", () => {
+    expect(categorizeAdapterError(undefined)).toBe("unknown");
+  });
+
+  it("returns 'unknown' for empty string errorCode", () => {
+    expect(categorizeAdapterError("")).toBe("unknown");
+  });
+
+  it("returns 'auth_required' for canonical auth_required code", () => {
+    expect(categorizeAdapterError("auth_required")).toBe("auth_required");
+  });
+
+  it("returns 'auth_required' for legacy claude_auth_required code", () => {
+    expect(categorizeAdapterError("claude_auth_required")).toBe("auth_required");
+  });
+
+  it("returns 'rate_limited' for canonical rate_limited code", () => {
+    expect(categorizeAdapterError("rate_limited")).toBe("rate_limited");
+  });
+
+  it("returns 'rate_limited' for legacy claude_rate_limited code", () => {
+    expect(categorizeAdapterError("claude_rate_limited")).toBe("rate_limited");
+  });
+
+  it("returns 'session_invalid' for canonical session_invalid code", () => {
+    expect(categorizeAdapterError("session_invalid")).toBe("session_invalid");
+  });
+
+  it("returns 'session_invalid' for legacy claude_session_invalid code", () => {
+    expect(categorizeAdapterError("claude_session_invalid")).toBe("session_invalid");
+  });
+
+  it("returns 'startup_failed' for canonical startup_failed code", () => {
+    expect(categorizeAdapterError("startup_failed")).toBe("startup_failed");
+  });
+
+  it("returns 'startup_failed' for legacy startup_failure code", () => {
+    expect(categorizeAdapterError("startup_failure")).toBe("startup_failed");
+  });
+
+  it("returns 'timeout' for timeout code", () => {
+    expect(categorizeAdapterError("timeout")).toBe("timeout");
+  });
+
+  it("returns 'provider_unavailable' for provider_unavailable code", () => {
+    expect(categorizeAdapterError("provider_unavailable")).toBe("provider_unavailable");
+  });
+
+  it("returns 'process_lost' for canonical process_lost code", () => {
+    expect(categorizeAdapterError("process_lost")).toBe("process_lost");
+  });
+
+  it("returns 'process_lost' for legacy process_detached code", () => {
+    expect(categorizeAdapterError("process_detached")).toBe("process_lost");
+  });
+
+  it("returns 'crash_no_output' for canonical crash_no_output code", () => {
+    expect(categorizeAdapterError("crash_no_output")).toBe("crash_no_output");
+  });
+
+  it("returns 'crash_no_output' for legacy claude_crash_no_output code", () => {
+    expect(categorizeAdapterError("claude_crash_no_output")).toBe("crash_no_output");
+  });
+
+  it("returns 'parse_error' for canonical parse_error code", () => {
+    expect(categorizeAdapterError("parse_error")).toBe("parse_error");
+  });
+
+  it("returns 'parse_error' for legacy claude_json_parse_failed code", () => {
+    expect(categorizeAdapterError("claude_json_parse_failed")).toBe("parse_error");
+  });
+
+  it("returns 'cancelled' for cancelled code", () => {
+    expect(categorizeAdapterError("cancelled")).toBe("cancelled");
+  });
+
+  it("returns 'nonzero_exit' for nonzero_exit code", () => {
+    expect(categorizeAdapterError("nonzero_exit")).toBe("nonzero_exit");
+  });
+
+  it("returns 'unknown' for all_adapters_exhausted code", () => {
+    expect(categorizeAdapterError("all_adapters_exhausted")).toBe("unknown");
+  });
+
+  it("returns 'unknown' for an unrecognized error code", () => {
+    expect(categorizeAdapterError("some_random_error")).toBe("unknown");
+  });
+
+  it("returns 'unknown' for a partially matching code that is not in the switch", () => {
+    expect(categorizeAdapterError("auth_require")).toBe("unknown");
+  });
+});

--- a/server/src/services/company-export-readme.test.ts
+++ b/server/src/services/company-export-readme.test.ts
@@ -40,7 +40,7 @@ function makeManifest(
     schemaVersion: 1,
     generatedAt: new Date().toISOString(),
     source: null,
-    includes: {},
+    includes: { company: false, agents: false, projects: false, issues: false, skills: false },
     company: null,
     sidebar: null,
     agents: overrides.agents ?? [],
@@ -193,7 +193,7 @@ describe("generateReadme", () => {
   it("includes content count table rows for each non-empty section", () => {
     const manifest = makeManifest({
       agents: [makeAgent()],
-      projects: [{ name: "Proj A", slug: "proj-a", path: "projects/proj-a", description: null, goals: [] }],
+      projects: [{ name: "Proj A", slug: "proj-a", path: "projects/proj-a", description: null, ownerAgentSlug: null, leadAgentSlug: null, targetDate: null, color: null, status: null, env: null, executionWorkspacePolicy: null, workspaces: [], metadata: null }],
     });
     const result = generateReadme(manifest, opts);
     expect(result).toContain("| Agents | 1 |");

--- a/server/src/services/company-export-readme.test.ts
+++ b/server/src/services/company-export-readme.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import { generateOrgChartMermaid, generateReadme } from "./company-export-readme.js";
+import type { CompanyPortabilityManifest } from "@paperclipai/shared";
+
+// ---------------------------------------------------------------------------
+// Minimal manifest factory
+// ---------------------------------------------------------------------------
+
+function makeAgent(
+  overrides: Partial<{
+    slug: string;
+    name: string;
+    role: string;
+    reportsToSlug: string | null;
+  }> = {},
+): CompanyPortabilityManifest["agents"][number] {
+  return {
+    slug: overrides.slug ?? "agent-1",
+    name: overrides.name ?? "Agent One",
+    path: "agents/agent-1",
+    skills: [],
+    role: overrides.role ?? "engineer",
+    title: null,
+    icon: null,
+    capabilities: null,
+    reportsToSlug: overrides.reportsToSlug ?? null,
+    adapterType: "codex-local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    permissions: {},
+    budgetMonthlyCents: 0,
+    metadata: null,
+  };
+}
+
+function makeManifest(
+  overrides: Partial<Pick<CompanyPortabilityManifest, "agents" | "projects" | "skills" | "issues">> = {},
+): CompanyPortabilityManifest {
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date().toISOString(),
+    source: null,
+    includes: {},
+    company: null,
+    sidebar: null,
+    agents: overrides.agents ?? [],
+    skills: overrides.skills ?? [],
+    projects: overrides.projects ?? [],
+    issues: overrides.issues ?? [],
+    envInputs: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// generateOrgChartMermaid
+// ---------------------------------------------------------------------------
+
+describe("generateOrgChartMermaid", () => {
+  it("returns null for an empty agents array", () => {
+    expect(generateOrgChartMermaid([])).toBeNull();
+  });
+
+  it("returns a mermaid code fence for a single agent", () => {
+    const result = generateOrgChartMermaid([makeAgent()]);
+    expect(result).not.toBeNull();
+    expect(result).toContain("```mermaid");
+    expect(result).toContain("graph TD");
+    expect(result).toContain("```");
+  });
+
+  it("includes the agent name in the mermaid node definition", () => {
+    const result = generateOrgChartMermaid([makeAgent({ name: "Alice" })]);
+    expect(result).toContain("Alice");
+  });
+
+  it("maps known roles to human-readable labels", () => {
+    const result = generateOrgChartMermaid([makeAgent({ role: "ceo" })]);
+    expect(result).toContain("CEO");
+  });
+
+  it("falls back to the raw role value for unknown roles", () => {
+    const result = generateOrgChartMermaid([makeAgent({ role: "wizard" })]);
+    expect(result).toContain("wizard");
+  });
+
+  it("sanitizes slug to alphanumeric+underscore for node IDs", () => {
+    const result = generateOrgChartMermaid([makeAgent({ slug: "my-agent.1" })]);
+    expect(result).toContain("my_agent_1");
+    expect(result).not.toContain("my-agent.1[");
+  });
+
+  it("escapes double quotes in agent names", () => {
+    const result = generateOrgChartMermaid([makeAgent({ name: 'Bot "Alpha"' })]);
+    expect(result).toContain("&quot;");
+    expect(result).not.toContain('"Alpha"');
+  });
+
+  it("escapes < and > in agent names", () => {
+    const result = generateOrgChartMermaid([makeAgent({ name: "Bot <v2>" })]);
+    expect(result).toContain("&lt;");
+    expect(result).toContain("&gt;");
+  });
+
+  it("adds an edge from parent to child when reportsToSlug is set and present in the list", () => {
+    const agents = [
+      makeAgent({ slug: "ceo", name: "CEO Agent", role: "ceo" }),
+      makeAgent({ slug: "dev", name: "Dev Agent", role: "engineer", reportsToSlug: "ceo" }),
+    ];
+    const result = generateOrgChartMermaid(agents);
+    expect(result).toContain("ceo --> dev");
+  });
+
+  it("does not add an edge when reportsToSlug references a slug not in the list", () => {
+    const agents = [makeAgent({ slug: "dev", reportsToSlug: "ghost-ceo" })];
+    const result = generateOrgChartMermaid(agents);
+    expect(result).not.toContain("-->");
+  });
+
+  it("does not add an edge when reportsToSlug is null", () => {
+    const agents = [makeAgent({ slug: "solo", reportsToSlug: null })];
+    const result = generateOrgChartMermaid(agents);
+    expect(result).not.toContain("-->");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateReadme
+// ---------------------------------------------------------------------------
+
+describe("generateReadme", () => {
+  const opts = { companyName: "Acme Corp", companyDescription: null };
+
+  it("starts with the company name as an H1 heading", () => {
+    const result = generateReadme(makeManifest(), opts);
+    expect(result).toContain("# Acme Corp");
+  });
+
+  it("includes the company description as a blockquote when provided", () => {
+    const result = generateReadme(makeManifest(), {
+      companyName: "Acme",
+      companyDescription: "We build stuff",
+    });
+    expect(result).toContain("> We build stuff");
+  });
+
+  it("omits the company description blockquote when description is null", () => {
+    const result = generateReadme(makeManifest(), { companyName: "Acme", companyDescription: null });
+    // The only blockquote in the output should be the "What's Inside" boilerplate, not a company description line.
+    // Verify the specific description text is not present.
+    expect(result).not.toContain("> We build stuff");
+  });
+
+  it("includes the Getting Started section", () => {
+    const result = generateReadme(makeManifest(), opts);
+    expect(result).toContain("## Getting Started");
+    expect(result).toContain("pnpm paperclipai company import");
+  });
+
+  it("includes a Paperclip footer", () => {
+    const result = generateReadme(makeManifest(), opts);
+    expect(result).toContain("Exported from [Paperclip]");
+  });
+
+  it("includes the What's Inside section", () => {
+    const result = generateReadme(makeManifest(), opts);
+    expect(result).toContain("## What's Inside");
+  });
+
+  it("includes an Agents table when agents are present", () => {
+    const manifest = makeManifest({ agents: [makeAgent({ role: "cto", name: "Zara" })] });
+    const result = generateReadme(manifest, opts);
+    expect(result).toContain("### Agents");
+    expect(result).toContain("Zara");
+    expect(result).toContain("CTO");
+  });
+
+  it("omits the Agents section when no agents are present", () => {
+    const result = generateReadme(makeManifest(), opts);
+    expect(result).not.toContain("### Agents");
+  });
+
+  it("includes the org chart image reference when agents are present", () => {
+    const manifest = makeManifest({ agents: [makeAgent()] });
+    const result = generateReadme(manifest, opts);
+    expect(result).toContain("![Org Chart](images/org-chart.png)");
+  });
+
+  it("omits the org chart image reference when no agents are present", () => {
+    const result = generateReadme(makeManifest(), opts);
+    expect(result).not.toContain("Org Chart");
+  });
+
+  it("includes content count table rows for each non-empty section", () => {
+    const manifest = makeManifest({
+      agents: [makeAgent()],
+      projects: [{ name: "Proj A", slug: "proj-a", path: "projects/proj-a", description: null, goals: [] }],
+    });
+    const result = generateReadme(manifest, opts);
+    expect(result).toContain("| Agents | 1 |");
+    expect(result).toContain("| Projects | 1 |");
+  });
+
+  it("omits the count table entirely when all sections are empty", () => {
+    const result = generateReadme(makeManifest(), opts);
+    expect(result).not.toContain("| Content | Count |");
+  });
+
+  it("includes a reports-to column for agents", () => {
+    const agents = [
+      makeAgent({ slug: "ceo", name: "CEO", role: "ceo" }),
+      makeAgent({ slug: "dev", name: "Dev", role: "engineer", reportsToSlug: "ceo" }),
+    ];
+    const result = generateReadme(makeManifest({ agents }), opts);
+    expect(result).toContain("ceo");
+  });
+});

--- a/server/src/services/company-portability-github.test.ts
+++ b/server/src/services/company-portability-github.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { parseGitHubSourceUrl } from "./company-portability.js";
+
+// ---------------------------------------------------------------------------
+// parseGitHubSourceUrl
+// ---------------------------------------------------------------------------
+
+describe("parseGitHubSourceUrl", () => {
+  it("parses a simple owner/repo GitHub URL", () => {
+    const result = parseGitHubSourceUrl("https://github.com/acme/my-repo");
+    expect(result.owner).toBe("acme");
+    expect(result.repo).toBe("my-repo");
+    expect(result.ref).toBe("main");
+    expect(result.basePath).toBe("");
+    expect(result.companyPath).toBe("COMPANY.md");
+  });
+
+  it("strips .git suffix from repo name", () => {
+    const result = parseGitHubSourceUrl("https://github.com/acme/my-repo.git");
+    expect(result.repo).toBe("my-repo");
+  });
+
+  it("throws for a non-HTTPS URL", () => {
+    expect(() => parseGitHubSourceUrl("http://github.com/acme/repo")).toThrow();
+  });
+
+  it("throws for a URL with fewer than 2 path segments", () => {
+    expect(() => parseGitHubSourceUrl("https://github.com/acme")).toThrow();
+  });
+
+  it("parses a tree URL with ref and nested path", () => {
+    const result = parseGitHubSourceUrl("https://github.com/acme/repo/tree/dev/packages/myapp");
+    expect(result.ref).toBe("dev");
+    expect(result.basePath).toBe("packages/myapp");
+    expect(result.companyPath).toBe("COMPANY.md");
+  });
+
+  it("parses a tree URL with just a ref (no extra path)", () => {
+    const result = parseGitHubSourceUrl("https://github.com/acme/repo/tree/v1.0.0");
+    expect(result.ref).toBe("v1.0.0");
+    expect(result.basePath).toBe("");
+  });
+
+  it("parses a blob URL pointing to a COMPANY.md file", () => {
+    const result = parseGitHubSourceUrl("https://github.com/acme/repo/blob/main/apps/myapp/COMPANY.md");
+    expect(result.ref).toBe("main");
+    expect(result.companyPath).toBe("apps/myapp/COMPANY.md");
+    expect(result.basePath).toBe("apps/myapp");
+  });
+
+  it("uses ?ref query param when present", () => {
+    const result = parseGitHubSourceUrl("https://github.com/acme/repo?ref=feature/x");
+    expect(result.ref).toBe("feature/x");
+  });
+
+  it("uses ?path query param to set basePath and companyPath", () => {
+    const result = parseGitHubSourceUrl("https://github.com/acme/repo?path=packages/agent");
+    expect(result.basePath).toBe("packages/agent");
+    expect(result.companyPath).toBe("packages/agent/COMPANY.md");
+  });
+
+  it("uses ?companyPath query param for an explicit companyPath", () => {
+    const result = parseGitHubSourceUrl("https://github.com/acme/repo?companyPath=custom/COMPANY.md");
+    expect(result.companyPath).toBe("custom/COMPANY.md");
+  });
+
+  it("uses 'main' as the default ref when ?ref is not present and no tree/blob path exists", () => {
+    const result = parseGitHubSourceUrl("https://github.com/acme/repo");
+    expect(result.ref).toBe("main");
+  });
+
+  it("preserves the hostname for non-github.com hosts", () => {
+    const result = parseGitHubSourceUrl("https://github.example.com/acme/repo");
+    expect(result.hostname).toBe("github.example.com");
+  });
+});

--- a/server/src/services/cron.test.ts
+++ b/server/src/services/cron.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "vitest";
+import { parseCron, validateCron, nextCronTick, nextCronTickFromExpression } from "./cron.js";
+
+// ---------------------------------------------------------------------------
+// parseCron
+// ---------------------------------------------------------------------------
+
+describe("parseCron", () => {
+  it("parses a wildcard-only expression correctly", () => {
+    const result = parseCron("* * * * *");
+    expect(result.minutes).toHaveLength(60); // 0-59
+    expect(result.hours).toHaveLength(24); // 0-23
+    expect(result.daysOfMonth).toHaveLength(31); // 1-31
+    expect(result.months).toHaveLength(12); // 1-12
+    expect(result.daysOfWeek).toHaveLength(7); // 0-6
+  });
+
+  it("parses exact values for each field", () => {
+    const result = parseCron("30 14 15 6 3");
+    expect(result.minutes).toEqual([30]);
+    expect(result.hours).toEqual([14]);
+    expect(result.daysOfMonth).toEqual([15]);
+    expect(result.months).toEqual([6]);
+    expect(result.daysOfWeek).toEqual([3]);
+  });
+
+  it("parses a range in the minutes field", () => {
+    const result = parseCron("0-5 * * * *");
+    expect(result.minutes).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it("parses a step expression (*/15 minutes)", () => {
+    const result = parseCron("*/15 * * * *");
+    expect(result.minutes).toEqual([0, 15, 30, 45]);
+  });
+
+  it("parses a step expression starting at N (5/15 minutes)", () => {
+    const result = parseCron("5/15 * * * *");
+    expect(result.minutes).toContain(5);
+    expect(result.minutes).toContain(20);
+    expect(result.minutes).toContain(35);
+    expect(result.minutes).toContain(50);
+  });
+
+  it("parses a range with step (0-30/10 minutes)", () => {
+    const result = parseCron("0-30/10 * * * *");
+    expect(result.minutes).toEqual([0, 10, 20, 30]);
+  });
+
+  it("parses a comma-separated list in the hours field", () => {
+    const result = parseCron("0 0,6,12,18 * * *");
+    expect(result.hours).toEqual([0, 6, 12, 18]);
+  });
+
+  it("parses a comma-separated list with ranges", () => {
+    const result = parseCron("0 1-3,22-23 * * *");
+    expect(result.hours).toEqual([1, 2, 3, 22, 23]);
+  });
+
+  it("deduplicates overlapping values in a comma list", () => {
+    const result = parseCron("0 1,1,2 * * *");
+    expect(result.hours).toEqual([1, 2]);
+  });
+
+  it("sorts values in ascending order", () => {
+    const result = parseCron("59,0,30 * * * *");
+    expect(result.minutes).toEqual([0, 30, 59]);
+  });
+
+  it("trims whitespace from the expression", () => {
+    const result = parseCron("  0 12 * * *  ");
+    expect(result.minutes).toEqual([0]);
+    expect(result.hours).toEqual([12]);
+  });
+
+  it("throws on an empty expression", () => {
+    expect(() => parseCron("")).toThrow();
+  });
+
+  it("throws on an expression with wrong field count (too few)", () => {
+    expect(() => parseCron("* * * *")).toThrow(/5 fields/);
+  });
+
+  it("throws on an expression with wrong field count (too many)", () => {
+    expect(() => parseCron("* * * * * *")).toThrow(/5 fields/);
+  });
+
+  it("throws when a minute value is out of range (60)", () => {
+    expect(() => parseCron("60 * * * *")).toThrow(/out of range/);
+  });
+
+  it("throws when an hour value is out of range (24)", () => {
+    expect(() => parseCron("0 24 * * *")).toThrow(/out of range/);
+  });
+
+  it("throws when day of month is out of range (0)", () => {
+    expect(() => parseCron("0 0 0 * *")).toThrow(/out of range/);
+  });
+
+  it("throws when month is out of range (13)", () => {
+    expect(() => parseCron("0 0 1 13 *")).toThrow(/out of range/);
+  });
+
+  it("throws on a range where start > end", () => {
+    expect(() => parseCron("5-3 * * * *")).toThrow(/start > end/);
+  });
+
+  it("throws on an invalid non-numeric field value", () => {
+    expect(() => parseCron("abc * * * *")).toThrow();
+  });
+
+  it("throws on a step of 0", () => {
+    expect(() => parseCron("*/0 * * * *")).toThrow(/Invalid step/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCron
+// ---------------------------------------------------------------------------
+
+describe("validateCron", () => {
+  it("returns null for a valid expression", () => {
+    expect(validateCron("0 12 * * *")).toBeNull();
+  });
+
+  it("returns null for the every-minute wildcard expression", () => {
+    expect(validateCron("* * * * *")).toBeNull();
+  });
+
+  it("returns an error string for an expression with too few fields", () => {
+    const error = validateCron("* * * *");
+    expect(typeof error).toBe("string");
+    expect(error).toBeTruthy();
+  });
+
+  it("returns an error string for an out-of-range minute", () => {
+    const error = validateCron("60 * * * *");
+    expect(typeof error).toBe("string");
+  });
+
+  it("returns an error string for an empty expression", () => {
+    const error = validateCron("");
+    expect(error).toBeTruthy();
+  });
+
+  it("returns null for a complex valid expression", () => {
+    expect(validateCron("0-30/5 8-18 1,15 * 1-5")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nextCronTick
+// ---------------------------------------------------------------------------
+
+describe("nextCronTick", () => {
+  it("returns a date strictly after the reference date", () => {
+    const after = new Date("2024-01-01T00:00:00Z");
+    const cron = { minutes: [0], hours: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23], daysOfMonth: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31], months: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], daysOfWeek: [0, 1, 2, 3, 4, 5, 6] };
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getTime()).toBeGreaterThan(after.getTime());
+  });
+
+  it("finds the next matching minute for '*/15 * * * *'", () => {
+    const cron = parseCron("*/15 * * * *");
+    const after = new Date("2024-01-01T00:01:00Z"); // 1 minute past
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCMinutes()).toBe(15);
+  });
+
+  it("advances to the next hour when no minute matches in the current hour", () => {
+    const cron = parseCron("0 * * * *"); // every hour on the hour
+    const after = new Date("2024-01-01T05:01:00Z");
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCHours()).toBe(6);
+    expect(next!.getUTCMinutes()).toBe(0);
+  });
+
+  it("advances to the next day when hour doesn't match", () => {
+    const cron = parseCron("0 9 * * *"); // daily at 09:00
+    const after = new Date("2024-01-01T10:00:00Z"); // already past 09:00
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCDate()).toBe(2);
+    expect(next!.getUTCHours()).toBe(9);
+    expect(next!.getUTCMinutes()).toBe(0);
+  });
+
+  it("advances to the next matching month", () => {
+    const cron = parseCron("0 0 1 6 *"); // June 1st at midnight
+    const after = new Date("2024-06-02T00:00:00Z"); // after June 1
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCFullYear()).toBe(2025);
+    expect(next!.getUTCMonth()).toBe(5); // June (0-based)
+    expect(next!.getUTCDate()).toBe(1);
+  });
+
+  it("matches on specific day of week", () => {
+    const cron = parseCron("0 9 * * 1"); // Monday 09:00
+    const after = new Date("2024-01-01T00:00:00Z"); // Monday Jan 1 2024
+    const next = nextCronTick(cron, after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCDay()).toBe(1); // Monday
+    expect(next!.getUTCHours()).toBe(9);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nextCronTickFromExpression
+// ---------------------------------------------------------------------------
+
+describe("nextCronTickFromExpression", () => {
+  it("parses and computes next tick in one call", () => {
+    const after = new Date("2024-06-15T12:00:00Z");
+    const next = nextCronTickFromExpression("30 12 * * *", after);
+    expect(next).not.toBeNull();
+    expect(next!.getUTCHours()).toBe(12);
+    expect(next!.getUTCMinutes()).toBe(30);
+  });
+
+  it("throws for an invalid expression", () => {
+    expect(() => nextCronTickFromExpression("invalid")).toThrow();
+  });
+});

--- a/server/src/services/documents.test.ts
+++ b/server/src/services/documents.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { extractLegacyPlanBody } from "./documents.js";
+
+// ---------------------------------------------------------------------------
+// extractLegacyPlanBody
+// ---------------------------------------------------------------------------
+
+describe("extractLegacyPlanBody", () => {
+  it("returns null for null input", () => {
+    expect(extractLegacyPlanBody(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(extractLegacyPlanBody(undefined)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(extractLegacyPlanBody("")).toBeNull();
+  });
+
+  it("returns null when no <plan> tag is present", () => {
+    expect(extractLegacyPlanBody("This is just a description with no plan tag.")).toBeNull();
+  });
+
+  it("extracts the body from a <plan>...</plan> block", () => {
+    const input = "Some text\n<plan>\nDo something\n</plan>\nMore text";
+    expect(extractLegacyPlanBody(input)).toBe("Do something");
+  });
+
+  it("trims leading and trailing whitespace from the extracted body", () => {
+    const input = "<plan>  \n  Trimmed body  \n  </plan>";
+    expect(extractLegacyPlanBody(input)).toBe("Trimmed body");
+  });
+
+  it("handles multiline plan bodies", () => {
+    const input = "<plan>\nStep 1\nStep 2\nStep 3\n</plan>";
+    expect(extractLegacyPlanBody(input)).toBe("Step 1\nStep 2\nStep 3");
+  });
+
+  it("is case-insensitive for the plan tag", () => {
+    expect(extractLegacyPlanBody("<PLAN>body</PLAN>")).toBe("body");
+    expect(extractLegacyPlanBody("<Plan>body</Plan>")).toBe("body");
+  });
+
+  it("returns null when <plan> tag is present but body is empty after trimming", () => {
+    expect(extractLegacyPlanBody("<plan>   </plan>")).toBeNull();
+  });
+
+  it("matches only the first <plan> block when multiple are present", () => {
+    const input = "<plan>first</plan> and <plan>second</plan>";
+    expect(extractLegacyPlanBody(input)).toBe("first");
+  });
+});

--- a/server/src/services/execution-workspace-policy.test.ts
+++ b/server/src/services/execution-workspace-policy.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseProjectExecutionWorkspacePolicy,
+  gateProjectExecutionWorkspacePolicy,
+  parseIssueExecutionWorkspaceSettings,
+  defaultIssueExecutionWorkspaceSettingsForProject,
+  issueExecutionWorkspaceModeForPersistedWorkspace,
+  resolveExecutionWorkspaceMode,
+} from "./execution-workspace-policy.js";
+
+// ---------------------------------------------------------------------------
+// gateProjectExecutionWorkspacePolicy
+// ---------------------------------------------------------------------------
+
+describe("gateProjectExecutionWorkspacePolicy", () => {
+  const policy = { enabled: true };
+
+  it("returns null when isolatedWorkspacesEnabled is false", () => {
+    expect(gateProjectExecutionWorkspacePolicy(policy, false)).toBeNull();
+  });
+
+  it("returns the policy when isolatedWorkspacesEnabled is true", () => {
+    expect(gateProjectExecutionWorkspacePolicy(policy, true)).toBe(policy);
+  });
+
+  it("returns null for a null policy regardless of flag", () => {
+    expect(gateProjectExecutionWorkspacePolicy(null, true)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issueExecutionWorkspaceModeForPersistedWorkspace
+// ---------------------------------------------------------------------------
+
+describe("issueExecutionWorkspaceModeForPersistedWorkspace", () => {
+  it("returns 'agent_default' for null input", () => {
+    expect(issueExecutionWorkspaceModeForPersistedWorkspace(null)).toBe("agent_default");
+  });
+
+  it("returns 'agent_default' for undefined input", () => {
+    expect(issueExecutionWorkspaceModeForPersistedWorkspace(undefined)).toBe("agent_default");
+  });
+
+  it("returns 'isolated_workspace' for 'isolated_workspace'", () => {
+    expect(issueExecutionWorkspaceModeForPersistedWorkspace("isolated_workspace")).toBe("isolated_workspace");
+  });
+
+  it("returns 'operator_branch' for 'operator_branch'", () => {
+    expect(issueExecutionWorkspaceModeForPersistedWorkspace("operator_branch")).toBe("operator_branch");
+  });
+
+  it("returns 'shared_workspace' for 'shared_workspace'", () => {
+    expect(issueExecutionWorkspaceModeForPersistedWorkspace("shared_workspace")).toBe("shared_workspace");
+  });
+
+  it("returns 'agent_default' for 'adapter_managed'", () => {
+    expect(issueExecutionWorkspaceModeForPersistedWorkspace("adapter_managed")).toBe("agent_default");
+  });
+
+  it("returns 'agent_default' for 'cloud_sandbox'", () => {
+    expect(issueExecutionWorkspaceModeForPersistedWorkspace("cloud_sandbox")).toBe("agent_default");
+  });
+
+  it("returns 'shared_workspace' for an unrecognized mode string", () => {
+    expect(issueExecutionWorkspaceModeForPersistedWorkspace("unknown_mode")).toBe("shared_workspace");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultIssueExecutionWorkspaceSettingsForProject
+// ---------------------------------------------------------------------------
+
+describe("defaultIssueExecutionWorkspaceSettingsForProject", () => {
+  it("returns null when policy is null", () => {
+    expect(defaultIssueExecutionWorkspaceSettingsForProject(null)).toBeNull();
+  });
+
+  it("returns null when policy.enabled is false", () => {
+    expect(defaultIssueExecutionWorkspaceSettingsForProject({ enabled: false })).toBeNull();
+  });
+
+  it("returns 'isolated_workspace' mode when policy defaultMode is 'isolated_workspace'", () => {
+    const result = defaultIssueExecutionWorkspaceSettingsForProject({
+      enabled: true,
+      defaultMode: "isolated_workspace",
+    });
+    expect(result?.mode).toBe("isolated_workspace");
+  });
+
+  it("returns 'operator_branch' mode when policy defaultMode is 'operator_branch'", () => {
+    const result = defaultIssueExecutionWorkspaceSettingsForProject({
+      enabled: true,
+      defaultMode: "operator_branch",
+    });
+    expect(result?.mode).toBe("operator_branch");
+  });
+
+  it("returns 'agent_default' mode when policy defaultMode is 'adapter_default'", () => {
+    const result = defaultIssueExecutionWorkspaceSettingsForProject({
+      enabled: true,
+      defaultMode: "adapter_default",
+    });
+    expect(result?.mode).toBe("agent_default");
+  });
+
+  it("returns 'shared_workspace' mode for 'shared_workspace' defaultMode", () => {
+    const result = defaultIssueExecutionWorkspaceSettingsForProject({
+      enabled: true,
+      defaultMode: "shared_workspace",
+    });
+    expect(result?.mode).toBe("shared_workspace");
+  });
+
+  it("returns 'shared_workspace' mode when policy has no defaultMode", () => {
+    const result = defaultIssueExecutionWorkspaceSettingsForProject({ enabled: true });
+    expect(result?.mode).toBe("shared_workspace");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveExecutionWorkspaceMode
+// ---------------------------------------------------------------------------
+
+describe("resolveExecutionWorkspaceMode", () => {
+  it("returns 'shared_workspace' when no policy, no issue settings, and no legacy flag", () => {
+    const result = resolveExecutionWorkspaceMode({
+      projectPolicy: null,
+      issueSettings: null,
+      legacyUseProjectWorkspace: null,
+    });
+    expect(result).toBe("shared_workspace");
+  });
+
+  it("uses issue mode when it is an explicit non-inherit value", () => {
+    const result = resolveExecutionWorkspaceMode({
+      projectPolicy: null,
+      issueSettings: { mode: "isolated_workspace" },
+      legacyUseProjectWorkspace: null,
+    });
+    expect(result).toBe("isolated_workspace");
+  });
+
+  it("falls through issue mode 'inherit' to project policy", () => {
+    const result = resolveExecutionWorkspaceMode({
+      projectPolicy: { enabled: true, defaultMode: "operator_branch" },
+      issueSettings: { mode: "inherit" },
+      legacyUseProjectWorkspace: null,
+    });
+    expect(result).toBe("operator_branch");
+  });
+
+  it("uses project policy defaultMode when issue settings have no mode", () => {
+    const result = resolveExecutionWorkspaceMode({
+      projectPolicy: { enabled: true, defaultMode: "isolated_workspace" },
+      issueSettings: null,
+      legacyUseProjectWorkspace: null,
+    });
+    expect(result).toBe("isolated_workspace");
+  });
+
+  it("returns 'shared_workspace' from enabled project policy with 'shared_workspace' defaultMode", () => {
+    const result = resolveExecutionWorkspaceMode({
+      projectPolicy: { enabled: true, defaultMode: "shared_workspace" },
+      issueSettings: null,
+      legacyUseProjectWorkspace: null,
+    });
+    expect(result).toBe("shared_workspace");
+  });
+
+  it("returns 'agent_default' from enabled project policy with 'adapter_default' defaultMode", () => {
+    const result = resolveExecutionWorkspaceMode({
+      projectPolicy: { enabled: true, defaultMode: "adapter_default" },
+      issueSettings: null,
+      legacyUseProjectWorkspace: null,
+    });
+    expect(result).toBe("agent_default");
+  });
+
+  it("returns 'agent_default' when legacy flag is false and no policy or settings", () => {
+    const result = resolveExecutionWorkspaceMode({
+      projectPolicy: null,
+      issueSettings: null,
+      legacyUseProjectWorkspace: false,
+    });
+    expect(result).toBe("agent_default");
+  });
+
+  it("project policy overrides the legacy flag", () => {
+    // Policy enabled → policy wins over legacyUseProjectWorkspace=false
+    const result = resolveExecutionWorkspaceMode({
+      projectPolicy: { enabled: true, defaultMode: "shared_workspace" },
+      issueSettings: null,
+      legacyUseProjectWorkspace: false,
+    });
+    expect(result).toBe("shared_workspace");
+  });
+
+  it("ignores a disabled project policy (falls through to legacy flag)", () => {
+    const result = resolveExecutionWorkspaceMode({
+      projectPolicy: { enabled: false, defaultMode: "isolated_workspace" },
+      issueSettings: null,
+      legacyUseProjectWorkspace: false,
+    });
+    expect(result).toBe("agent_default");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseProjectExecutionWorkspacePolicy
+// ---------------------------------------------------------------------------
+
+describe("parseProjectExecutionWorkspacePolicy", () => {
+  it("returns null for null input", () => {
+    expect(parseProjectExecutionWorkspacePolicy(null)).toBeNull();
+  });
+
+  it("returns null for empty object", () => {
+    expect(parseProjectExecutionWorkspacePolicy({})).toBeNull();
+  });
+
+  it("returns a policy with enabled=false by default when only other fields are present", () => {
+    const result = parseProjectExecutionWorkspacePolicy({ defaultMode: "shared_workspace" });
+    expect(result?.enabled).toBe(false);
+  });
+
+  it("parses enabled=true correctly", () => {
+    const result = parseProjectExecutionWorkspacePolicy({ enabled: true });
+    expect(result?.enabled).toBe(true);
+  });
+
+  it("normalizes legacy 'project_primary' defaultMode to 'shared_workspace'", () => {
+    const result = parseProjectExecutionWorkspacePolicy({ enabled: true, defaultMode: "project_primary" });
+    expect(result?.defaultMode).toBe("shared_workspace");
+  });
+
+  it("normalizes legacy 'isolated' defaultMode to 'isolated_workspace'", () => {
+    const result = parseProjectExecutionWorkspacePolicy({ enabled: true, defaultMode: "isolated" });
+    expect(result?.defaultMode).toBe("isolated_workspace");
+  });
+
+  it("passes through 'shared_workspace' defaultMode unchanged", () => {
+    const result = parseProjectExecutionWorkspacePolicy({ enabled: true, defaultMode: "shared_workspace" });
+    expect(result?.defaultMode).toBe("shared_workspace");
+  });
+
+  it("parses allowIssueOverride boolean", () => {
+    const result = parseProjectExecutionWorkspacePolicy({ enabled: true, allowIssueOverride: true });
+    expect(result?.allowIssueOverride).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseIssueExecutionWorkspaceSettings
+// ---------------------------------------------------------------------------
+
+describe("parseIssueExecutionWorkspaceSettings", () => {
+  it("returns null for null input", () => {
+    expect(parseIssueExecutionWorkspaceSettings(null)).toBeNull();
+  });
+
+  it("returns null for empty object", () => {
+    expect(parseIssueExecutionWorkspaceSettings({})).toBeNull();
+  });
+
+  it("parses 'isolated_workspace' mode", () => {
+    const result = parseIssueExecutionWorkspaceSettings({ mode: "isolated_workspace" });
+    expect(result?.mode).toBe("isolated_workspace");
+  });
+
+  it("normalizes legacy 'isolated' to 'isolated_workspace'", () => {
+    const result = parseIssueExecutionWorkspaceSettings({ mode: "isolated" });
+    expect(result?.mode).toBe("isolated_workspace");
+  });
+
+  it("normalizes legacy 'project_primary' to 'shared_workspace'", () => {
+    const result = parseIssueExecutionWorkspaceSettings({ mode: "project_primary" });
+    expect(result?.mode).toBe("shared_workspace");
+  });
+
+  it("omits mode when input mode is unrecognized", () => {
+    const result = parseIssueExecutionWorkspaceSettings({ mode: "unknown_mode" });
+    expect(result).not.toHaveProperty("mode");
+  });
+
+  it("parses 'inherit' mode", () => {
+    const result = parseIssueExecutionWorkspaceSettings({ mode: "inherit" });
+    expect(result?.mode).toBe("inherit");
+  });
+});

--- a/server/src/services/feedback-redaction.test.ts
+++ b/server/src/services/feedback-redaction.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import {
+  createFeedbackRedactionState,
+  stableStringify,
+  sha256Digest,
+  sanitizeFeedbackText,
+  sanitizeFeedbackValue,
+  finalizeFeedbackRedactionSummary,
+} from "./feedback-redaction.js";
+
+// ---------------------------------------------------------------------------
+// stableStringify
+// ---------------------------------------------------------------------------
+
+describe("stableStringify", () => {
+  it("serializes null", () => {
+    expect(stableStringify(null)).toBe("null");
+  });
+
+  it("serializes numbers", () => {
+    expect(stableStringify(42)).toBe("42");
+  });
+
+  it("serializes strings with JSON encoding", () => {
+    expect(stableStringify("hello")).toBe('"hello"');
+  });
+
+  it("serializes arrays in order", () => {
+    expect(stableStringify([1, 2, 3])).toBe("[1,2,3]");
+  });
+
+  it("sorts object keys alphabetically", () => {
+    expect(stableStringify({ z: 1, a: 2 })).toBe('{"a":2,"z":1}');
+  });
+
+  it("produces the same output regardless of key insertion order", () => {
+    const obj1 = { b: 2, a: 1 };
+    const obj2 = { a: 1, b: 2 };
+    expect(stableStringify(obj1)).toBe(stableStringify(obj2));
+  });
+
+  it("sorts nested object keys", () => {
+    const result = stableStringify({ z: { y: 1, x: 2 }, a: 0 });
+    expect(result).toBe('{"a":0,"z":{"x":2,"y":1}}');
+  });
+
+  it("handles arrays of objects with sorted keys", () => {
+    const result = stableStringify([{ z: 2, a: 1 }]);
+    expect(result).toBe('[{"a":1,"z":2}]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sha256Digest
+// ---------------------------------------------------------------------------
+
+describe("sha256Digest", () => {
+  it("returns a 64-character hex string", () => {
+    const digest = sha256Digest("test");
+    expect(digest).toHaveLength(64);
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(sha256Digest({ key: "value" })).toBe(sha256Digest({ key: "value" }));
+  });
+
+  it("differs for different inputs", () => {
+    expect(sha256Digest("a")).not.toBe(sha256Digest("b"));
+  });
+
+  it("is stable regardless of object key insertion order", () => {
+    const digest1 = sha256Digest({ b: 2, a: 1 });
+    const digest2 = sha256Digest({ a: 1, b: 2 });
+    expect(digest1).toBe(digest2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createFeedbackRedactionState
+// ---------------------------------------------------------------------------
+
+describe("createFeedbackRedactionState", () => {
+  it("returns a state with empty sets and an empty counts map", () => {
+    const state = createFeedbackRedactionState();
+    expect(state.redactedFields.size).toBe(0);
+    expect(state.truncatedFields.size).toBe(0);
+    expect(state.omittedFields.size).toBe(0);
+    expect(state.notes.size).toBe(0);
+    expect(state.counts.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeFeedbackText
+// ---------------------------------------------------------------------------
+
+describe("sanitizeFeedbackText", () => {
+  it("returns the input unchanged when there is nothing to redact", () => {
+    const state = createFeedbackRedactionState();
+    const result = sanitizeFeedbackText("hello world", state, "msg", 1000);
+    expect(result).toBe("hello world");
+    expect(state.redactedFields.size).toBe(0);
+  });
+
+  it("redacts a bearer token (standalone form)", () => {
+    const state = createFeedbackRedactionState();
+    // Use the standalone bearer form so the bearer_token regex (not secret_assignment) handles it
+    const result = sanitizeFeedbackText("Bearer abc123xyz456789", state, "header", 1000);
+    expect(result).not.toContain("abc123xyz456789");
+    expect(result).toContain("[REDACTED_TOKEN]");
+  });
+
+  it("redacts a GitHub token", () => {
+    const state = createFeedbackRedactionState();
+    const result = sanitizeFeedbackText("token ghp_abcdefghij1234567890", state, "env", 1000);
+    expect(result).not.toContain("ghp_abcdefghij1234567890");
+    expect(result).toContain("[REDACTED_GITHUB_TOKEN]");
+  });
+
+  it("redacts an API key matching sk- pattern", () => {
+    const state = createFeedbackRedactionState();
+    const result = sanitizeFeedbackText("key=sk-ant-abcdefghijklmnop", state, "config", 1000);
+    expect(result).not.toContain("sk-ant-abcdefghijklmnop");
+  });
+
+  it("redacts an email address", () => {
+    const state = createFeedbackRedactionState();
+    const result = sanitizeFeedbackText("Contact: user@example.com", state, "body", 1000);
+    expect(result).not.toContain("user@example.com");
+    expect(result).toContain("[REDACTED_EMAIL]");
+  });
+
+  it("truncates text exceeding maxLength with an ellipsis", () => {
+    const state = createFeedbackRedactionState();
+    // truncation formula: slice(0, maxLength - 1) + "..." = maxLength - 1 + 3 chars
+    const maxLength = 10;
+    const result = sanitizeFeedbackText("a".repeat(20), state, "field", maxLength);
+    expect(result.endsWith("...")).toBe(true);
+    expect(result.length).toBe(maxLength + 2); // (maxLength - 1) chars + "..."
+    expect(state.truncatedFields.has("field")).toBe(true);
+  });
+
+  it("records the field path when redaction occurs", () => {
+    const state = createFeedbackRedactionState();
+    sanitizeFeedbackText("Bearer abc123xyz", state, "auth.header", 1000);
+    expect(state.redactedFields.has("auth.header")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeFeedbackValue
+// ---------------------------------------------------------------------------
+
+describe("sanitizeFeedbackValue", () => {
+  it("returns non-string, non-object, non-array values as-is", () => {
+    const state = createFeedbackRedactionState();
+    expect(sanitizeFeedbackValue(42, state, "num", 1000)).toBe(42);
+    expect(sanitizeFeedbackValue(true, state, "bool", 1000)).toBe(true);
+    expect(sanitizeFeedbackValue(null, state, "nul", 1000)).toBeNull();
+  });
+
+  it("redacts strings recursively", () => {
+    const state = createFeedbackRedactionState();
+    const result = sanitizeFeedbackValue("user@test.com", state, "email", 1000);
+    expect(result).toContain("[REDACTED_EMAIL]");
+  });
+
+  it("processes arrays element by element", () => {
+    const state = createFeedbackRedactionState();
+    const result = sanitizeFeedbackValue(["hello", "user@test.com"], state, "list", 1000) as string[];
+    expect(result[0]).toBe("hello");
+    expect(result[1]).toContain("[REDACTED_EMAIL]");
+  });
+
+  it("processes object values recursively", () => {
+    const state = createFeedbackRedactionState();
+    const result = sanitizeFeedbackValue(
+      { greeting: "hello", contact: "admin@corp.io" },
+      state,
+      "obj",
+      1000,
+    ) as Record<string, string>;
+    expect(result.greeting).toBe("hello");
+    expect(result.contact).toContain("[REDACTED_EMAIL]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// finalizeFeedbackRedactionSummary
+// ---------------------------------------------------------------------------
+
+describe("finalizeFeedbackRedactionSummary", () => {
+  it("returns a summary with sorted arrays and the deterministic strategy tag", () => {
+    const state = createFeedbackRedactionState();
+    state.redactedFields.add("b.field");
+    state.redactedFields.add("a.field");
+    state.truncatedFields.add("z.field");
+    state.counts.set("email", 2);
+    state.counts.set("bearer_token", 1);
+
+    const summary = finalizeFeedbackRedactionSummary(state);
+
+    expect(summary.strategy).toBe("deterministic_feedback_v2");
+    expect(summary.redactedFields).toEqual(["a.field", "b.field"]);
+    expect(summary.truncatedFields).toEqual(["z.field"]);
+    expect(summary.counts).toEqual({ bearer_token: 1, email: 2 });
+  });
+
+  it("returns empty arrays and counts when state is clean", () => {
+    const state = createFeedbackRedactionState();
+    const summary = finalizeFeedbackRedactionSummary(state);
+    expect(summary.redactedFields).toEqual([]);
+    expect(summary.truncatedFields).toEqual([]);
+    expect(summary.omittedFields).toEqual([]);
+    expect(summary.counts).toEqual({});
+  });
+});

--- a/server/src/services/github-fetch.test.ts
+++ b/server/src/services/github-fetch.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { gitHubApiBase, resolveRawGitHubUrl } from "./github-fetch.js";
+
+// ---------------------------------------------------------------------------
+// gitHubApiBase
+// ---------------------------------------------------------------------------
+
+describe("gitHubApiBase", () => {
+  it("returns the public GitHub API URL for 'github.com'", () => {
+    expect(gitHubApiBase("github.com")).toBe("https://api.github.com");
+  });
+
+  it("returns the public GitHub API URL for 'www.github.com'", () => {
+    expect(gitHubApiBase("www.github.com")).toBe("https://api.github.com");
+  });
+
+  it("is case-insensitive for 'GITHUB.COM'", () => {
+    expect(gitHubApiBase("GITHUB.COM")).toBe("https://api.github.com");
+  });
+
+  it("returns a GHE API URL for a custom hostname", () => {
+    expect(gitHubApiBase("github.example.com")).toBe("https://github.example.com/api/v3");
+  });
+
+  it("returns a GHE API URL for another custom hostname", () => {
+    expect(gitHubApiBase("git.corp.internal")).toBe("https://git.corp.internal/api/v3");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveRawGitHubUrl
+// ---------------------------------------------------------------------------
+
+describe("resolveRawGitHubUrl", () => {
+  it("returns a raw.githubusercontent.com URL for github.com", () => {
+    const url = resolveRawGitHubUrl("github.com", "acme", "repo", "main", "README.md");
+    expect(url).toBe("https://raw.githubusercontent.com/acme/repo/main/README.md");
+  });
+
+  it("returns a GHE raw URL for a custom hostname", () => {
+    const url = resolveRawGitHubUrl("github.example.com", "acme", "repo", "main", "README.md");
+    expect(url).toBe("https://github.example.com/raw/acme/repo/main/README.md");
+  });
+
+  it("strips a leading slash from the file path", () => {
+    const url = resolveRawGitHubUrl("github.com", "acme", "repo", "main", "/path/file.ts");
+    expect(url).toBe("https://raw.githubusercontent.com/acme/repo/main/path/file.ts");
+  });
+
+  it("strips multiple leading slashes from the file path", () => {
+    const url = resolveRawGitHubUrl("github.com", "acme", "repo", "main", "//nested/file.ts");
+    expect(url).toBe("https://raw.githubusercontent.com/acme/repo/main/nested/file.ts");
+  });
+
+  it("handles a ref with slashes (branch name)", () => {
+    const url = resolveRawGitHubUrl("github.com", "acme", "repo", "feature/x", "src/index.ts");
+    expect(url).toBe("https://raw.githubusercontent.com/acme/repo/feature/x/src/index.ts");
+  });
+
+  it("handles a nested file path", () => {
+    const url = resolveRawGitHubUrl("github.com", "acme", "repo", "v1.0.0", "packages/lib/index.ts");
+    expect(url).toBe("https://raw.githubusercontent.com/acme/repo/v1.0.0/packages/lib/index.ts");
+  });
+
+  it("handles a GHE hostname with a nested file path", () => {
+    const url = resolveRawGitHubUrl("git.corp.internal", "team", "monorepo", "dev", "apps/api/main.ts");
+    expect(url).toBe("https://git.corp.internal/raw/team/monorepo/dev/apps/api/main.ts");
+  });
+});

--- a/server/src/services/heartbeat-pure.test.ts
+++ b/server/src/services/heartbeat-pure.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import {
+  compactRunLogChunk,
+  summarizeHeartbeatRunContextSnapshot,
+  summarizeHeartbeatRunListResultJson,
+  formatRuntimeWorkspaceWarningLog,
+} from "./heartbeat.js";
+
+// ---------------------------------------------------------------------------
+// compactRunLogChunk
+// ---------------------------------------------------------------------------
+
+describe("compactRunLogChunk", () => {
+  it("returns the chunk unchanged when it fits within maxChars", () => {
+    expect(compactRunLogChunk("hello world", 100)).toBe("hello world");
+  });
+
+  it("truncates the chunk when it exceeds maxChars", () => {
+    const long = "a".repeat(1000);
+    const result = compactRunLogChunk(long, 100);
+    expect(result).toContain("[paperclip truncated run log chunk:");
+    expect(result.length).toBeLessThan(long.length);
+  });
+
+  it("preserves head and tail portions when truncating", () => {
+    const head = "HEAD_DATA";
+    const middle = "x".repeat(200);
+    const tail = "TAIL_DATA";
+    const result = compactRunLogChunk(`${head}${middle}${tail}`, 50);
+    expect(result).toContain("HEAD_DATA");
+    expect(result).toContain("TAIL_DATA");
+  });
+
+  it("mentions the number of omitted chars in the truncation marker", () => {
+    const long = "x".repeat(1000);
+    const result = compactRunLogChunk(long, 100);
+    expect(result).toMatch(/omitted \d+ chars/);
+  });
+
+  it("uses the default maxChars when not provided", () => {
+    const short = "small";
+    expect(compactRunLogChunk(short)).toBe(short);
+  });
+
+  it("redacts base64 image data embedded in the chunk", () => {
+    const base64Data = "A".repeat(1024);
+    const withBase64 = `{"type":"image","source":{"type":"base64","data":"${base64Data}"}}`;
+    const result = compactRunLogChunk(withBase64, 100000);
+    expect(result).toContain("[omitted base64 image data:");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeHeartbeatRunContextSnapshot
+// ---------------------------------------------------------------------------
+
+describe("summarizeHeartbeatRunContextSnapshot", () => {
+  it("returns null for null input", () => {
+    expect(summarizeHeartbeatRunContextSnapshot(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(summarizeHeartbeatRunContextSnapshot(undefined)).toBeNull();
+  });
+
+  it("returns null when no recognized keys have non-empty string values", () => {
+    expect(summarizeHeartbeatRunContextSnapshot({ unknownKey: "value" })).toBeNull();
+  });
+
+  it("includes issueId when present and non-empty", () => {
+    const result = summarizeHeartbeatRunContextSnapshot({ issueId: "issue-123" });
+    expect(result?.issueId).toBe("issue-123");
+  });
+
+  it("includes wakeReason when present", () => {
+    const result = summarizeHeartbeatRunContextSnapshot({ wakeReason: "comment_added" });
+    expect(result?.wakeReason).toBe("comment_added");
+  });
+
+  it("omits keys with empty or whitespace values", () => {
+    const result = summarizeHeartbeatRunContextSnapshot({ issueId: "id-1", commentId: "" });
+    expect(result?.commentId).toBeUndefined();
+  });
+
+  it("returns only the recognized keys (omits unknown keys)", () => {
+    const result = summarizeHeartbeatRunContextSnapshot({ issueId: "id-1", randomKey: "value" });
+    expect(result).not.toHaveProperty("randomKey");
+    expect(result?.issueId).toBe("id-1");
+  });
+
+  it("includes multiple recognized keys when all are present", () => {
+    const result = summarizeHeartbeatRunContextSnapshot({
+      issueId: "issue-1",
+      wakeReason: "wake",
+      wakeSource: "api",
+    });
+    expect(result?.issueId).toBe("issue-1");
+    expect(result?.wakeReason).toBe("wake");
+    expect(result?.wakeSource).toBe("api");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeHeartbeatRunListResultJson
+// ---------------------------------------------------------------------------
+
+describe("summarizeHeartbeatRunListResultJson", () => {
+  it("returns null when all inputs are null/empty", () => {
+    expect(summarizeHeartbeatRunListResultJson({})).toBeNull();
+  });
+
+  it("includes summary when provided", () => {
+    const result = summarizeHeartbeatRunListResultJson({ summary: "done" });
+    expect(result?.summary).toBe("done");
+  });
+
+  it("includes result when provided", () => {
+    const result = summarizeHeartbeatRunListResultJson({ result: "ok" });
+    expect(result?.result).toBe("ok");
+  });
+
+  it("includes message and error when provided", () => {
+    const result = summarizeHeartbeatRunListResultJson({
+      message: "hello",
+      error: "oops",
+    });
+    expect(result?.message).toBe("hello");
+    expect(result?.error).toBe("oops");
+  });
+
+  it("parses totalCostUsd as a number when provided as a parseable string", () => {
+    const result = summarizeHeartbeatRunListResultJson({ totalCostUsd: "1.23" });
+    expect(result?.total_cost_usd).toBe(1.23);
+  });
+
+  it("omits cost fields when the string is not a valid number", () => {
+    const result = summarizeHeartbeatRunListResultJson({
+      summary: "done",
+      totalCostUsd: "not-a-number",
+    });
+    expect(result).not.toHaveProperty("total_cost_usd");
+  });
+
+  it("omits null/empty text fields", () => {
+    const result = summarizeHeartbeatRunListResultJson({
+      summary: null,
+      result: "",
+      message: "hello",
+    });
+    expect(result).not.toHaveProperty("summary");
+    expect(result).not.toHaveProperty("result");
+    expect(result?.message).toBe("hello");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatRuntimeWorkspaceWarningLog
+// ---------------------------------------------------------------------------
+
+describe("formatRuntimeWorkspaceWarningLog", () => {
+  it("returns an object with stream 'stdout' and the formatted chunk", () => {
+    const result = formatRuntimeWorkspaceWarningLog("workspace not ready");
+    expect(result.stream).toBe("stdout");
+    expect(result.chunk).toContain("[paperclip]");
+    expect(result.chunk).toContain("workspace not ready");
+  });
+
+  it("appends a newline to the chunk", () => {
+    const result = formatRuntimeWorkspaceWarningLog("test");
+    expect(result.chunk.endsWith("\n")).toBe(true);
+  });
+});

--- a/server/src/services/heartbeat-run-summary.test.ts
+++ b/server/src/services/heartbeat-run-summary.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  mergeHeartbeatRunResultJson,
+  summarizeHeartbeatRunResultJson,
+  buildHeartbeatRunIssueComment,
+  HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS,
+} from "./heartbeat-run-summary.js";
+
+// ---------------------------------------------------------------------------
+// mergeHeartbeatRunResultJson
+// ---------------------------------------------------------------------------
+
+describe("mergeHeartbeatRunResultJson", () => {
+  it("returns null when both resultJson and summary are null", () => {
+    expect(mergeHeartbeatRunResultJson(null, null)).toBeNull();
+  });
+
+  it("returns null when resultJson is null and summary is empty string", () => {
+    expect(mergeHeartbeatRunResultJson(null, "")).toBeNull();
+  });
+
+  it("returns null when resultJson is null and summary is whitespace only", () => {
+    expect(mergeHeartbeatRunResultJson(null, "   ")).toBeNull();
+  });
+
+  it("returns { summary } when resultJson is null and summary is a non-empty string", () => {
+    expect(mergeHeartbeatRunResultJson(null, "done!")).toEqual({ summary: "done!" });
+  });
+
+  it("returns the base result unchanged when summary is null", () => {
+    const base = { status: "ok", count: 3 };
+    expect(mergeHeartbeatRunResultJson(base, null)).toEqual(base);
+  });
+
+  it("returns the base result unchanged when it already has a summary", () => {
+    const base = { summary: "existing summary", extra: true };
+    const result = mergeHeartbeatRunResultJson(base, "new summary");
+    expect(result?.summary).toBe("existing summary");
+  });
+
+  it("injects the summary when resultJson has no summary field", () => {
+    const base = { status: "ok" };
+    const result = mergeHeartbeatRunResultJson(base, "injected");
+    expect(result?.summary).toBe("injected");
+    expect(result?.status).toBe("ok");
+  });
+
+  it("treats a whitespace-only existing summary as absent and injects the new one", () => {
+    const base = { summary: "   " };
+    const result = mergeHeartbeatRunResultJson(base, "replacement");
+    expect(result?.summary).toBe("replacement");
+  });
+
+  it("returns null when resultJson is an array", () => {
+    expect(mergeHeartbeatRunResultJson(["a"] as unknown as Record<string, unknown>, "s")).toEqual({ summary: "s" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeHeartbeatRunResultJson
+// ---------------------------------------------------------------------------
+
+describe("summarizeHeartbeatRunResultJson", () => {
+  it("returns null for null input", () => {
+    expect(summarizeHeartbeatRunResultJson(null)).toBeNull();
+  });
+
+  it("returns null for an array input", () => {
+    expect(summarizeHeartbeatRunResultJson([] as unknown as Record<string, unknown>)).toBeNull();
+  });
+
+  it("returns null when no recognized fields are present", () => {
+    expect(summarizeHeartbeatRunResultJson({ other: "value" })).toBeNull();
+  });
+
+  it("includes the summary field when present", () => {
+    const result = summarizeHeartbeatRunResultJson({ summary: "done" });
+    expect(result?.summary).toBe("done");
+  });
+
+  it("includes the result field when present", () => {
+    const result = summarizeHeartbeatRunResultJson({ result: "ok" });
+    expect(result?.result).toBe("ok");
+  });
+
+  it("includes the message field when present", () => {
+    const result = summarizeHeartbeatRunResultJson({ message: "hello" });
+    expect(result?.message).toBe("hello");
+  });
+
+  it("includes the error field when present", () => {
+    const result = summarizeHeartbeatRunResultJson({ error: "oops" });
+    expect(result?.error).toBe("oops");
+  });
+
+  it("includes cost_usd numeric field", () => {
+    const result = summarizeHeartbeatRunResultJson({ cost_usd: 0.05 });
+    expect(result?.cost_usd).toBe(0.05);
+  });
+
+  it("includes total_cost_usd numeric field", () => {
+    const result = summarizeHeartbeatRunResultJson({ total_cost_usd: 1.2 });
+    expect(result?.total_cost_usd).toBe(1.2);
+  });
+
+  it("includes costUsd numeric field", () => {
+    const result = summarizeHeartbeatRunResultJson({ costUsd: 0.001 });
+    expect(result?.costUsd).toBe(0.001);
+  });
+
+  it("truncates summary text to HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS", () => {
+    const long = "x".repeat(HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS + 10);
+    const result = summarizeHeartbeatRunResultJson({ summary: long });
+    expect(typeof result?.summary).toBe("string");
+    expect((result?.summary as string).length).toBe(HEARTBEAT_RUN_RESULT_SUMMARY_MAX_CHARS);
+  });
+
+  it("omits unrecognized fields from the output", () => {
+    const result = summarizeHeartbeatRunResultJson({ summary: "ok", irrelevant: "field" });
+    expect(result).not.toHaveProperty("irrelevant");
+  });
+
+  it("omits a numeric field when its value is null", () => {
+    const result = summarizeHeartbeatRunResultJson({ cost_usd: null });
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildHeartbeatRunIssueComment
+// ---------------------------------------------------------------------------
+
+describe("buildHeartbeatRunIssueComment", () => {
+  it("returns null for null input", () => {
+    expect(buildHeartbeatRunIssueComment(null)).toBeNull();
+  });
+
+  it("returns null for an array input", () => {
+    expect(buildHeartbeatRunIssueComment([] as unknown as Record<string, unknown>)).toBeNull();
+  });
+
+  it("returns null when no recognized text fields are present", () => {
+    expect(buildHeartbeatRunIssueComment({ cost_usd: 1 })).toBeNull();
+  });
+
+  it("returns the summary field when present and non-empty", () => {
+    expect(buildHeartbeatRunIssueComment({ summary: "  done  " })).toBe("done");
+  });
+
+  it("falls back to result when summary is absent", () => {
+    expect(buildHeartbeatRunIssueComment({ result: "ok" })).toBe("ok");
+  });
+
+  it("falls back to message when summary and result are absent", () => {
+    expect(buildHeartbeatRunIssueComment({ message: "hi" })).toBe("hi");
+  });
+
+  it("prefers summary over result and message", () => {
+    const result = buildHeartbeatRunIssueComment({
+      summary: "summary text",
+      result: "result text",
+      message: "message text",
+    });
+    expect(result).toBe("summary text");
+  });
+
+  it("returns null when all text fields are whitespace-only", () => {
+    expect(buildHeartbeatRunIssueComment({ summary: "   ", result: " " })).toBeNull();
+  });
+});

--- a/server/src/services/issue-execution-policy.test.ts
+++ b/server/src/services/issue-execution-policy.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeIssueExecutionPolicy,
+  parseIssueExecutionState,
+  assigneePrincipal,
+} from "./issue-execution-policy.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const AGENT_UUID = "aaaaaaaa-aaaa-4aaa-aaaa-aaaaaaaaaaaa";
+const AGENT_UUID_2 = "dddddddd-dddd-4ddd-dddd-dddddddddddd";
+const USER_ID = "user-abc";
+const STAGE_UUID = "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb";
+const DECISION_UUID = "cccccccc-cccc-4ccc-cccc-cccccccccccc";
+
+/** Minimal stage fixture with a valid agent participant */
+function agentStage(stageOverrides: Record<string, unknown> = {}) {
+  return {
+    type: "review",
+    participants: [{ type: "agent", agentId: AGENT_UUID }],
+    ...stageOverrides,
+  };
+}
+
+/** Minimal valid policy with one agent review stage */
+function singleAgentPolicy(policyOverrides: Record<string, unknown> = {}) {
+  return { stages: [agentStage()], ...policyOverrides };
+}
+
+function makeExecutionState(overrides: Record<string, unknown> = {}) {
+  return {
+    status: "pending",
+    currentStageId: STAGE_UUID,
+    currentStageIndex: 0,
+    currentStageType: "review",
+    currentParticipant: { type: "agent", agentId: AGENT_UUID, userId: null },
+    returnAssignee: null,
+    completedStageIds: [],
+    lastDecisionId: null,
+    lastDecisionOutcome: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// normalizeIssueExecutionPolicy
+// ---------------------------------------------------------------------------
+
+describe("normalizeIssueExecutionPolicy", () => {
+  it("returns null for null input", () => {
+    expect(normalizeIssueExecutionPolicy(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(normalizeIssueExecutionPolicy(undefined)).toBeNull();
+  });
+
+  it("returns null when stages array is empty (no valid stages)", () => {
+    expect(normalizeIssueExecutionPolicy({ stages: [] })).toBeNull();
+  });
+
+  it("returns null when input has no stages property (defaults to empty)", () => {
+    expect(normalizeIssueExecutionPolicy({})).toBeNull();
+  });
+
+  it("returns a normalized policy for a valid input with one stage", () => {
+    const result = normalizeIssueExecutionPolicy(singleAgentPolicy());
+    expect(result).not.toBeNull();
+    expect(result!.stages).toHaveLength(1);
+  });
+
+  it("defaults mode to 'normal' when not provided", () => {
+    const result = normalizeIssueExecutionPolicy(singleAgentPolicy());
+    expect(result!.mode).toBe("normal");
+  });
+
+  it("preserves an explicit mode value of 'auto'", () => {
+    const result = normalizeIssueExecutionPolicy(singleAgentPolicy({ mode: "auto" }));
+    expect(result!.mode).toBe("auto");
+  });
+
+  it("always returns commentRequired: true (hardcoded)", () => {
+    const result = normalizeIssueExecutionPolicy(singleAgentPolicy());
+    expect(result!.commentRequired).toBe(true);
+  });
+
+  it("assigns a UUID to a stage that has no id", () => {
+    const result = normalizeIssueExecutionPolicy(singleAgentPolicy());
+    expect(result!.stages[0].id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("preserves an existing stage id", () => {
+    const result = normalizeIssueExecutionPolicy({
+      stages: [agentStage({ id: STAGE_UUID })],
+    });
+    expect(result!.stages[0].id).toBe(STAGE_UUID);
+  });
+
+  it("assigns a UUID to each participant that has no id", () => {
+    const result = normalizeIssueExecutionPolicy(singleAgentPolicy());
+    expect(result!.stages[0].participants[0].id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("deduplicates participants with the same agentId", () => {
+    const result = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          type: "review",
+          participants: [
+            { type: "agent", agentId: AGENT_UUID },
+            { type: "agent", agentId: AGENT_UUID },
+          ],
+        },
+      ],
+    });
+    expect(result!.stages[0].participants).toHaveLength(1);
+  });
+
+  it("keeps two participants with different agentIds", () => {
+    const result = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          type: "review",
+          participants: [
+            { type: "agent", agentId: AGENT_UUID },
+            { type: "agent", agentId: AGENT_UUID_2 },
+          ],
+        },
+      ],
+    });
+    expect(result!.stages[0].participants).toHaveLength(2);
+  });
+
+  it("deduplicates participants with the same userId", () => {
+    const result = normalizeIssueExecutionPolicy({
+      stages: [
+        {
+          type: "review",
+          participants: [
+            { type: "user", userId: USER_ID },
+            { type: "user", userId: USER_ID },
+          ],
+        },
+      ],
+    });
+    expect(result!.stages[0].participants).toHaveLength(1);
+  });
+
+  it("throws for a completely invalid input (non-object)", () => {
+    expect(() => normalizeIssueExecutionPolicy("not-an-object")).toThrow();
+  });
+
+  it("handles a user participant correctly", () => {
+    const result = normalizeIssueExecutionPolicy({
+      stages: [{ type: "approval", participants: [{ type: "user", userId: USER_ID }] }],
+    });
+    expect(result!.stages[0].participants[0].type).toBe("user");
+    expect(result!.stages[0].participants[0].userId).toBe(USER_ID);
+    expect(result!.stages[0].participants[0].agentId).toBeNull();
+  });
+
+  it("sets agentId to null for user participants", () => {
+    const result = normalizeIssueExecutionPolicy({
+      stages: [{ type: "review", participants: [{ type: "user", userId: USER_ID }] }],
+    });
+    expect(result!.stages[0].participants[0].agentId).toBeNull();
+  });
+
+  it("sets userId to null for agent participants", () => {
+    const result = normalizeIssueExecutionPolicy(singleAgentPolicy());
+    expect(result!.stages[0].participants[0].userId).toBeNull();
+  });
+
+  it("sets approvalsNeeded to 1 for each stage", () => {
+    const result = normalizeIssueExecutionPolicy(singleAgentPolicy());
+    expect(result!.stages[0].approvalsNeeded).toBe(1);
+  });
+
+  it("normalizes multiple stages in order", () => {
+    const result = normalizeIssueExecutionPolicy({
+      stages: [
+        { type: "review", participants: [{ type: "agent", agentId: AGENT_UUID }] },
+        { type: "approval", participants: [{ type: "user", userId: USER_ID }] },
+      ],
+    });
+    expect(result!.stages).toHaveLength(2);
+    expect(result!.stages[0].type).toBe("review");
+    expect(result!.stages[1].type).toBe("approval");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseIssueExecutionState
+// ---------------------------------------------------------------------------
+
+describe("parseIssueExecutionState", () => {
+  it("returns null for null input", () => {
+    expect(parseIssueExecutionState(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(parseIssueExecutionState(undefined)).toBeNull();
+  });
+
+  it("returns null for an invalid input (missing required fields)", () => {
+    expect(parseIssueExecutionState({})).toBeNull();
+  });
+
+  it("returns null for an unrecognized status value", () => {
+    expect(parseIssueExecutionState(makeExecutionState({ status: "unknown_status" }))).toBeNull();
+  });
+
+  it("parses a valid 'pending' state", () => {
+    const result = parseIssueExecutionState(makeExecutionState({ status: "pending" }));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("pending");
+  });
+
+  it("parses a valid 'idle' state", () => {
+    const result = parseIssueExecutionState(
+      makeExecutionState({
+        status: "idle",
+        currentStageId: null,
+        currentStageIndex: null,
+        currentStageType: null,
+        currentParticipant: null,
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("idle");
+  });
+
+  it("parses a valid 'completed' state", () => {
+    const result = parseIssueExecutionState(makeExecutionState({ status: "completed" }));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("completed");
+  });
+
+  it("parses a valid 'changes_requested' state", () => {
+    const result = parseIssueExecutionState(makeExecutionState({ status: "changes_requested" }));
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe("changes_requested");
+  });
+
+  it("preserves the completedStageIds array", () => {
+    const result = parseIssueExecutionState(makeExecutionState({ completedStageIds: [STAGE_UUID] }));
+    expect(result!.completedStageIds).toEqual([STAGE_UUID]);
+  });
+
+  it("defaults completedStageIds to an empty array when not provided", () => {
+    const state = makeExecutionState();
+    delete (state as Record<string, unknown>).completedStageIds;
+    const result = parseIssueExecutionState(state);
+    expect(result!.completedStageIds).toEqual([]);
+  });
+
+  it("preserves lastDecisionOutcome when present", () => {
+    const result = parseIssueExecutionState(
+      makeExecutionState({ lastDecisionId: DECISION_UUID, lastDecisionOutcome: "approved" }),
+    );
+    expect(result!.lastDecisionOutcome).toBe("approved");
+  });
+
+  it("returns null for an unrecognized lastDecisionOutcome value", () => {
+    const result = parseIssueExecutionState(
+      makeExecutionState({ lastDecisionId: DECISION_UUID, lastDecisionOutcome: "bad_outcome" }),
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assigneePrincipal
+// ---------------------------------------------------------------------------
+
+describe("assigneePrincipal", () => {
+  it("returns null when both assigneeAgentId and assigneeUserId are absent", () => {
+    expect(assigneePrincipal({})).toBeNull();
+  });
+
+  it("returns null when both assigneeAgentId and assigneeUserId are null", () => {
+    expect(assigneePrincipal({ assigneeAgentId: null, assigneeUserId: null })).toBeNull();
+  });
+
+  it("returns an agent principal when assigneeAgentId is set", () => {
+    const result = assigneePrincipal({ assigneeAgentId: AGENT_UUID });
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("agent");
+    expect(result!.agentId).toBe(AGENT_UUID);
+    expect(result!.userId).toBeNull();
+  });
+
+  it("returns a user principal when assigneeUserId is set", () => {
+    const result = assigneePrincipal({ assigneeUserId: USER_ID });
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("user");
+    expect(result!.userId).toBe(USER_ID);
+    expect(result!.agentId).toBeNull();
+  });
+
+  it("prefers assigneeAgentId over assigneeUserId when both are set", () => {
+    const result = assigneePrincipal({ assigneeAgentId: AGENT_UUID, assigneeUserId: USER_ID });
+    expect(result!.type).toBe("agent");
+    expect(result!.agentId).toBe(AGENT_UUID);
+  });
+});

--- a/server/src/services/issue-goal-fallback.test.ts
+++ b/server/src/services/issue-goal-fallback.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
+
+// ---------------------------------------------------------------------------
+// resolveIssueGoalId
+// ---------------------------------------------------------------------------
+
+describe("resolveIssueGoalId", () => {
+  it("returns explicit goalId when set", () => {
+    expect(
+      resolveIssueGoalId({ projectId: null, goalId: "goal-1", defaultGoalId: "default-goal" }),
+    ).toBe("goal-1");
+  });
+
+  it("prefers explicit goalId over projectGoalId", () => {
+    expect(
+      resolveIssueGoalId({
+        projectId: "proj-1",
+        goalId: "goal-1",
+        projectGoalId: "proj-goal",
+        defaultGoalId: "default-goal",
+      }),
+    ).toBe("goal-1");
+  });
+
+  it("returns projectGoalId when projectId is set and goalId is absent", () => {
+    expect(
+      resolveIssueGoalId({
+        projectId: "proj-1",
+        goalId: null,
+        projectGoalId: "proj-goal",
+        defaultGoalId: "default-goal",
+      }),
+    ).toBe("proj-goal");
+  });
+
+  it("returns null when projectId is set but projectGoalId is absent", () => {
+    expect(
+      resolveIssueGoalId({ projectId: "proj-1", goalId: null, defaultGoalId: "default-goal" }),
+    ).toBeNull();
+  });
+
+  it("returns defaultGoalId when neither goalId nor projectId is set", () => {
+    expect(
+      resolveIssueGoalId({ projectId: null, goalId: null, defaultGoalId: "default-goal" }),
+    ).toBe("default-goal");
+  });
+
+  it("returns null when goalId, projectId, and defaultGoalId are all null", () => {
+    expect(resolveIssueGoalId({ projectId: null, goalId: null, defaultGoalId: null })).toBeNull();
+  });
+
+  it("returns null when goalId is null, projectId is set, and projectGoalId is null", () => {
+    expect(
+      resolveIssueGoalId({ projectId: "proj-1", goalId: null, projectGoalId: null, defaultGoalId: "fallback" }),
+    ).toBeNull();
+  });
+
+  it("ignores defaultGoalId when projectId is set (project takes precedence over default)", () => {
+    const result = resolveIssueGoalId({
+      projectId: "proj-1",
+      goalId: null,
+      projectGoalId: "proj-goal",
+      defaultGoalId: "should-not-be-used",
+    });
+    expect(result).toBe("proj-goal");
+    expect(result).not.toBe("should-not-be-used");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveNextIssueGoalId
+// ---------------------------------------------------------------------------
+
+describe("resolveNextIssueGoalId", () => {
+  it("returns the explicit incoming goalId when it is non-null", () => {
+    expect(
+      resolveNextIssueGoalId({
+        currentProjectId: null,
+        currentGoalId: null,
+        goalId: "new-goal",
+        defaultGoalId: "default",
+      }),
+    ).toBe("new-goal");
+  });
+
+  it("falls back to project goal when explicit goalId is explicitly null", () => {
+    expect(
+      resolveNextIssueGoalId({
+        currentProjectId: null,
+        currentGoalId: "old-goal",
+        goalId: null,
+        projectId: "proj-1",
+        projectGoalId: "proj-goal",
+        defaultGoalId: "default",
+      }),
+    ).toBe("proj-goal");
+  });
+
+  it("falls back to defaultGoalId when goalId is null and no project", () => {
+    expect(
+      resolveNextIssueGoalId({
+        currentProjectId: null,
+        currentGoalId: null,
+        goalId: null,
+        projectId: null,
+        defaultGoalId: "default",
+      }),
+    ).toBe("default");
+  });
+
+  it("preserves currentGoalId when it is not the current fallback and goalId is not provided", () => {
+    expect(
+      resolveNextIssueGoalId({
+        currentProjectId: null,
+        currentGoalId: "custom-goal",
+        defaultGoalId: "default",
+      }),
+    ).toBe("custom-goal");
+  });
+
+  it("replaces currentGoalId with next fallback when goalId is not provided and the current goal is the current fallback", () => {
+    expect(
+      resolveNextIssueGoalId({
+        currentProjectId: null,
+        currentGoalId: "default",
+        projectId: "proj-1",
+        projectGoalId: "proj-goal",
+        defaultGoalId: "default",
+      }),
+    ).toBe("proj-goal");
+  });
+
+  it("returns nextFallback when currentGoalId is null and goalId is not provided", () => {
+    expect(
+      resolveNextIssueGoalId({
+        currentProjectId: "proj-1",
+        currentGoalId: null,
+        projectId: "proj-2",
+        projectGoalId: "proj-2-goal",
+        defaultGoalId: "default",
+      }),
+    ).toBe("proj-2-goal");
+  });
+
+  it("inherits currentProjectId when projectId is not specified", () => {
+    expect(
+      resolveNextIssueGoalId({
+        currentProjectId: "proj-1",
+        currentGoalId: null,
+        currentProjectGoalId: "proj-1-goal",
+        defaultGoalId: "default",
+      }),
+    ).toBe("proj-1-goal");
+  });
+
+  it("uses currentProjectGoalId when projectId is not overridden and project is unchanged", () => {
+    const result = resolveNextIssueGoalId({
+      currentProjectId: "proj-1",
+      currentGoalId: null,
+      currentProjectGoalId: "proj-1-goal",
+      defaultGoalId: "default",
+    });
+    expect(result).toBe("proj-1-goal");
+  });
+
+  it("returns null when everything is null and goalId is not provided", () => {
+    expect(
+      resolveNextIssueGoalId({
+        currentProjectId: null,
+        currentGoalId: null,
+        defaultGoalId: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/server/src/services/plugin-capability-validator.test.ts
+++ b/server/src/services/plugin-capability-validator.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect } from "vitest";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+import { PLUGIN_API_VERSION } from "@paperclipai/shared";
+import { pluginCapabilityValidator } from "./plugin-capability-validator.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeManifest(
+  capabilities: PaperclipPluginManifestV1["capabilities"],
+  extras: Partial<PaperclipPluginManifestV1> = {},
+): PaperclipPluginManifestV1 {
+  return {
+    id: "test-plugin",
+    apiVersion: PLUGIN_API_VERSION,
+    version: "1.0.0",
+    displayName: "Test Plugin",
+    description: "A plugin used in unit tests",
+    author: "Test Author",
+    categories: ["connector"],
+    capabilities,
+    entrypoints: { worker: "dist/worker.js" },
+    ...extras,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// hasCapability
+// ---------------------------------------------------------------------------
+
+describe("pluginCapabilityValidator.hasCapability", () => {
+  it("returns true when the manifest declares the capability", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    expect(v.hasCapability(m, "issues.read")).toBe(true);
+  });
+
+  it("returns false when the manifest does not declare the capability", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    expect(v.hasCapability(m, "issues.create")).toBe(false);
+  });
+
+  it("returns false for an empty capabilities list", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest([] as unknown as PaperclipPluginManifestV1["capabilities"]);
+    expect(v.hasCapability(m, "issues.read")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasAllCapabilities
+// ---------------------------------------------------------------------------
+
+describe("pluginCapabilityValidator.hasAllCapabilities", () => {
+  it("returns allowed:true when all requested capabilities are declared", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read", "issues.create"]);
+    const result = v.hasAllCapabilities(m, ["issues.read", "issues.create"]);
+    expect(result.allowed).toBe(true);
+    expect(result.missing).toHaveLength(0);
+  });
+
+  it("returns allowed:false and lists missing capabilities", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    const result = v.hasAllCapabilities(m, ["issues.read", "issues.create"]);
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain("issues.create");
+  });
+
+  it("includes the pluginId in the result", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    const result = v.hasAllCapabilities(m, ["issues.read"]);
+    expect(result.pluginId).toBe("test-plugin");
+  });
+
+  it("returns allowed:true for an empty requirements list", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    const result = v.hasAllCapabilities(m, []);
+    expect(result.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasAnyCapability
+// ---------------------------------------------------------------------------
+
+describe("pluginCapabilityValidator.hasAnyCapability", () => {
+  it("returns true when at least one capability matches", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    expect(v.hasAnyCapability(m, ["issues.read", "issues.create"])).toBe(true);
+  });
+
+  it("returns false when none of the capabilities match", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    expect(v.hasAnyCapability(m, ["issues.create", "issues.update"])).toBe(false);
+  });
+
+  it("returns false for an empty capabilities list", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    expect(v.hasAnyCapability(m, [])).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkOperation
+// ---------------------------------------------------------------------------
+
+describe("pluginCapabilityValidator.checkOperation", () => {
+  it("returns allowed:true when the plugin has the required capability for the operation", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    const result = v.checkOperation(m, "issues.list");
+    expect(result.allowed).toBe(true);
+    expect(result.missing).toHaveLength(0);
+    expect(result.operation).toBe("issues.list");
+  });
+
+  it("returns allowed:false with missing capabilities when the plugin lacks them", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    const result = v.checkOperation(m, "issues.create");
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain("issues.create");
+  });
+
+  it("rejects an unknown operation by default (allowed:false, missing:[])", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read", "issues.create"]);
+    const result = v.checkOperation(m, "completely.unknown.operation");
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toHaveLength(0);
+  });
+
+  it("gates agent.tools.register on the correct capability", () => {
+    const v = pluginCapabilityValidator();
+    const without = makeManifest(["issues.read"]);
+    expect(v.checkOperation(without, "agent.tools.register").allowed).toBe(false);
+
+    const with_ = makeManifest(["issues.read", "agent.tools.register"]);
+    expect(v.checkOperation(with_, "agent.tools.register").allowed).toBe(true);
+  });
+
+  it("gates secrets.resolve on secrets.read-ref capability", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read", "secrets.read-ref"]);
+    expect(v.checkOperation(m, "secrets.resolve").allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertOperation
+// ---------------------------------------------------------------------------
+
+describe("pluginCapabilityValidator.assertOperation", () => {
+  it("does not throw when the operation is allowed", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    expect(() => v.assertOperation(m, "issues.list")).not.toThrow();
+  });
+
+  it("throws when the operation is not allowed", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    expect(() => v.assertOperation(m, "issues.create")).toThrow();
+  });
+
+  it("throws for an unknown operation", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    expect(() => v.assertOperation(m, "no.such.op")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertCapability
+// ---------------------------------------------------------------------------
+
+describe("pluginCapabilityValidator.assertCapability", () => {
+  it("does not throw when the manifest has the capability", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    expect(() => v.assertCapability(m, "issues.read")).not.toThrow();
+  });
+
+  it("throws when the manifest lacks the capability", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    expect(() => v.assertCapability(m, "issues.create")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkUiSlot
+// ---------------------------------------------------------------------------
+
+describe("pluginCapabilityValidator.checkUiSlot", () => {
+  it("returns allowed:true when the manifest has the required ui capability", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read", "ui.sidebar.register"]);
+    const result = v.checkUiSlot(m, "sidebar");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("returns allowed:false when the manifest lacks the required ui capability", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    const result = v.checkUiSlot(m, "sidebar");
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain("ui.sidebar.register");
+  });
+
+  it("returns allowed:true for a page slot with ui.page.register", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read", "ui.page.register"]);
+    const result = v.checkUiSlot(m, "page");
+    expect(result.allowed).toBe(true);
+  });
+
+  it("returns allowed:true for a dashboardWidget slot with ui.dashboardWidget.register", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read", "ui.dashboardWidget.register"]);
+    const result = v.checkUiSlot(m, "dashboardWidget");
+    expect(result.allowed).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateManifestCapabilities
+// ---------------------------------------------------------------------------
+
+describe("pluginCapabilityValidator.validateManifestCapabilities", () => {
+  it("returns allowed:true for a manifest with no feature declarations", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"]);
+    const result = v.validateManifestCapabilities(m);
+    expect(result.allowed).toBe(true);
+    expect(result.missing).toHaveLength(0);
+  });
+
+  it("returns allowed:false when tools are declared without agent.tools.register", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"], {
+      tools: [
+        {
+          name: "my_tool",
+          displayName: "My Tool",
+          description: "A test tool",
+          parametersSchema: { type: "object", properties: {} },
+        },
+      ],
+    });
+    const result = v.validateManifestCapabilities(m);
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain("agent.tools.register");
+  });
+
+  it("returns allowed:true when tools are declared with agent.tools.register", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read", "agent.tools.register"], {
+      tools: [
+        {
+          name: "my_tool",
+          displayName: "My Tool",
+          description: "A test tool",
+          parametersSchema: { type: "object", properties: {} },
+        },
+      ],
+    });
+    const result = v.validateManifestCapabilities(m);
+    expect(result.allowed).toBe(true);
+  });
+
+  it("returns allowed:false when jobs are declared without jobs.schedule", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"], {
+      jobs: [{ name: "daily-sync", description: "Sync daily", trigger: { type: "schedule", cron: "0 0 * * *" } }],
+    });
+    const result = v.validateManifestCapabilities(m);
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain("jobs.schedule");
+  });
+
+  it("reports multiple missing capabilities at once", () => {
+    const v = pluginCapabilityValidator();
+    const m = makeManifest(["issues.read"], {
+      tools: [
+        { name: "t", displayName: "T", description: "test", parametersSchema: { type: "object", properties: {} } },
+      ],
+      jobs: [{ name: "j", description: "job", trigger: { type: "schedule", cron: "* * * * *" } }],
+    });
+    const result = v.validateManifestCapabilities(m);
+    expect(result.allowed).toBe(false);
+    expect(result.missing).toContain("agent.tools.register");
+    expect(result.missing).toContain("jobs.schedule");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getRequiredCapabilities
+// ---------------------------------------------------------------------------
+
+describe("pluginCapabilityValidator.getRequiredCapabilities", () => {
+  it("returns the capabilities required for a known operation", () => {
+    const v = pluginCapabilityValidator();
+    const caps = v.getRequiredCapabilities("issues.list");
+    expect(caps).toContain("issues.read");
+  });
+
+  it("returns an empty array for an unknown operation", () => {
+    const v = pluginCapabilityValidator();
+    const caps = v.getRequiredCapabilities("no.such.operation");
+    expect(Array.isArray(caps)).toBe(true);
+    expect(caps).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getUiSlotCapability
+// ---------------------------------------------------------------------------
+
+describe("pluginCapabilityValidator.getUiSlotCapability", () => {
+  it("returns the capability for the sidebar slot type", () => {
+    const v = pluginCapabilityValidator();
+    expect(v.getUiSlotCapability("sidebar")).toBe("ui.sidebar.register");
+  });
+
+  it("returns the capability for the page slot type", () => {
+    const v = pluginCapabilityValidator();
+    expect(v.getUiSlotCapability("page")).toBe("ui.page.register");
+  });
+
+  it("returns the capability for the detailTab slot type", () => {
+    const v = pluginCapabilityValidator();
+    expect(v.getUiSlotCapability("detailTab")).toBe("ui.detailTab.register");
+  });
+
+  it("returns the capability for the commentAnnotation slot type", () => {
+    const v = pluginCapabilityValidator();
+    expect(v.getUiSlotCapability("commentAnnotation")).toBe("ui.commentAnnotation.register");
+  });
+});

--- a/server/src/services/plugin-capability-validator.test.ts
+++ b/server/src/services/plugin-capability-validator.test.ts
@@ -281,7 +281,7 @@ describe("pluginCapabilityValidator.validateManifestCapabilities", () => {
   it("returns allowed:false when jobs are declared without jobs.schedule", () => {
     const v = pluginCapabilityValidator();
     const m = makeManifest(["issues.read"], {
-      jobs: [{ name: "daily-sync", description: "Sync daily", trigger: { type: "schedule", cron: "0 0 * * *" } }],
+      jobs: [{ jobKey: "daily-sync", displayName: "Daily Sync", description: "Sync daily", schedule: "0 0 * * *" }],
     });
     const result = v.validateManifestCapabilities(m);
     expect(result.allowed).toBe(false);
@@ -294,7 +294,7 @@ describe("pluginCapabilityValidator.validateManifestCapabilities", () => {
       tools: [
         { name: "t", displayName: "T", description: "test", parametersSchema: { type: "object", properties: {} } },
       ],
-      jobs: [{ name: "j", description: "job", trigger: { type: "schedule", cron: "* * * * *" } }],
+      jobs: [{ jobKey: "j", displayName: "J", description: "job", schedule: "* * * * *" }],
     });
     const result = v.validateManifestCapabilities(m);
     expect(result.allowed).toBe(false);

--- a/server/src/services/plugin-config-validator.test.ts
+++ b/server/src/services/plugin-config-validator.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { validateInstanceConfig } from "./plugin-config-validator.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const stringSchema = {
+  type: "object" as const,
+  properties: { name: { type: "string" } },
+  required: ["name"],
+  additionalProperties: false,
+};
+
+const numberSchema = {
+  type: "object" as const,
+  properties: { count: { type: "number", minimum: 1, maximum: 100 } },
+  required: ["count"],
+  additionalProperties: false,
+};
+
+// ---------------------------------------------------------------------------
+// validateInstanceConfig
+// ---------------------------------------------------------------------------
+
+describe("validateInstanceConfig", () => {
+  it("returns valid:true for a config that satisfies the schema", () => {
+    const result = validateInstanceConfig({ name: "my-plugin" }, stringSchema);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
+
+  it("returns valid:false when a required field is missing", () => {
+    const result = validateInstanceConfig({}, stringSchema);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.length).toBeGreaterThan(0);
+  });
+
+  it("returns field path information in the error list", () => {
+    const result = validateInstanceConfig({ count: "not-a-number" }, numberSchema);
+    expect(result.valid).toBe(false);
+    const fields = result.errors!.map((e) => e.field);
+    // the path should reference the count property
+    expect(fields.some((f) => f.includes("count") || f === "/")).toBe(true);
+  });
+
+  it("returns a non-empty message string for each error", () => {
+    const result = validateInstanceConfig({}, stringSchema);
+    expect(result.valid).toBe(false);
+    result.errors!.forEach((e) => {
+      expect(typeof e.message).toBe("string");
+      expect(e.message.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("returns valid:false when an additional property is provided and additionalProperties is false", () => {
+    const result = validateInstanceConfig({ name: "ok", extra: "bad" }, stringSchema);
+    expect(result.valid).toBe(false);
+  });
+
+  it("returns valid:true for an empty config against an empty-required schema", () => {
+    const emptySchema = { type: "object" as const, properties: {}, additionalProperties: false };
+    const result = validateInstanceConfig({}, emptySchema);
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates numeric minimum constraint", () => {
+    const result = validateInstanceConfig({ count: 0 }, numberSchema);
+    expect(result.valid).toBe(false);
+    expect(result.errors!.some((e) => e.field.includes("count") || e.field === "/count")).toBe(true);
+  });
+
+  it("validates numeric maximum constraint", () => {
+    const result = validateInstanceConfig({ count: 101 }, numberSchema);
+    expect(result.valid).toBe(false);
+  });
+
+  it("validates a valid number within range", () => {
+    const result = validateInstanceConfig({ count: 50 }, numberSchema);
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns multiple errors when multiple fields are invalid", () => {
+    const multiSchema = {
+      type: "object" as const,
+      properties: {
+        a: { type: "string" },
+        b: { type: "number" },
+      },
+      required: ["a", "b"],
+    };
+    const result = validateInstanceConfig({}, multiSchema);
+    expect(result.valid).toBe(false);
+    expect(result.errors!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("validates enum constraints", () => {
+    const enumSchema = {
+      type: "object" as const,
+      properties: { mode: { type: "string", enum: ["fast", "slow"] } },
+      required: ["mode"],
+    };
+    const invalid = validateInstanceConfig({ mode: "medium" }, enumSchema);
+    expect(invalid.valid).toBe(false);
+
+    const valid = validateInstanceConfig({ mode: "fast" }, enumSchema);
+    expect(valid.valid).toBe(true);
+  });
+
+  it("accepts the secret-ref format without error", () => {
+    const secretRefSchema = {
+      type: "object" as const,
+      properties: { apiKey: { type: "string", format: "secret-ref" } },
+      required: ["apiKey"],
+    };
+    const result = validateInstanceConfig({ apiKey: "any-uuid-value" }, secretRefSchema);
+    expect(result.valid).toBe(true);
+  });
+
+  it("validates email format via ajv-formats", () => {
+    const emailSchema = {
+      type: "object" as const,
+      properties: { email: { type: "string", format: "email" } },
+      required: ["email"],
+    };
+    const invalid = validateInstanceConfig({ email: "not-an-email" }, emailSchema);
+    expect(invalid.valid).toBe(false);
+
+    const valid = validateInstanceConfig({ email: "user@example.com" }, emailSchema);
+    expect(valid.valid).toBe(true);
+  });
+});

--- a/server/src/services/plugin-manifest-validator.test.ts
+++ b/server/src/services/plugin-manifest-validator.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from "vitest";
+import { PLUGIN_API_VERSION } from "@paperclipai/shared";
+import { pluginManifestValidator } from "./plugin-manifest-validator.js";
+
+// ---------------------------------------------------------------------------
+// Minimal valid manifest fixture
+// ---------------------------------------------------------------------------
+
+function makeMinimalManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "my-plugin",
+    apiVersion: PLUGIN_API_VERSION,
+    version: "1.0.0",
+    displayName: "My Plugin",
+    description: "A minimal test plugin for unit tests",
+    author: "Test Author",
+    categories: ["connector"],
+    capabilities: ["issues.read"],
+    entrypoints: { worker: "dist/worker.js" },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// pluginManifestValidator
+// ---------------------------------------------------------------------------
+
+describe("pluginManifestValidator", () => {
+  it("getSupportedVersions returns an array containing PLUGIN_API_VERSION", () => {
+    const validator = pluginManifestValidator();
+    const versions = validator.getSupportedVersions();
+    expect(Array.isArray(versions)).toBe(true);
+    expect(versions).toContain(PLUGIN_API_VERSION);
+  });
+
+  it("parse returns success:true for a minimal valid manifest", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(makeMinimalManifest());
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.manifest.id).toBe("my-plugin");
+    }
+  });
+
+  it("parse returns success:false for null input", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(null);
+    expect(result.success).toBe(false);
+  });
+
+  it("parse returns success:false for an empty object", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse({});
+    expect(result.success).toBe(false);
+  });
+
+  it("parse returns success:false when apiVersion is wrong", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(makeMinimalManifest({ apiVersion: 99 }));
+    expect(result.success).toBe(false);
+  });
+
+  it("parse returns success:false when id is empty", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(makeMinimalManifest({ id: "" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("parse returns success:false when id contains invalid characters", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(makeMinimalManifest({ id: "INVALID_CAPS" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("parse returns success:false when categories is empty", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(makeMinimalManifest({ categories: [] }));
+    expect(result.success).toBe(false);
+  });
+
+  it("parse returns success:false when capabilities is empty", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(makeMinimalManifest({ capabilities: [] }));
+    expect(result.success).toBe(false);
+  });
+
+  it("parse returns success:false when version is not semver", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(makeMinimalManifest({ version: "not-semver" }));
+    expect(result.success).toBe(false);
+  });
+
+  it("parse populates errors string on failure", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(makeMinimalManifest({ id: "" }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(typeof result.errors).toBe("string");
+      expect(result.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("parse populates details array on failure", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(makeMinimalManifest({ id: "" }));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(Array.isArray(result.details)).toBe(true);
+      expect(result.details.length).toBeGreaterThan(0);
+      expect(typeof result.details[0].message).toBe("string");
+    }
+  });
+
+  it("parse accepts an optional ui entrypoint when no ui slots are declared", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(
+      makeMinimalManifest({ entrypoints: { worker: "dist/worker.js", ui: "dist/ui.js" } }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("parse fails when ui slots are declared but entrypoints.ui is missing", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(
+      makeMinimalManifest({
+        capabilities: ["issues.read", "ui.slots"],
+        ui: { slots: [{ id: "slot-a", label: "Slot A", placement: "issue.sidebar" }] },
+        entrypoints: { worker: "dist/worker.js" }, // no ui entrypoint
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("parse succeeds with a pre-release semver version", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(makeMinimalManifest({ version: "1.0.0-beta.1" }));
+    expect(result.success).toBe(true);
+  });
+
+  it("parse succeeds when tools are declared with the agent.tools.register capability", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(
+      makeMinimalManifest({
+        capabilities: ["issues.read", "agent.tools.register"],
+        tools: [
+          {
+            name: "my_tool",
+            displayName: "My Tool",
+            description: "Does something useful",
+            parametersSchema: { type: "object", properties: {} },
+          },
+        ],
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("parse fails when tools are declared without the agent.tools.register capability", () => {
+    const validator = pluginManifestValidator();
+    const result = validator.parse(
+      makeMinimalManifest({
+        capabilities: ["issues.read"],
+        tools: [
+          {
+            name: "my_tool",
+            displayName: "My Tool",
+            description: "Does something useful",
+            parametersSchema: { type: "object", properties: {} },
+          },
+        ],
+      }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("parseOrThrow returns the manifest for a valid input", () => {
+    const validator = pluginManifestValidator();
+    const manifest = validator.parseOrThrow(makeMinimalManifest());
+    expect(manifest.id).toBe("my-plugin");
+  });
+
+  it("parseOrThrow throws for an invalid input", () => {
+    const validator = pluginManifestValidator();
+    expect(() => validator.parseOrThrow({})).toThrow();
+  });
+
+  it("parseOrThrow throws an error whose message mentions 'Invalid plugin manifest'", () => {
+    const validator = pluginManifestValidator();
+    expect(() => validator.parseOrThrow({ id: "" })).toThrow(/Invalid plugin manifest/);
+  });
+});

--- a/server/src/services/project-workspace-runtime-config.test.ts
+++ b/server/src/services/project-workspace-runtime-config.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import {
+  readProjectWorkspaceRuntimeConfig,
+  mergeProjectWorkspaceRuntimeConfig,
+} from "./project-workspace-runtime-config.js";
+
+// ---------------------------------------------------------------------------
+// readProjectWorkspaceRuntimeConfig
+// ---------------------------------------------------------------------------
+
+describe("readProjectWorkspaceRuntimeConfig", () => {
+  it("returns null for null metadata", () => {
+    expect(readProjectWorkspaceRuntimeConfig(null)).toBeNull();
+  });
+
+  it("returns null for undefined metadata", () => {
+    expect(readProjectWorkspaceRuntimeConfig(undefined)).toBeNull();
+  });
+
+  it("returns null when metadata has no runtimeConfig key", () => {
+    expect(readProjectWorkspaceRuntimeConfig({ other: "value" })).toBeNull();
+  });
+
+  it("returns null when runtimeConfig is not a record (e.g., a string)", () => {
+    expect(readProjectWorkspaceRuntimeConfig({ runtimeConfig: "not-an-object" })).toBeNull();
+  });
+
+  it("returns null when runtimeConfig record has no recognized fields", () => {
+    expect(readProjectWorkspaceRuntimeConfig({ runtimeConfig: { unknown: true } })).toBeNull();
+  });
+
+  it("reads desiredState 'running' from runtimeConfig", () => {
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { desiredState: "running" },
+    });
+    expect(result?.desiredState).toBe("running");
+  });
+
+  it("reads desiredState 'stopped' from runtimeConfig", () => {
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { desiredState: "stopped" },
+    });
+    expect(result?.desiredState).toBe("stopped");
+  });
+
+  it("returns null desiredState for an unrecognized value", () => {
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { workspaceRuntime: { env: {} }, desiredState: "paused" },
+    });
+    expect(result?.desiredState).toBeNull();
+  });
+
+  it("reads workspaceRuntime as a cloned record", () => {
+    const runtimeObj = { mode: "docker" };
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: { workspaceRuntime: runtimeObj },
+    });
+    expect(result?.workspaceRuntime).toEqual({ mode: "docker" });
+    expect(result?.workspaceRuntime).not.toBe(runtimeObj);
+  });
+
+  it("reads serviceStates, keeping only 'running' and 'stopped' entries", () => {
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: {
+        serviceStates: { db: "running", api: "stopped", cache: "unknown" },
+      },
+    });
+    expect(result?.serviceStates).toEqual({ db: "running", api: "stopped" });
+    expect(result?.serviceStates).not.toHaveProperty("cache");
+  });
+
+  it("returns null serviceStates when all entries are invalid", () => {
+    const result = readProjectWorkspaceRuntimeConfig({
+      runtimeConfig: {
+        workspaceRuntime: { foo: "bar" },
+        serviceStates: { cache: "invalid" },
+      },
+    });
+    expect(result?.serviceStates).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeProjectWorkspaceRuntimeConfig
+// ---------------------------------------------------------------------------
+
+describe("mergeProjectWorkspaceRuntimeConfig", () => {
+  it("removes runtimeConfig from metadata when patch is null", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { runtimeConfig: { desiredState: "running" }, other: "keep" },
+      null,
+    );
+    expect(result).not.toHaveProperty("runtimeConfig");
+    expect(result).toHaveProperty("other", "keep");
+  });
+
+  it("returns null when metadata was only runtimeConfig and patch removes it", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig({ runtimeConfig: { desiredState: "running" } }, null);
+    expect(result).toBeNull();
+  });
+
+  it("sets desiredState on a fresh metadata object", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(null, { desiredState: "stopped" });
+    expect((result?.runtimeConfig as Record<string, unknown>)?.desiredState).toBe("stopped");
+  });
+
+  it("merges desiredState patch without overwriting other runtimeConfig fields", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { runtimeConfig: { workspaceRuntime: { mode: "docker" } } },
+      { desiredState: "running" },
+    );
+    const rc = result?.runtimeConfig as Record<string, unknown>;
+    expect(rc?.desiredState).toBe("running");
+    expect(rc?.workspaceRuntime).toEqual({ mode: "docker" });
+  });
+
+  it("replaces workspaceRuntime when patch supplies one", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { runtimeConfig: { workspaceRuntime: { old: true } } },
+      { workspaceRuntime: { new: true } },
+    );
+    expect(
+      (result?.runtimeConfig as Record<string, unknown>)?.workspaceRuntime,
+    ).toEqual({ new: true });
+  });
+
+  it("removes runtimeConfig entirely when merged result has all null fields", () => {
+    // Starting with desiredState; patching desiredState to undefined but null patch clears it
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { runtimeConfig: { desiredState: "running" } },
+      { desiredState: null },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("preserves unrelated metadata keys through the merge", () => {
+    const result = mergeProjectWorkspaceRuntimeConfig(
+      { existingKey: "value" },
+      { desiredState: "running" },
+    );
+    expect(result).toHaveProperty("existingKey", "value");
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive unit test coverage for pure utility functions across the `server`, `cli`, and `shared` packages. All tests use Vitest and cover the public API surface of each module with edge cases, error paths, and boundary conditions.

### Test files added (session 1 — PR #115–#123 range):
- `server/src/services/adapter-failure-taxonomy.test.ts` — 24 tests
- `server/src/services/company-export-readme.test.ts` — 24 tests
- `server/src/services/issue-goal-fallback.test.ts` — 17 tests
- `server/src/services/feedback-redaction.test.ts` — 26 tests
- `server/src/services/heartbeat-run-summary.test.ts` — 30 tests
- `server/src/services/execution-workspace-policy.test.ts` — 42 tests
- `server/src/services/project-workspace-runtime-config.test.ts` — 18 tests
- `server/src/services/cron.test.ts` — 35 tests
- `server/src/services/documents.test.ts` — 10 tests
- `server/src/services/company-portability-github.test.ts` — 12 tests

### Test files added (session 2):
- `server/src/services/heartbeat-pure.test.ts` — 23 tests (compactRunLogChunk, summarizeHeartbeatRunContextSnapshot, summarizeHeartbeatRunListResultJson, formatRuntimeWorkspaceWarningLog)
- `server/src/services/plugin-config-validator.test.ts` — 13 tests (validateInstanceConfig: type constraints, format validation, multi-error)
- `server/src/services/plugin-manifest-validator.test.ts` — 20 tests (parse/parseOrThrow, capability/slot consistency)
- `server/src/services/plugin-capability-validator.test.ts` — 35 tests (hasCapability, checkOperation, assertOperation, checkUiSlot, validateManifestCapabilities)
- `server/src/services/issue-execution-policy.test.ts` — 37 tests (normalizeIssueExecutionPolicy, parseIssueExecutionState, assigneePrincipal)
- `server/src/services/github-fetch.test.ts` — 12 tests (gitHubApiBase, resolveRawGitHubUrl)
- `cli/src/__tests__/hostnames.test.ts` — 21 tests (normalizeHostnameInput, parseHostnameCsv)
- `cli/src/__tests__/server-bind.test.ts` — 30 tests (inferConfiguredBind, buildPresetServerConfig, buildCustomServerConfig, resolveQuickstartServerConfig)
- `packages/shared/src/validators/plugin.test.ts` — 47 tests (jsonSchemaSchema, pluginJobDeclarationSchema, pluginWebhookDeclarationSchema, pluginToolDeclarationSchema, pluginUiSlotDeclarationSchema, installPluginSchema, upsertPluginConfigSchema)

**Total: 478+ pure-function unit tests across 19 test files**

## Test plan
- [x] All tests pass locally: `pnpm vitest run` across server, cli, and shared packages
- [x] TypeScript type errors fixed in company-export-readme.test.ts (CompanyPortabilityInclude required fields, removed non-existent `goals` field)
- [x] CI running on branch