### PR TITLE
test(server): 27 unit tests for checkout wakeup guard and org-chart SVG renderer

### DIFF
--- a/packages/db/src/backup-lib.test.ts
+++ b/packages/db/src/backup-lib.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import postgres from "postgres";
-import { createBufferedTextFileWriter, runDatabaseBackup, runDatabaseRestore } from "./backup-lib.js";
+import { createBufferedTextFileWriter, formatDatabaseBackupResult, runDatabaseBackup, runDatabaseRestore } from "./backup-lib.js";
 import { ensurePostgresDatabase } from "./client.js";
 import {
   getEmbeddedPostgresTestSupport,
@@ -221,4 +221,75 @@ describeEmbeddedPostgres("runDatabaseBackup", () => {
     },
     20_000,
   );
+});
+
+// ---------------------------------------------------------------------------
+// formatDatabaseBackupResult — pure formatting function
+// ---------------------------------------------------------------------------
+
+describe("formatDatabaseBackupResult", () => {
+  it("formats a result with no pruned files", () => {
+    const result = formatDatabaseBackupResult({
+      backupFile: "/backups/db-2026-04-17.jsonl.gz",
+      sizeBytes: 512,
+      prunedCount: 0,
+    });
+    expect(result).toContain("/backups/db-2026-04-17.jsonl.gz");
+    expect(result).not.toContain("pruned");
+  });
+
+  it("includes pruned count when prunedCount > 0", () => {
+    const result = formatDatabaseBackupResult({
+      backupFile: "backup.jsonl.gz",
+      sizeBytes: 1024,
+      prunedCount: 3,
+    });
+    expect(result).toContain("pruned 3 old backup(s)");
+  });
+
+  it("formats byte sizes under 1 KB as raw bytes", () => {
+    const result = formatDatabaseBackupResult({
+      backupFile: "small.gz",
+      sizeBytes: 512,
+      prunedCount: 0,
+    });
+    expect(result).toContain("512B");
+  });
+
+  it("formats sizes between 1 KB and 1 MB in kilobytes with one decimal", () => {
+    const result = formatDatabaseBackupResult({
+      backupFile: "medium.gz",
+      sizeBytes: 2048,
+      prunedCount: 0,
+    });
+    expect(result).toContain("2.0K");
+  });
+
+  it("formats sizes at or above 1 MB in megabytes with one decimal", () => {
+    const result = formatDatabaseBackupResult({
+      backupFile: "large.gz",
+      sizeBytes: 1024 * 1024 * 5,
+      prunedCount: 0,
+    });
+    expect(result).toContain("5.0M");
+  });
+
+  it("includes both the file name and size in the output", () => {
+    const result = formatDatabaseBackupResult({
+      backupFile: "db.jsonl.gz",
+      sizeBytes: 1536,
+      prunedCount: 0,
+    });
+    expect(result).toContain("db.jsonl.gz");
+    expect(result).toContain("1.5K");
+  });
+
+  it("formats pruned=1 correctly (singular form treated as plural)", () => {
+    const result = formatDatabaseBackupResult({
+      backupFile: "db.gz",
+      sizeBytes: 1024,
+      prunedCount: 1,
+    });
+    expect(result).toContain("pruned 1 old backup(s)");
+  });
 });

--- a/server/src/routes/issues-checkout-wakeup.test.ts
+++ b/server/src/routes/issues-checkout-wakeup.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { shouldWakeAssigneeOnCheckout } from "./issues-checkout-wakeup.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const AGENT_ID = "agent-abc";
+const OTHER_AGENT_ID = "agent-xyz";
+const RUN_ID = "run-001";
+
+// ---------------------------------------------------------------------------
+// shouldWakeAssigneeOnCheckout
+// ---------------------------------------------------------------------------
+
+describe("shouldWakeAssigneeOnCheckout", () => {
+  // Returns false (skip wakeup) only when:
+  //   actorType === "agent" AND actorAgentId present AND actorAgentId === checkoutAgentId AND checkoutRunId present
+
+  it("returns true when actorType is board", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "board",
+        actorAgentId: null,
+        checkoutAgentId: AGENT_ID,
+        checkoutRunId: RUN_ID,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when actorType is none", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "none",
+        actorAgentId: null,
+        checkoutAgentId: AGENT_ID,
+        checkoutRunId: RUN_ID,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when actorType is agent but actorAgentId is null", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "agent",
+        actorAgentId: null,
+        checkoutAgentId: AGENT_ID,
+        checkoutRunId: RUN_ID,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when actorType is agent but actorAgentId is empty string", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "agent",
+        actorAgentId: "",
+        checkoutAgentId: AGENT_ID,
+        checkoutRunId: RUN_ID,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when actorType is agent but actorAgentId differs from checkoutAgentId", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "agent",
+        actorAgentId: OTHER_AGENT_ID,
+        checkoutAgentId: AGENT_ID,
+        checkoutRunId: RUN_ID,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when actorType is agent, same agentId, but checkoutRunId is null", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "agent",
+        actorAgentId: AGENT_ID,
+        checkoutAgentId: AGENT_ID,
+        checkoutRunId: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when agent checks out its own run (no wakeup needed)", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "agent",
+        actorAgentId: AGENT_ID,
+        checkoutAgentId: AGENT_ID,
+        checkoutRunId: RUN_ID,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for a different valid runId when all other conditions match", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "agent",
+        actorAgentId: AGENT_ID,
+        checkoutAgentId: AGENT_ID,
+        checkoutRunId: "run-different-but-non-null",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when board actor checks out with matching agent ids (actorType overrides)", () => {
+    expect(
+      shouldWakeAssigneeOnCheckout({
+        actorType: "board",
+        actorAgentId: AGENT_ID,
+        checkoutAgentId: AGENT_ID,
+        checkoutRunId: RUN_ID,
+      }),
+    ).toBe(true);
+  });
+});

--- a/server/src/routes/org-chart-svg.test.ts
+++ b/server/src/routes/org-chart-svg.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderOrgChartSvg,
+  ORG_CHART_STYLES,
+  type OrgNode,
+  type OrgChartStyle,
+} from "./org-chart-svg.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function leafNode(id: string, name: string, role = "engineer"): OrgNode {
+  return { id, name, role, status: "active", reports: [] };
+}
+
+const SINGLE_NODE: OrgNode[] = [leafNode("ceo-1", "Alice", "ceo")];
+
+const TWO_LEVEL_TREE: OrgNode[] = [
+  {
+    id: "ceo-1",
+    name: "Alice",
+    role: "ceo",
+    status: "active",
+    reports: [
+      leafNode("cto-1", "Bob", "cto"),
+      leafNode("cfo-1", "Carol", "cfo"),
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// renderOrgChartSvg — output structure
+// ---------------------------------------------------------------------------
+
+describe("renderOrgChartSvg output structure", () => {
+  it("returns a string", () => {
+    expect(typeof renderOrgChartSvg(SINGLE_NODE)).toBe("string");
+  });
+
+  it("returns a string that starts with <svg", () => {
+    expect(renderOrgChartSvg(SINGLE_NODE).trimStart()).toMatch(/^<svg /);
+  });
+
+  it("includes the xmlns attribute", () => {
+    expect(renderOrgChartSvg(SINGLE_NODE)).toContain('xmlns="http://www.w3.org/2000/svg"');
+  });
+
+  it("closes the svg element at the end", () => {
+    const svg = renderOrgChartSvg(SINGLE_NODE);
+    expect(svg.trimEnd()).toMatch(/<\/svg>$/);
+  });
+
+  it("includes a width and height attribute", () => {
+    const svg = renderOrgChartSvg(SINGLE_NODE);
+    expect(svg).toMatch(/width="\d+"/);
+    expect(svg).toMatch(/height="\d+"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderOrgChartSvg — node content
+// ---------------------------------------------------------------------------
+
+describe("renderOrgChartSvg node content", () => {
+  it("includes the agent name from a single-node tree", () => {
+    expect(renderOrgChartSvg(SINGLE_NODE)).toContain("Alice");
+  });
+
+  it("includes all agent names from a multi-node tree", () => {
+    const svg = renderOrgChartSvg(TWO_LEVEL_TREE);
+    expect(svg).toContain("Alice");
+    expect(svg).toContain("Bob");
+    expect(svg).toContain("Carol");
+  });
+
+  it("handles an empty orgTree by rendering a virtual root", () => {
+    const svg = renderOrgChartSvg([]);
+    expect(svg).toMatch(/^<svg /);
+  });
+
+  it("renders a multi-root tree using a virtual root wrapper", () => {
+    const multiRoot: OrgNode[] = [
+      leafNode("a-1", "Agent A"),
+      leafNode("a-2", "Agent B"),
+    ];
+    const svg = renderOrgChartSvg(multiRoot);
+    expect(svg).toContain("Agent A");
+    expect(svg).toContain("Agent B");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderOrgChartSvg — style variants
+// ---------------------------------------------------------------------------
+
+describe("renderOrgChartSvg style variants", () => {
+  it("renders successfully for each canonical style", () => {
+    for (const style of ORG_CHART_STYLES) {
+      const svg = renderOrgChartSvg(SINGLE_NODE, style);
+      expect(svg).toMatch(/^<svg /);
+    }
+  });
+
+  it("defaults to warmth style when style is omitted", () => {
+    const svgDefault = renderOrgChartSvg(SINGLE_NODE);
+    const svgWarmth = renderOrgChartSvg(SINGLE_NODE, "warmth");
+    expect(svgDefault).toBe(svgWarmth);
+  });
+
+  it("produces different output for different styles", () => {
+    const svgMonochrome = renderOrgChartSvg(SINGLE_NODE, "monochrome");
+    const svgNebula = renderOrgChartSvg(SINGLE_NODE, "nebula");
+    expect(svgMonochrome).not.toBe(svgNebula);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderOrgChartSvg — overlay options
+// ---------------------------------------------------------------------------
+
+describe("renderOrgChartSvg overlay options", () => {
+  it("includes the companyName in SVG text when provided", () => {
+    const svg = renderOrgChartSvg(SINGLE_NODE, "warmth", { companyName: "Acme Corp" });
+    expect(svg).toContain("Acme Corp");
+  });
+
+  it("includes the stats string in SVG text when provided", () => {
+    const svg = renderOrgChartSvg(SINGLE_NODE, "warmth", { stats: "Agents: 3" });
+    expect(svg).toContain("Agents: 3");
+  });
+
+  it("escapes special characters in companyName", () => {
+    const svg = renderOrgChartSvg(SINGLE_NODE, "warmth", { companyName: "A&B <Corp>" });
+    expect(svg).toContain("A&amp;B &lt;Corp&gt;");
+    expect(svg).not.toContain("A&B <Corp>");
+  });
+
+  it("renders without overlay when overlay is omitted", () => {
+    const svg = renderOrgChartSvg(SINGLE_NODE, "warmth");
+    expect(svg).toMatch(/^<svg /);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ORG_CHART_STYLES constant
+// ---------------------------------------------------------------------------
+
+describe("ORG_CHART_STYLES", () => {
+  it("contains exactly 5 style names", () => {
+    expect(ORG_CHART_STYLES).toHaveLength(5);
+  });
+
+  it("includes monochrome, nebula, circuit, warmth, schematic", () => {
+    expect(ORG_CHART_STYLES).toContain("monochrome");
+    expect(ORG_CHART_STYLES).toContain("nebula");
+    expect(ORG_CHART_STYLES).toContain("circuit");
+    expect(ORG_CHART_STYLES).toContain("warmth");
+    expect(ORG_CHART_STYLES).toContain("schematic");
+  });
+});

--- a/ui/src/adapters/adapter-display-registry.test.ts
+++ b/ui/src/adapters/adapter-display-registry.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  getAdapterLabel,
+  getAdapterLabels,
+  getAdapterDisplay,
+  isKnownAdapterType,
+} from "./adapter-display-registry.js";
+
+// ---------------------------------------------------------------------------
+// isKnownAdapterType
+// ---------------------------------------------------------------------------
+
+describe("isKnownAdapterType", () => {
+  it("returns true for known built-in types", () => {
+    expect(isKnownAdapterType("claude_local")).toBe(true);
+    expect(isKnownAdapterType("codex_local")).toBe(true);
+    expect(isKnownAdapterType("gemini_local")).toBe(true);
+    expect(isKnownAdapterType("opencode_local")).toBe(true);
+    expect(isKnownAdapterType("process")).toBe(true);
+    expect(isKnownAdapterType("http")).toBe(true);
+  });
+
+  it("returns false for unknown external types", () => {
+    expect(isKnownAdapterType("my_custom_adapter")).toBe(false);
+    expect(isKnownAdapterType("droid_local")).toBe(false);
+    expect(isKnownAdapterType("")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAdapterLabel
+// ---------------------------------------------------------------------------
+
+describe("getAdapterLabel", () => {
+  it("returns the known label with (local) suffix for claude_local", () => {
+    expect(getAdapterLabel("claude_local")).toBe("Claude Code (local)");
+  });
+
+  it("returns the known label with (local) suffix for codex_local", () => {
+    expect(getAdapterLabel("codex_local")).toBe("Codex (local)");
+  });
+
+  it("returns the known label with (local) suffix for gemini_local", () => {
+    expect(getAdapterLabel("gemini_local")).toBe("Gemini CLI (local)");
+  });
+
+  it("returns the known label with (local) suffix for opencode_local", () => {
+    expect(getAdapterLabel("opencode_local")).toBe("OpenCode (local)");
+  });
+
+  it("humanizes unknown local types and appends (local)", () => {
+    const label = getAdapterLabel("droid_local");
+    // "droid_local" → strip "_local" → "droid" → "Droid" → "Droid (local)"
+    expect(label).toContain("Droid");
+    expect(label).toContain("(local)");
+  });
+
+  it("humanizes unknown types without a known suffix", () => {
+    const label = getAdapterLabel("my_custom_tool");
+    expect(label).toContain("My");
+    expect(label).toContain("Custom");
+  });
+
+  it("returns a non-empty string for any input", () => {
+    expect(getAdapterLabel("unknown_adapter")).toBeTruthy();
+    expect(typeof getAdapterLabel("foo")).toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAdapterLabels
+// ---------------------------------------------------------------------------
+
+describe("getAdapterLabels", () => {
+  it("returns a record of known adapter labels with type suffixes", () => {
+    const labels = getAdapterLabels();
+    expect(typeof labels).toBe("object");
+    // _local types get (local) suffix appended
+    expect(labels.claude_local).toBe("Claude Code (local)");
+    expect(labels.codex_local).toBe("Codex (local)");
+  });
+
+  it("includes all well-known adapter types", () => {
+    const labels = getAdapterLabels();
+    const knownTypes = ["claude_local", "codex_local", "gemini_local", "opencode_local", "process", "http"];
+    for (const type of knownTypes) {
+      expect(labels).toHaveProperty(type);
+      expect(typeof labels[type]).toBe("string");
+      expect(labels[type].length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAdapterDisplay
+// ---------------------------------------------------------------------------
+
+describe("getAdapterDisplay", () => {
+  it("returns display info with label and description for a known type", () => {
+    const info = getAdapterDisplay("claude_local");
+    expect(info.label).toBe("Claude Code");
+    expect(typeof info.description).toBe("string");
+    expect(info.description.length).toBeGreaterThan(0);
+    expect(info.icon).toBeDefined();
+  });
+
+  it("returns display info for an unknown type with a humanized label", () => {
+    const info = getAdapterDisplay("droid_local");
+    expect(typeof info.label).toBe("string");
+    expect(info.label.length).toBeGreaterThan(0);
+    expect(typeof info.description).toBe("string");
+    expect(info.icon).toBeDefined();
+  });
+
+  it("includes description 'External local adapter' for unknown _local type", () => {
+    const info = getAdapterDisplay("droid_local");
+    expect(info.description).toContain("local");
+  });
+
+  it("includes description 'External adapter' for unknown type without suffix", () => {
+    const info = getAdapterDisplay("my_tool");
+    expect(info.description).toContain("External");
+  });
+
+  it("claude_local is marked as recommended", () => {
+    const info = getAdapterDisplay("claude_local");
+    expect(info.recommended).toBe(true);
+  });
+
+  it("codex_local is marked as recommended", () => {
+    const info = getAdapterDisplay("codex_local");
+    expect(info.recommended).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 9 tests for `shouldWakeAssigneeOnCheckout` in `server/src/routes/issues-checkout-wakeup.ts` — pure boolean guard covering board/none/agent actor types, null agentId, agent mismatch, null runId, and the suppressed-wakeup path
- Adds 18 tests for `renderOrgChartSvg` in `server/src/routes/org-chart-svg.ts` — pure SVG renderer covering output structure, node content, all 5 style variants, overlay text injection, and SVG-escape of special characters

## Test plan
- [x] `pnpm vitest run server/src/routes/issues-checkout-wakeup.test.ts` — 9/9 pass
- [x] `pnpm vitest run server/src/routes/org-chart-svg.test.ts` — 18/18 pass
- [ ] CI verify job (typecheck + full test suite + coverage threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)