### PR TITLE
test(openclaw-gateway): add to vitest workspace with 37 unit tests

### DIFF
--- a/packages/adapters/openclaw-gateway/src/shared/stream.test.ts
+++ b/packages/adapters/openclaw-gateway/src/shared/stream.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { normalizeOpenClawGatewayStreamLine } from "./stream.js";
+
+describe("normalizeOpenClawGatewayStreamLine", () => {
+  it("returns null stream and empty line for an empty string", () => {
+    expect(normalizeOpenClawGatewayStreamLine("")).toEqual({ stream: null, line: "" });
+  });
+
+  it("returns null stream and empty line for whitespace-only input", () => {
+    expect(normalizeOpenClawGatewayStreamLine("   \t  ")).toEqual({ stream: null, line: "" });
+  });
+
+  it("returns null stream and trimmed line for a plain message", () => {
+    expect(normalizeOpenClawGatewayStreamLine("hello world")).toEqual({
+      stream: null,
+      line: "hello world",
+    });
+  });
+
+  it("returns null stream and trimmed line for a line with leading/trailing whitespace", () => {
+    expect(normalizeOpenClawGatewayStreamLine("  plain output  ")).toEqual({
+      stream: null,
+      line: "plain output",
+    });
+  });
+
+  it("detects stdout prefix with colon separator", () => {
+    expect(normalizeOpenClawGatewayStreamLine("stdout: hello")).toEqual({
+      stream: "stdout",
+      line: "hello",
+    });
+  });
+
+  it("detects stderr prefix with colon separator", () => {
+    expect(normalizeOpenClawGatewayStreamLine("stderr: error message")).toEqual({
+      stream: "stderr",
+      line: "error message",
+    });
+  });
+
+  it("detects stdout prefix with equals separator", () => {
+    expect(normalizeOpenClawGatewayStreamLine("stdout= output text")).toEqual({
+      stream: "stdout",
+      line: "output text",
+    });
+  });
+
+  it("detects stderr prefix with equals separator", () => {
+    expect(normalizeOpenClawGatewayStreamLine("stderr= warning")).toEqual({
+      stream: "stderr",
+      line: "warning",
+    });
+  });
+
+  it("detects stdout prefix with no separator", () => {
+    expect(normalizeOpenClawGatewayStreamLine("stdout some text")).toEqual({
+      stream: "stdout",
+      line: "some text",
+    });
+  });
+
+  it("is case-insensitive for the prefix", () => {
+    expect(normalizeOpenClawGatewayStreamLine("STDOUT: caps line")).toEqual({
+      stream: "stdout",
+      line: "caps line",
+    });
+    expect(normalizeOpenClawGatewayStreamLine("STDERR: caps error")).toEqual({
+      stream: "stderr",
+      line: "caps error",
+    });
+  });
+
+  it("strips surrounding whitespace from the extracted line", () => {
+    expect(normalizeOpenClawGatewayStreamLine("stdout:   padded   ")).toEqual({
+      stream: "stdout",
+      line: "padded",
+    });
+  });
+
+  it("returns empty string as line when prefix has no content after it", () => {
+    const result = normalizeOpenClawGatewayStreamLine("stdout:");
+    expect(result.stream).toBe("stdout");
+    expect(result.line).toBe("");
+  });
+});

--- a/packages/adapters/openclaw-gateway/src/ui/build-config.test.ts
+++ b/packages/adapters/openclaw-gateway/src/ui/build-config.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { buildOpenClawGatewayConfig } from "./build-config.js";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function makeValues(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "openclaw_gateway",
+    cwd: "",
+    instructionsFilePath: "",
+    promptTemplate: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    dangerouslySkipPermissions: false,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: false,
+    command: "",
+    args: "",
+    extraArgs: "",
+    envVars: "",
+    envBindings: {},
+    url: "",
+    bootstrapPrompt: "",
+    payloadTemplateJson: "",
+    workspaceStrategyType: "project_primary",
+    workspaceBaseRef: "",
+    workspaceBranchTemplate: "",
+    worktreeParentDir: "",
+    runtimeServicesJson: "",
+    maxTurnsPerRun: 1000,
+    heartbeatEnabled: false,
+    intervalSec: 300,
+    ...overrides,
+  };
+}
+
+describe("buildOpenClawGatewayConfig", () => {
+  it("includes url when provided", () => {
+    const config = buildOpenClawGatewayConfig(makeValues({ url: "ws://localhost:8080" }));
+    expect(config.url).toBe("ws://localhost:8080");
+  });
+
+  it("omits url when empty", () => {
+    const config = buildOpenClawGatewayConfig(makeValues({ url: "" }));
+    expect(config).not.toHaveProperty("url");
+  });
+
+  it("sets required defaults: timeoutSec, waitTimeoutMs, sessionKeyStrategy, role, scopes", () => {
+    const config = buildOpenClawGatewayConfig(makeValues());
+    expect(config.timeoutSec).toBe(120);
+    expect(config.waitTimeoutMs).toBe(120000);
+    expect(config.sessionKeyStrategy).toBe("issue");
+    expect(config.role).toBe("operator");
+    expect(config.scopes).toEqual(["operator.admin"]);
+  });
+
+  it("parses payloadTemplateJson and includes it as payloadTemplate", () => {
+    const template = { key: "value", nested: { a: 1 } };
+    const config = buildOpenClawGatewayConfig(
+      makeValues({ payloadTemplateJson: JSON.stringify(template) }),
+    );
+    expect(config.payloadTemplate).toEqual(template);
+  });
+
+  it("omits payloadTemplate when payloadTemplateJson is empty", () => {
+    const config = buildOpenClawGatewayConfig(makeValues({ payloadTemplateJson: "" }));
+    expect(config).not.toHaveProperty("payloadTemplate");
+  });
+
+  it("omits payloadTemplate when payloadTemplateJson is invalid JSON", () => {
+    const config = buildOpenClawGatewayConfig(makeValues({ payloadTemplateJson: "not-json" }));
+    expect(config).not.toHaveProperty("payloadTemplate");
+  });
+
+  it("omits payloadTemplate when payloadTemplateJson is a JSON array (not an object)", () => {
+    const config = buildOpenClawGatewayConfig(makeValues({ payloadTemplateJson: "[1,2,3]" }));
+    expect(config).not.toHaveProperty("payloadTemplate");
+  });
+
+  it("parses runtimeServicesJson with services array and sets workspaceRuntime", () => {
+    const services = { services: [{ name: "db", port: 5432 }] };
+    const config = buildOpenClawGatewayConfig(
+      makeValues({ runtimeServicesJson: JSON.stringify(services) }),
+    );
+    expect(config.workspaceRuntime).toEqual(services);
+  });
+
+  it("omits workspaceRuntime when runtimeServicesJson is empty", () => {
+    const config = buildOpenClawGatewayConfig(makeValues({ runtimeServicesJson: "" }));
+    expect(config).not.toHaveProperty("workspaceRuntime");
+  });
+
+  it("omits workspaceRuntime when runtimeServicesJson has no services array", () => {
+    const config = buildOpenClawGatewayConfig(
+      makeValues({ runtimeServicesJson: JSON.stringify({ other: "field" }) }),
+    );
+    expect(config).not.toHaveProperty("workspaceRuntime");
+  });
+
+  it("returns a plain object with all expected keys for a full config", () => {
+    const template = { auth: "token" };
+    const services = { services: [{ name: "redis" }] };
+    const config = buildOpenClawGatewayConfig(
+      makeValues({
+        url: "ws://example.com",
+        payloadTemplateJson: JSON.stringify(template),
+        runtimeServicesJson: JSON.stringify(services),
+      }),
+    );
+    expect(config).toMatchObject({
+      url: "ws://example.com",
+      timeoutSec: 120,
+      waitTimeoutMs: 120000,
+      sessionKeyStrategy: "issue",
+      role: "operator",
+      scopes: ["operator.admin"],
+      payloadTemplate: template,
+      workspaceRuntime: services,
+    });
+  });
+});

--- a/packages/adapters/openclaw-gateway/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/openclaw-gateway/src/ui/parse-stdout.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { parseOpenClawGatewayStdoutLine } from "./parse-stdout.js";
+
+const TS = "2026-04-17T00:00:00.000Z";
+
+describe("parseOpenClawGatewayStdoutLine", () => {
+  it("returns empty array for an empty line", () => {
+    expect(parseOpenClawGatewayStdoutLine("", TS)).toEqual([]);
+  });
+
+  it("returns empty array for a whitespace-only line", () => {
+    expect(parseOpenClawGatewayStdoutLine("   ", TS)).toEqual([]);
+  });
+
+  it("returns stdout transcript entry for a plain line with no prefix", () => {
+    expect(parseOpenClawGatewayStdoutLine("hello", TS)).toEqual([
+      { kind: "stdout", ts: TS, text: "hello" },
+    ]);
+  });
+
+  it("returns stderr transcript entry when the line has a stderr prefix", () => {
+    expect(parseOpenClawGatewayStdoutLine("stderr: something went wrong", TS)).toEqual([
+      { kind: "stderr", ts: TS, text: "something went wrong" },
+    ]);
+  });
+
+  it("emits a system entry for an [openclaw-gateway] lifecycle line", () => {
+    const result = parseOpenClawGatewayStdoutLine("[openclaw-gateway] session started", TS);
+    expect(result).toEqual([
+      { kind: "system", ts: TS, text: "session started" },
+    ]);
+  });
+
+  it("emits assistant transcript entry for an [openclaw-gateway:event] assistant delta", () => {
+    const eventLine = `[openclaw-gateway:event] run=run-1 stream=assistant data=${JSON.stringify({ delta: "Hello " })}`;
+    const result = parseOpenClawGatewayStdoutLine(eventLine, TS);
+    expect(result).toEqual([
+      { kind: "assistant", ts: TS, text: "Hello ", delta: true },
+    ]);
+  });
+
+  it("emits assistant transcript entry for an [openclaw-gateway:event] assistant full text", () => {
+    const eventLine = `[openclaw-gateway:event] run=run-1 stream=assistant data=${JSON.stringify({ text: "Final text" })}`;
+    const result = parseOpenClawGatewayStdoutLine(eventLine, TS);
+    expect(result).toEqual([
+      { kind: "assistant", ts: TS, text: "Final text" },
+    ]);
+  });
+
+  it("emits stderr entry for an [openclaw-gateway:event] error stream", () => {
+    const eventLine = `[openclaw-gateway:event] run=run-1 stream=error data=${JSON.stringify({ error: "something failed" })}`;
+    const result = parseOpenClawGatewayStdoutLine(eventLine, TS);
+    expect(result).toEqual([
+      { kind: "stderr", ts: TS, text: "something failed" },
+    ]);
+  });
+
+  it("returns empty array for [openclaw-gateway:event] error stream with no message", () => {
+    const eventLine = `[openclaw-gateway:event] run=run-1 stream=error data={}`;
+    const result = parseOpenClawGatewayStdoutLine(eventLine, TS);
+    expect(result).toEqual([]);
+  });
+
+  it("emits stderr entry for [openclaw-gateway:event] lifecycle failed with message", () => {
+    const eventLine = `[openclaw-gateway:event] run=run-1 stream=lifecycle data=${JSON.stringify({ phase: "failed", message: "timed out" })}`;
+    const result = parseOpenClawGatewayStdoutLine(eventLine, TS);
+    expect(result).toEqual([
+      { kind: "stderr", ts: TS, text: "timed out" },
+    ]);
+  });
+
+  it("returns empty array for [openclaw-gateway:event] lifecycle non-error phase", () => {
+    const eventLine = `[openclaw-gateway:event] run=run-1 stream=lifecycle data=${JSON.stringify({ phase: "started" })}`;
+    const result = parseOpenClawGatewayStdoutLine(eventLine, TS);
+    expect(result).toEqual([]);
+  });
+
+  it("returns stdout entry for an unrecognized [openclaw-gateway:event] stream", () => {
+    const eventLine = `[openclaw-gateway:event] run=run-1 stream=unknown data={}`;
+    const result = parseOpenClawGatewayStdoutLine(eventLine, TS);
+    expect(result).toEqual([]);
+  });
+
+  it("returns stdout entry for a line that does not match the event format", () => {
+    const result = parseOpenClawGatewayStdoutLine("[openclaw-gateway:event] malformed", TS);
+    expect(result).toEqual([
+      { kind: "stdout", ts: TS, text: "[openclaw-gateway:event] malformed" },
+    ]);
+  });
+
+  it("propagates the ts parameter into all transcript entries", () => {
+    const customTs = "2026-01-01T12:00:00.000Z";
+    const result = parseOpenClawGatewayStdoutLine("plain output", customTs);
+    expect(result[0]?.ts).toBe(customTs);
+  });
+});

--- a/packages/adapters/openclaw-gateway/vitest.config.ts
+++ b/packages/adapters/openclaw-gateway/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       "packages/adapters/codex-local",
       "packages/adapters/gemini-local",
       "packages/adapters/opencode-local",
+      "packages/adapters/openclaw-gateway",
       "packages/adapters/pi-local",
       "packages/shared",
       "server",


### PR DESCRIPTION
## Summary

- Adds `packages/adapters/openclaw-gateway` to the root vitest workspace (with `vitest.config.ts`)
- **37 new unit tests** covering three pure-function modules:
  - `normalizeOpenClawGatewayStreamLine` (12 tests) — stream prefix detection, separators, case-insensitivity, whitespace handling
  - `parseOpenClawGatewayStdoutLine` (14 tests) — empty/stderr/system/assistant-delta/assistant-text/error/lifecycle/unrecognized event paths
  - `buildOpenClawGatewayConfig` (11 tests) — url present/absent, required defaults, payloadTemplate parse and omit paths, workspaceRuntime parse and omit paths

## Test plan

- [x] All 37 new tests pass locally (`pnpm exec vitest run` in the package)
- [x] Pre-existing `src/server/execute.test.ts` (4 tests) still passes
- [ ] CI verify + coverage threshold pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)