### PR TITLE
test(adapters): unit tests for claude-local and cursor-local server/parse and ui/build-config

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -1,0 +1,668 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseClaudeStreamJson,
+  extractClaudeLoginUrl,
+  detectClaudeLoginRequired,
+  detectClaudeRateLimited,
+  describeClaudeFailure,
+  isClaudeMaxTurnsResult,
+  isClaudeUnknownSessionError,
+} from "./parse.js";
+
+// ============================================================================
+// parseClaudeStreamJson — empty / no result
+// ============================================================================
+
+describe("parseClaudeStreamJson — empty input", () => {
+  it("returns nulls for empty stdout", () => {
+    const result = parseClaudeStreamJson("");
+    expect(result.sessionId).toBeNull();
+    expect(result.model).toBe("");
+    expect(result.costUsd).toBeNull();
+    expect(result.usage).toBeNull();
+    expect(result.summary).toBe("");
+    expect(result.resultJson).toBeNull();
+    expect(result.skillInvocations).toEqual([]);
+  });
+
+  it("returns nulls when stdout has only blank lines", () => {
+    const result = parseClaudeStreamJson("\n\n   \n");
+    expect(result.sessionId).toBeNull();
+    expect(result.resultJson).toBeNull();
+  });
+
+  it("ignores non-JSON lines", () => {
+    const result = parseClaudeStreamJson("not json\nstill not json\n");
+    expect(result.sessionId).toBeNull();
+    expect(result.resultJson).toBeNull();
+  });
+});
+
+// ============================================================================
+// parseClaudeStreamJson — session / model extraction
+// ============================================================================
+
+describe("parseClaudeStreamJson — sessionId and model", () => {
+  it("reads sessionId and model from system init event", () => {
+    const lines = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "sess-abc", model: "claude-opus-4-6" }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.sessionId).toBe("sess-abc");
+    expect(result.model).toBe("claude-opus-4-6");
+  });
+
+  it("reads sessionId from assistant event", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "sess-from-assistant",
+        message: { content: [{ type: "text", text: "hi" }] },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.sessionId).toBe("sess-from-assistant");
+  });
+
+  it("reads sessionId from result event", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        session_id: "sess-result",
+        result: "done",
+        total_cost_usd: 0,
+        usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0 },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.sessionId).toBe("sess-result");
+  });
+
+  it("keeps earlier sessionId when later event has empty session_id", () => {
+    const lines = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "first", model: "m" }),
+      JSON.stringify({
+        type: "result",
+        session_id: "",
+        result: "",
+        total_cost_usd: 0,
+        usage: {},
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.sessionId).toBe("first");
+  });
+});
+
+// ============================================================================
+// parseClaudeStreamJson — assistant text accumulation
+// ============================================================================
+
+describe("parseClaudeStreamJson — assistant text", () => {
+  it("collects text from assistant content blocks", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: { content: [{ type: "text", text: "Hello world" }] },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.summary).toContain("Hello world");
+  });
+
+  it("joins multiple assistant texts with double newlines", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: { content: [{ type: "text", text: "First" }] },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: { content: [{ type: "text", text: "Second" }] },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.summary).toBe("First\n\nSecond");
+  });
+
+  it("skips non-text content blocks", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: { content: [{ type: "thinking", thinking: "private" }] },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.summary).toBe("");
+  });
+
+  it("uses result.result text as summary when no assistant texts", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        session_id: "s",
+        result: "Final answer",
+        total_cost_usd: 0.001,
+        usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 0 },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.summary).toBe("Final answer");
+  });
+
+  it("prefers result.result over accumulated assistant texts for summary", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: { content: [{ type: "text", text: "Intermediate" }] },
+      }),
+      JSON.stringify({
+        type: "result",
+        session_id: "s",
+        result: "Final",
+        total_cost_usd: 0,
+        usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0 },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.summary).toBe("Final");
+  });
+});
+
+// ============================================================================
+// parseClaudeStreamJson — usage and cost
+// ============================================================================
+
+describe("parseClaudeStreamJson — usage and cost", () => {
+  it("parses usage tokens and cost from result event", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        session_id: "s",
+        result: "ok",
+        total_cost_usd: 0.0042,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_input_tokens: 20,
+        },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.costUsd).toBe(0.0042);
+    expect(result.usage).toEqual({
+      inputTokens: 100,
+      cachedInputTokens: 20,
+      outputTokens: 50,
+    });
+  });
+
+  it("includes cacheCreationInputTokens when non-zero", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        session_id: "s",
+        result: "",
+        total_cost_usd: 0,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 200,
+        },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.usage?.cacheCreationInputTokens).toBe(200);
+  });
+
+  it("omits cacheCreationInputTokens when zero", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        session_id: "s",
+        result: "",
+        total_cost_usd: 0,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.usage).not.toHaveProperty("cacheCreationInputTokens");
+  });
+
+  it("returns null costUsd when total_cost_usd is missing", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        session_id: "s",
+        result: "",
+        usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0 },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.costUsd).toBeNull();
+  });
+
+  it("returns null costUsd when total_cost_usd is not a finite number", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        session_id: "s",
+        result: "",
+        total_cost_usd: "not-a-number",
+        usage: { input_tokens: 1, output_tokens: 1, cache_read_input_tokens: 0 },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.costUsd).toBeNull();
+  });
+});
+
+// ============================================================================
+// parseClaudeStreamJson — skill invocation tracking
+// ============================================================================
+
+describe("parseClaudeStreamJson — skill invocations", () => {
+  it("records successful skill invocation when tool_result follows tool_use", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: {
+          content: [
+            { type: "tool_use", id: "tu-1", name: "Skill", input: { skill: "my-skill" } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "tool_result",
+        tool_use_id: "tu-1",
+        is_error: false,
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.skillInvocations).toHaveLength(1);
+    expect(result.skillInvocations[0]).toMatchObject({
+      skillName: "my-skill",
+      status: "success",
+    });
+    expect(result.skillInvocations[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("records error skill invocation when is_error is true", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: {
+          content: [
+            { type: "tool_use", id: "tu-2", name: "Skill", input: { skill: "failing-skill" } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "tool_result",
+        tool_use_id: "tu-2",
+        is_error: true,
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.skillInvocations[0]).toMatchObject({
+      skillName: "failing-skill",
+      status: "error",
+    });
+  });
+
+  it("records orphaned skill (no tool_result) as error", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: {
+          content: [
+            { type: "tool_use", id: "tu-orphan", name: "Skill", input: { skill: "orphan-skill" } },
+          ],
+        },
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.skillInvocations).toHaveLength(1);
+    expect(result.skillInvocations[0]).toMatchObject({
+      skillName: "orphan-skill",
+      status: "error",
+    });
+  });
+
+  it("does not track non-Skill tool_use blocks", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: {
+          content: [
+            { type: "tool_use", id: "tu-bash", name: "Bash", input: { command: "ls" } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "tool_result",
+        tool_use_id: "tu-bash",
+        is_error: false,
+      }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.skillInvocations).toHaveLength(0);
+  });
+
+  it("tracks multiple skill invocations independently", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: {
+          content: [
+            { type: "tool_use", id: "tu-a", name: "Skill", input: { skill: "skill-a" } },
+            { type: "tool_use", id: "tu-b", name: "Skill", input: { skill: "skill-b" } },
+          ],
+        },
+      }),
+      JSON.stringify({ type: "tool_result", tool_use_id: "tu-a", is_error: false }),
+      JSON.stringify({ type: "tool_result", tool_use_id: "tu-b", is_error: true }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.skillInvocations).toHaveLength(2);
+    const skillA = result.skillInvocations.find((s) => s.skillName === "skill-a");
+    const skillB = result.skillInvocations.find((s) => s.skillName === "skill-b");
+    expect(skillA?.status).toBe("success");
+    expect(skillB?.status).toBe("error");
+  });
+
+  it("uses 'unknown' as skill name when skill input is missing", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s",
+        message: {
+          content: [
+            { type: "tool_use", id: "tu-x", name: "Skill", input: {} },
+          ],
+        },
+      }),
+      JSON.stringify({ type: "tool_result", tool_use_id: "tu-x", is_error: false }),
+    ];
+    const result = parseClaudeStreamJson(lines.join("\n"));
+    expect(result.skillInvocations[0].skillName).toBe("unknown");
+  });
+});
+
+// ============================================================================
+// extractClaudeLoginUrl
+// ============================================================================
+
+describe("extractClaudeLoginUrl", () => {
+  it("returns null for empty string", () => {
+    expect(extractClaudeLoginUrl("")).toBeNull();
+  });
+
+  it("returns null when no URLs present", () => {
+    expect(extractClaudeLoginUrl("please run claude login to continue")).toBeNull();
+  });
+
+  it("extracts anthropic URL from text", () => {
+    const text = "Please visit https://claude.ai/auth/login to authenticate";
+    const url = extractClaudeLoginUrl(text);
+    expect(url).toContain("claude.ai");
+  });
+
+  it("extracts auth URL from text", () => {
+    const text = "Open https://auth.example.com/login?token=abc to continue";
+    const url = extractClaudeLoginUrl(text);
+    expect(url).toContain("auth.example.com");
+  });
+
+  it("returns first URL when no auth/claude/anthropic URL found", () => {
+    const text = "Visit https://example.com/page for more info";
+    const url = extractClaudeLoginUrl(text);
+    expect(url).toContain("example.com");
+  });
+
+  it("strips trailing punctuation from URL", () => {
+    const text = "See https://claude.ai/login.";
+    const url = extractClaudeLoginUrl(text);
+    expect(url).not.toMatch(/\.$/);
+  });
+});
+
+// ============================================================================
+// detectClaudeLoginRequired
+// ============================================================================
+
+describe("detectClaudeLoginRequired", () => {
+  it("returns requiresLogin=false for normal output", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: { result: "Task complete" },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(false);
+  });
+
+  it("detects 'not logged in' in result text", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: { result: "Error: not logged in" },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(true);
+  });
+
+  it("detects 'please run `claude login`' in stdout", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: null,
+      stdout: "please run `claude login` to authenticate",
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(true);
+  });
+
+  it("detects 'Authentication required' in stderr", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: null,
+      stdout: "",
+      stderr: "Authentication required",
+    });
+    expect(result.requiresLogin).toBe(true);
+  });
+
+  it("detects 'unauthorized' in error messages", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: { errors: ["unauthorized"] },
+      stdout: "",
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(true);
+  });
+
+  it("extracts loginUrl from stdout when requiresLogin is true", () => {
+    const result = detectClaudeLoginRequired({
+      parsed: { result: "not logged in" },
+      stdout: "Visit https://claude.ai/auth to login",
+      stderr: "",
+    });
+    expect(result.requiresLogin).toBe(true);
+    expect(result.loginUrl).toContain("claude.ai");
+  });
+});
+
+// ============================================================================
+// detectClaudeRateLimited
+// ============================================================================
+
+describe("detectClaudeRateLimited", () => {
+  it("returns false for normal output", () => {
+    expect(
+      detectClaudeRateLimited({ parsed: { result: "done" }, stdout: "", stderr: "" })
+    ).toBe(false);
+  });
+
+  it("detects rate_limit_event in stdout JSON line", () => {
+    const line = JSON.stringify({ type: "rate_limit_event" });
+    expect(
+      detectClaudeRateLimited({ parsed: null, stdout: line, stderr: "" })
+    ).toBe(true);
+  });
+
+  it("detects rate_limit_info in stdout JSON line", () => {
+    const line = JSON.stringify({ type: "other", rate_limit_info: { reset_at: "2026-01-01" } });
+    expect(
+      detectClaudeRateLimited({ parsed: null, stdout: line, stderr: "" })
+    ).toBe(true);
+  });
+
+  it("detects 'too many requests' in result text", () => {
+    expect(
+      detectClaudeRateLimited({
+        parsed: { result: "Error: too many requests" },
+        stdout: "",
+        stderr: "",
+      })
+    ).toBe(true);
+  });
+
+  it("detects 'quota exceeded' in stderr", () => {
+    expect(
+      detectClaudeRateLimited({ parsed: null, stdout: "", stderr: "quota exceeded" })
+    ).toBe(true);
+  });
+
+  it("detects '429' in any message", () => {
+    expect(
+      detectClaudeRateLimited({ parsed: null, stdout: "HTTP 429 error", stderr: "" })
+    ).toBe(true);
+  });
+
+  it("detects 'usage limit reached'", () => {
+    expect(
+      detectClaudeRateLimited({ parsed: { result: "usage limit reached" }, stdout: "", stderr: "" })
+    ).toBe(true);
+  });
+
+  it("detects 'out of extra usage'", () => {
+    expect(
+      detectClaudeRateLimited({ parsed: null, stdout: "out of extra usage for this period", stderr: "" })
+    ).toBe(true);
+  });
+});
+
+// ============================================================================
+// describeClaudeFailure
+// ============================================================================
+
+describe("describeClaudeFailure", () => {
+  it("returns null when no meaningful info present", () => {
+    expect(describeClaudeFailure({ result: "", subtype: "" })).toBeNull();
+  });
+
+  it("returns message with subtype", () => {
+    const msg = describeClaudeFailure({ subtype: "timeout", result: "" });
+    expect(msg).toContain("subtype=timeout");
+  });
+
+  it("includes result text in message", () => {
+    const msg = describeClaudeFailure({ result: "something went wrong", subtype: "" });
+    expect(msg).toContain("something went wrong");
+  });
+
+  it("falls back to error messages when result is empty", () => {
+    const msg = describeClaudeFailure({ result: "", subtype: "", errors: ["network error"] });
+    expect(msg).toContain("network error");
+  });
+
+  it("includes both subtype and detail", () => {
+    const msg = describeClaudeFailure({ subtype: "error_max_turns", result: "Max turns reached" });
+    expect(msg).toContain("subtype=error_max_turns");
+    expect(msg).toContain("Max turns reached");
+  });
+});
+
+// ============================================================================
+// isClaudeMaxTurnsResult
+// ============================================================================
+
+describe("isClaudeMaxTurnsResult", () => {
+  it("returns false for null", () => {
+    expect(isClaudeMaxTurnsResult(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isClaudeMaxTurnsResult(undefined)).toBe(false);
+  });
+
+  it("returns true for subtype=error_max_turns", () => {
+    expect(isClaudeMaxTurnsResult({ subtype: "error_max_turns" })).toBe(true);
+  });
+
+  it("returns true for stop_reason=max_turns", () => {
+    expect(isClaudeMaxTurnsResult({ stop_reason: "max_turns" })).toBe(true);
+  });
+
+  it("returns true when result text contains 'max turns'", () => {
+    expect(isClaudeMaxTurnsResult({ result: "Reached max turns limit" })).toBe(true);
+  });
+
+  it("returns true when result text contains 'maximum turns'", () => {
+    expect(isClaudeMaxTurnsResult({ result: "exceeded maximum turns" })).toBe(true);
+  });
+
+  it("returns false for normal result", () => {
+    expect(isClaudeMaxTurnsResult({ subtype: "success", result: "done" })).toBe(false);
+  });
+
+  it("is case-insensitive for subtype", () => {
+    expect(isClaudeMaxTurnsResult({ subtype: "ERROR_MAX_TURNS" })).toBe(true);
+  });
+});
+
+// ============================================================================
+// isClaudeUnknownSessionError
+// ============================================================================
+
+describe("isClaudeUnknownSessionError", () => {
+  it("returns false for normal result", () => {
+    expect(isClaudeUnknownSessionError({ result: "Task complete" })).toBe(false);
+  });
+
+  it("detects 'no conversation found with session id'", () => {
+    expect(
+      isClaudeUnknownSessionError({ result: "no conversation found with session id abc123" })
+    ).toBe(true);
+  });
+
+  it("detects 'unknown session'", () => {
+    expect(isClaudeUnknownSessionError({ result: "unknown session" })).toBe(true);
+  });
+
+  it("detects 'session not found' pattern", () => {
+    expect(isClaudeUnknownSessionError({ result: "session abc123 not found" })).toBe(true);
+  });
+
+  it("checks error messages array in addition to result", () => {
+    expect(
+      isClaudeUnknownSessionError({ result: "", errors: ["unknown session xyz"] })
+    ).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isClaudeUnknownSessionError({ result: "No Conversation Found With Session Id XYZ" })).toBe(true);
+  });
+});

--- a/packages/adapters/claude-local/src/ui/build-config.test.ts
+++ b/packages/adapters/claude-local/src/ui/build-config.test.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from "vitest";
+import { buildClaudeLocalConfig } from "./build-config.js";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function base(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "claude_local",
+    cwd: "",
+    instructionsFilePath: "",
+    promptTemplate: "",
+    bootstrapPrompt: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: false,
+    dangerouslySkipPermissions: false,
+    envVars: "",
+    envBindings: {},
+    url: "",
+    args: "",
+    extraArgs: "",
+    maxTurnsPerRun: 10,
+    heartbeatEnabled: false,
+    intervalSec: 60,
+    adapterFallbackChain: [],
+    fallbackToCodexOnRateLimit: false,
+    workspaceStrategyType: "",
+    workspaceBaseRef: "",
+    workspaceBranchTemplate: "",
+    worktreeParentDir: "",
+    runtimeServicesJson: "",
+    command: "",
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Always-set fields
+// ============================================================================
+
+describe("buildClaudeLocalConfig — always-set fields", () => {
+  it("always sets timeoutSec to 0", () => {
+    const config = buildClaudeLocalConfig(base());
+    expect(config.timeoutSec).toBe(0);
+  });
+
+  it("always sets graceSec to 15", () => {
+    const config = buildClaudeLocalConfig(base());
+    expect(config.graceSec).toBe(15);
+  });
+
+  it("always includes maxTurnsPerRun", () => {
+    const config = buildClaudeLocalConfig(base({ maxTurnsPerRun: 25 }));
+    expect(config.maxTurnsPerRun).toBe(25);
+  });
+
+  it("always includes dangerouslySkipPermissions", () => {
+    const config = buildClaudeLocalConfig(base({ dangerouslySkipPermissions: true }));
+    expect(config.dangerouslySkipPermissions).toBe(true);
+  });
+});
+
+// ============================================================================
+// Conditional fields — only set when truthy
+// ============================================================================
+
+describe("buildClaudeLocalConfig — conditional fields", () => {
+  it("sets cwd when provided", () => {
+    const config = buildClaudeLocalConfig(base({ cwd: "/home/user/project" }));
+    expect(config.cwd).toBe("/home/user/project");
+  });
+
+  it("omits cwd when empty", () => {
+    const config = buildClaudeLocalConfig(base({ cwd: "" }));
+    expect(config).not.toHaveProperty("cwd");
+  });
+
+  it("sets model when provided", () => {
+    const config = buildClaudeLocalConfig(base({ model: "claude-opus-4-6" }));
+    expect(config.model).toBe("claude-opus-4-6");
+  });
+
+  it("omits model when empty", () => {
+    const config = buildClaudeLocalConfig(base({ model: "" }));
+    expect(config).not.toHaveProperty("model");
+  });
+
+  it("maps thinkingEffort to effort", () => {
+    const config = buildClaudeLocalConfig(base({ thinkingEffort: "high" }));
+    expect(config.effort).toBe("high");
+  });
+
+  it("omits effort when thinkingEffort is empty", () => {
+    const config = buildClaudeLocalConfig(base({ thinkingEffort: "" }));
+    expect(config).not.toHaveProperty("effort");
+  });
+
+  it("sets chrome: true when chrome is truthy", () => {
+    const config = buildClaudeLocalConfig(base({ chrome: true }));
+    expect(config.chrome).toBe(true);
+  });
+
+  it("omits chrome when falsy", () => {
+    const config = buildClaudeLocalConfig(base({ chrome: false }));
+    expect(config).not.toHaveProperty("chrome");
+  });
+
+  it("sets instructionsFilePath when provided", () => {
+    const config = buildClaudeLocalConfig(base({ instructionsFilePath: "/path/to/instructions.md" }));
+    expect(config.instructionsFilePath).toBe("/path/to/instructions.md");
+  });
+
+  it("sets promptTemplate when provided", () => {
+    const config = buildClaudeLocalConfig(base({ promptTemplate: "Do {{task}}" }));
+    expect(config.promptTemplate).toBe("Do {{task}}");
+  });
+
+  it("maps bootstrapPrompt to bootstrapPromptTemplate", () => {
+    const config = buildClaudeLocalConfig(base({ bootstrapPrompt: "Bootstrap me" }));
+    expect(config.bootstrapPromptTemplate).toBe("Bootstrap me");
+  });
+
+  it("sets command when provided", () => {
+    const config = buildClaudeLocalConfig(base({ command: "/usr/local/bin/claude" }));
+    expect(config.command).toBe("/usr/local/bin/claude");
+  });
+
+  it("parses extraArgs as comma-separated list", () => {
+    const config = buildClaudeLocalConfig(base({ extraArgs: "--verbose, --debug, --no-color" }));
+    expect(config.extraArgs).toEqual(["--verbose", "--debug", "--no-color"]);
+  });
+
+  it("omits extraArgs when empty", () => {
+    const config = buildClaudeLocalConfig(base({ extraArgs: "" }));
+    expect(config).not.toHaveProperty("extraArgs");
+  });
+});
+
+// ============================================================================
+// envVars parsing
+// ============================================================================
+
+describe("buildClaudeLocalConfig — envVars (legacy)", () => {
+  it("parses KEY=VALUE pairs", () => {
+    const config = buildClaudeLocalConfig(base({ envVars: "FOO=bar\nBAZ=qux" }));
+    const env = config.env as Record<string, unknown>;
+    expect(env).toBeDefined();
+    expect(env["FOO"]).toEqual({ type: "plain", value: "bar" });
+    expect(env["BAZ"]).toEqual({ type: "plain", value: "qux" });
+  });
+
+  it("preserves value with equals sign", () => {
+    const config = buildClaudeLocalConfig(base({ envVars: "TOKEN=abc=def=ghi" }));
+    const env = config.env as Record<string, { value: string }>;
+    expect(env["TOKEN"].value).toBe("abc=def=ghi");
+  });
+
+  it("ignores comment lines starting with #", () => {
+    const config = buildClaudeLocalConfig(base({ envVars: "# comment\nFOO=1" }));
+    const env = config.env as Record<string, unknown>;
+    expect(env).not.toHaveProperty("# comment");
+    expect(env["FOO"]).toBeDefined();
+  });
+
+  it("ignores blank lines in envVars", () => {
+    const config = buildClaudeLocalConfig(base({ envVars: "\n\nFOO=1\n\n" }));
+    const env = config.env as Record<string, unknown>;
+    expect(Object.keys(env)).toHaveLength(1);
+  });
+
+  it("ignores entries with invalid key names", () => {
+    const config = buildClaudeLocalConfig(base({ envVars: "123BAD=value\nGOOD_KEY=ok" }));
+    const env = config.env as Record<string, unknown>;
+    expect(env).not.toHaveProperty("123BAD");
+    expect(env["GOOD_KEY"]).toBeDefined();
+  });
+
+  it("omits env field when envVars is empty and no envBindings", () => {
+    const config = buildClaudeLocalConfig(base({ envVars: "", envBindings: {} }));
+    expect(config).not.toHaveProperty("env");
+  });
+});
+
+// ============================================================================
+// envBindings (structured)
+// ============================================================================
+
+describe("buildClaudeLocalConfig — envBindings", () => {
+  it("stores plain string bindings as plain type", () => {
+    const config = buildClaudeLocalConfig(base({ envBindings: { MY_VAR: "my-value" } }));
+    const env = config.env as Record<string, unknown>;
+    expect(env["MY_VAR"]).toEqual({ type: "plain", value: "my-value" });
+  });
+
+  it("stores plain object bindings unchanged", () => {
+    const config = buildClaudeLocalConfig(
+      base({ envBindings: { MY_VAR: { type: "plain", value: "structured" } } })
+    );
+    const env = config.env as Record<string, unknown>;
+    expect(env["MY_VAR"]).toEqual({ type: "plain", value: "structured" });
+  });
+
+  it("stores secret_ref bindings with secretId", () => {
+    const config = buildClaudeLocalConfig(
+      base({
+        envBindings: {
+          API_KEY: { type: "secret_ref", secretId: "secret-abc", version: "latest" },
+        },
+      })
+    );
+    const env = config.env as Record<string, unknown>;
+    expect(env["API_KEY"]).toEqual({ type: "secret_ref", secretId: "secret-abc", version: "latest" });
+  });
+
+  it("envBindings take priority over envVars for same key", () => {
+    const config = buildClaudeLocalConfig(
+      base({
+        envBindings: { FOO: { type: "plain", value: "from-bindings" } },
+        envVars: "FOO=from-legacy",
+      })
+    );
+    const env = config.env as Record<string, { value: string }>;
+    expect(env["FOO"].value).toBe("from-bindings");
+  });
+
+  it("ignores bindings with invalid key names", () => {
+    const config = buildClaudeLocalConfig(base({ envBindings: { "123BAD": "value" } }));
+    const env = config.env as Record<string, unknown> | undefined;
+    expect(env).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// adapterFallbackChain / rateLimitFallback
+// ============================================================================
+
+describe("buildClaudeLocalConfig — fallback chain", () => {
+  it("sets adapterFallbackChain when provided", () => {
+    const chain = [{ adapterType: "codex_local" }];
+    const config = buildClaudeLocalConfig(base({ adapterFallbackChain: chain }));
+    expect(config.adapterFallbackChain).toEqual(chain);
+  });
+
+  it("omits adapterFallbackChain when empty array", () => {
+    const config = buildClaudeLocalConfig(base({ adapterFallbackChain: [] }));
+    expect(config).not.toHaveProperty("adapterFallbackChain");
+  });
+
+  it("sets rateLimitFallback when fallbackToCodexOnRateLimit is true and no explicit chain", () => {
+    const config = buildClaudeLocalConfig(
+      base({ fallbackToCodexOnRateLimit: true, adapterFallbackChain: [] })
+    );
+    expect(config.rateLimitFallback).toEqual({ adapterType: "codex_local" });
+  });
+
+  it("does not set rateLimitFallback when adapterFallbackChain is provided", () => {
+    const config = buildClaudeLocalConfig(
+      base({
+        fallbackToCodexOnRateLimit: true,
+        adapterFallbackChain: [{ adapterType: "codex_local" }],
+      })
+    );
+    expect(config).not.toHaveProperty("rateLimitFallback");
+  });
+});
+
+// ============================================================================
+// workspaceStrategy
+// ============================================================================
+
+describe("buildClaudeLocalConfig — workspaceStrategy", () => {
+  it("sets git_worktree strategy when workspaceStrategyType is git_worktree", () => {
+    const config = buildClaudeLocalConfig(
+      base({
+        workspaceStrategyType: "git_worktree",
+        workspaceBaseRef: "main",
+        workspaceBranchTemplate: "agent/{{issue}}",
+        worktreeParentDir: "/tmp/worktrees",
+      })
+    );
+    expect(config.workspaceStrategy).toEqual({
+      type: "git_worktree",
+      baseRef: "main",
+      branchTemplate: "agent/{{issue}}",
+      worktreeParentDir: "/tmp/worktrees",
+    });
+  });
+
+  it("omits optional workspace fields when not set", () => {
+    const config = buildClaudeLocalConfig(
+      base({ workspaceStrategyType: "git_worktree" })
+    );
+    const ws = config.workspaceStrategy as Record<string, unknown>;
+    expect(ws.type).toBe("git_worktree");
+    expect(ws).not.toHaveProperty("baseRef");
+    expect(ws).not.toHaveProperty("branchTemplate");
+    expect(ws).not.toHaveProperty("worktreeParentDir");
+  });
+
+  it("omits workspaceStrategy when not git_worktree", () => {
+    const config = buildClaudeLocalConfig(base({ workspaceStrategyType: "" }));
+    expect(config).not.toHaveProperty("workspaceStrategy");
+  });
+});
+
+// ============================================================================
+// runtimeServicesJson
+// ============================================================================
+
+describe("buildClaudeLocalConfig — runtimeServicesJson", () => {
+  it("sets workspaceRuntime when valid JSON with services array", () => {
+    const services = { services: [{ type: "postgres", port: 5432 }] };
+    const config = buildClaudeLocalConfig(
+      base({ runtimeServicesJson: JSON.stringify(services) })
+    );
+    expect(config.workspaceRuntime).toEqual(services);
+  });
+
+  it("omits workspaceRuntime when runtimeServicesJson is empty", () => {
+    const config = buildClaudeLocalConfig(base({ runtimeServicesJson: "" }));
+    expect(config).not.toHaveProperty("workspaceRuntime");
+  });
+
+  it("omits workspaceRuntime when parsed object has no services array", () => {
+    const config = buildClaudeLocalConfig(
+      base({ runtimeServicesJson: JSON.stringify({ notServices: true }) })
+    );
+    expect(config).not.toHaveProperty("workspaceRuntime");
+  });
+
+  it("omits workspaceRuntime when JSON is invalid", () => {
+    const config = buildClaudeLocalConfig(base({ runtimeServicesJson: "not-json" }));
+    expect(config).not.toHaveProperty("workspaceRuntime");
+  });
+});

--- a/packages/adapters/cursor-local/src/server/parse.test.ts
+++ b/packages/adapters/cursor-local/src/server/parse.test.ts
@@ -1,0 +1,388 @@
+import { describe, expect, it } from "vitest";
+import { parseCursorJsonl, isCursorUnknownSessionError } from "./parse.js";
+
+// ============================================================================
+// parseCursorJsonl — empty / no result
+// ============================================================================
+
+describe("parseCursorJsonl — empty input", () => {
+  it("returns defaults for empty stdout", () => {
+    const result = parseCursorJsonl("");
+    expect(result.sessionId).toBeNull();
+    expect(result.summary).toBe("");
+    expect(result.costUsd).toBeNull();
+    expect(result.errorMessage).toBeNull();
+    expect(result.usage).toEqual({ inputTokens: 0, cachedInputTokens: 0, outputTokens: 0 });
+  });
+
+  it("returns defaults for whitespace-only stdout", () => {
+    const result = parseCursorJsonl("\n\n   \n");
+    expect(result.sessionId).toBeNull();
+    expect(result.summary).toBe("");
+  });
+
+  it("ignores non-JSON lines", () => {
+    const result = parseCursorJsonl("not json\nstill not json");
+    expect(result.sessionId).toBeNull();
+    expect(result.summary).toBe("");
+  });
+});
+
+// ============================================================================
+// parseCursorJsonl — session ID variants
+// ============================================================================
+
+describe("parseCursorJsonl — session ID extraction", () => {
+  it("reads session_id (snake_case)", () => {
+    const lines = [
+      JSON.stringify({ type: "assistant", session_id: "sess-snake", message: "hi" }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.sessionId).toBe("sess-snake");
+  });
+
+  it("reads sessionId (camelCase)", () => {
+    const lines = [
+      JSON.stringify({ type: "assistant", sessionId: "sess-camel", message: "hi" }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.sessionId).toBe("sess-camel");
+  });
+
+  it("reads sessionID (all caps ID)", () => {
+    const lines = [
+      JSON.stringify({ type: "assistant", sessionID: "sess-caps", message: "hi" }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.sessionId).toBe("sess-caps");
+  });
+
+  it("keeps first non-empty session ID when multiple events arrive", () => {
+    const lines = [
+      JSON.stringify({ type: "assistant", session_id: "first", message: "hi" }),
+      JSON.stringify({ type: "assistant", session_id: "second", message: "bye" }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.sessionId).toBe("second"); // last non-empty wins
+  });
+});
+
+// ============================================================================
+// parseCursorJsonl — assistant text accumulation
+// ============================================================================
+
+describe("parseCursorJsonl — assistant text", () => {
+  it("collects string message", () => {
+    const lines = [
+      JSON.stringify({ type: "assistant", message: "Hello world" }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.summary).toBe("Hello world");
+  });
+
+  it("collects message.text from object message", () => {
+    const lines = [
+      JSON.stringify({ type: "assistant", message: { text: "Direct text" } }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.summary).toBe("Direct text");
+  });
+
+  it("collects output_text content parts", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "output_text", text: "Content text" }] },
+      }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.summary).toBe("Content text");
+  });
+
+  it("collects text content parts", () => {
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Text part" }] },
+      }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.summary).toBe("Text part");
+  });
+
+  it("joins multiple messages with double newlines", () => {
+    const lines = [
+      JSON.stringify({ type: "assistant", message: "First" }),
+      JSON.stringify({ type: "assistant", message: "Second" }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.summary).toBe("First\n\nSecond");
+  });
+
+  it("uses result.result text as summary when no assistant messages", () => {
+    const lines = [
+      JSON.stringify({ type: "result", result: "Final result", usage: {} }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.summary).toBe("Final result");
+  });
+
+  it("does not include result.result when assistant messages already present", () => {
+    const lines = [
+      JSON.stringify({ type: "assistant", message: "Intermediate" }),
+      JSON.stringify({ type: "result", result: "ignored", usage: {} }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.summary).toBe("Intermediate");
+  });
+});
+
+// ============================================================================
+// parseCursorJsonl — usage accumulation
+// ============================================================================
+
+describe("parseCursorJsonl — usage tokens", () => {
+  it("reads snake_case token fields from result event", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_input_tokens: 20,
+        },
+      }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.usage).toEqual({ inputTokens: 100, outputTokens: 50, cachedInputTokens: 20 });
+  });
+
+  it("reads camelCase token fields as fallback", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        usage: {
+          inputTokens: 80,
+          outputTokens: 40,
+          cachedInputTokens: 10,
+        },
+      }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.usage).toEqual({ inputTokens: 80, outputTokens: 40, cachedInputTokens: 10 });
+  });
+
+  it("reads cache_read_input_tokens as fallback for cachedInputTokens", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_read_input_tokens: 3,
+        },
+      }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.usage.cachedInputTokens).toBe(3);
+  });
+
+  it("accumulates tokens from multiple result events", () => {
+    const lines = [
+      JSON.stringify({ type: "result", usage: { input_tokens: 50, output_tokens: 20, cache_read_input_tokens: 5 } }),
+      JSON.stringify({ type: "result", usage: { input_tokens: 30, output_tokens: 10, cache_read_input_tokens: 0 } }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.usage).toEqual({ inputTokens: 80, outputTokens: 30, cachedInputTokens: 5 });
+  });
+
+  it("accumulates tokens from step_finish events", () => {
+    const lines = [
+      JSON.stringify({
+        type: "step_finish",
+        part: { tokens: { input: 40, output: 15, cache: { read: 8 } }, cost: 0.001 },
+      }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.usage.inputTokens).toBe(40);
+    expect(result.usage.outputTokens).toBe(15);
+    expect(result.usage.cachedInputTokens).toBe(8);
+  });
+});
+
+// ============================================================================
+// parseCursorJsonl — cost
+// ============================================================================
+
+describe("parseCursorJsonl — cost", () => {
+  it("reads total_cost_usd from result event", () => {
+    const lines = [
+      JSON.stringify({ type: "result", total_cost_usd: 0.0042, usage: {} }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.costUsd).toBe(0.0042);
+  });
+
+  it("reads cost_usd as fallback", () => {
+    const lines = [
+      JSON.stringify({ type: "result", cost_usd: 0.001, usage: {} }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.costUsd).toBe(0.001);
+  });
+
+  it("reads cost as second fallback", () => {
+    const lines = [
+      JSON.stringify({ type: "result", cost: 0.0005, usage: {} }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.costUsd).toBe(0.0005);
+  });
+
+  it("accumulates cost from step_finish events", () => {
+    const lines = [
+      JSON.stringify({ type: "step_finish", part: { tokens: {}, cost: 0.002 } }),
+      JSON.stringify({ type: "step_finish", part: { tokens: {}, cost: 0.003 } }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.costUsd).toBeCloseTo(0.005);
+  });
+
+  it("returns null costUsd when no cost found", () => {
+    const lines = [
+      JSON.stringify({ type: "result", usage: {} }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.costUsd).toBeNull();
+  });
+});
+
+// ============================================================================
+// parseCursorJsonl — error handling
+// ============================================================================
+
+describe("parseCursorJsonl — error message extraction", () => {
+  it("captures error message from is_error result event", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        is_error: true,
+        error: "Rate limit exceeded",
+        usage: {},
+      }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.errorMessage).toBe("Rate limit exceeded");
+  });
+
+  it("captures error from subtype=error result event", () => {
+    const lines = [
+      JSON.stringify({
+        type: "result",
+        subtype: "error",
+        message: "Something went wrong",
+        usage: {},
+      }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.errorMessage).toBe("Something went wrong");
+  });
+
+  it("captures error message from type=error event", () => {
+    const lines = [
+      JSON.stringify({ type: "error", message: "Connection failed" }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.errorMessage).toBe("Connection failed");
+  });
+
+  it("captures error message from type=system subtype=error event", () => {
+    const lines = [
+      JSON.stringify({ type: "system", subtype: "error", message: "System crashed" }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.errorMessage).toBe("System crashed");
+  });
+
+  it("returns null errorMessage for successful run", () => {
+    const lines = [
+      JSON.stringify({ type: "result", result: "done", usage: {} }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.errorMessage).toBeNull();
+  });
+});
+
+// ============================================================================
+// parseCursorJsonl — legacy event shapes
+// ============================================================================
+
+describe("parseCursorJsonl — legacy event shapes", () => {
+  it("reads text from type=text event part", () => {
+    const lines = [
+      JSON.stringify({ type: "text", part: { text: "Legacy text" } }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.summary).toBe("Legacy text");
+  });
+
+  it("accumulates tokens from step_finish event", () => {
+    const lines = [
+      JSON.stringify({
+        type: "step_finish",
+        part: {
+          reason: "stop",
+          tokens: { input: 100, output: 50, cache: { read: 10 } },
+          cost: 0.001,
+        },
+      }),
+    ];
+    const result = parseCursorJsonl(lines.join("\n"));
+    expect(result.usage.inputTokens).toBe(100);
+    expect(result.usage.outputTokens).toBe(50);
+    expect(result.usage.cachedInputTokens).toBe(10);
+    expect(result.costUsd).toBe(0.001);
+  });
+});
+
+// ============================================================================
+// isCursorUnknownSessionError
+// ============================================================================
+
+describe("isCursorUnknownSessionError", () => {
+  it("returns false for normal output", () => {
+    expect(isCursorUnknownSessionError("All good", "")).toBe(false);
+  });
+
+  it("detects 'unknown session' in stdout", () => {
+    expect(isCursorUnknownSessionError("unknown session abc123", "")).toBe(true);
+  });
+
+  it("detects 'unknown chat' in stdout", () => {
+    expect(isCursorUnknownSessionError("unknown chat xyz", "")).toBe(true);
+  });
+
+  it("detects 'session not found' in stderr", () => {
+    expect(isCursorUnknownSessionError("", "session abc not found")).toBe(true);
+  });
+
+  it("detects 'chat not found' in stderr", () => {
+    expect(isCursorUnknownSessionError("", "chat def not found")).toBe(true);
+  });
+
+  it("detects 'resume not found' pattern", () => {
+    expect(isCursorUnknownSessionError("resume abc123 not found", "")).toBe(true);
+  });
+
+  it("detects 'could not resume' pattern", () => {
+    expect(isCursorUnknownSessionError("could not resume previous session", "")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isCursorUnknownSessionError("Unknown Session XYZ", "")).toBe(true);
+  });
+
+  it("returns false for empty strings", () => {
+    expect(isCursorUnknownSessionError("", "")).toBe(false);
+  });
+});

--- a/packages/adapters/cursor-local/src/ui/build-config.test.ts
+++ b/packages/adapters/cursor-local/src/ui/build-config.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import { buildCursorLocalConfig } from "./build-config.js";
+import { DEFAULT_CURSOR_LOCAL_MODEL } from "../index.js";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+
+function base(overrides: Partial<CreateConfigValues> = {}): CreateConfigValues {
+  return {
+    adapterType: "cursor_local",
+    cwd: "",
+    instructionsFilePath: "",
+    promptTemplate: "",
+    bootstrapPrompt: "",
+    model: "",
+    thinkingEffort: "",
+    chrome: false,
+    search: false,
+    fastMode: false,
+    dangerouslyBypassSandbox: false,
+    dangerouslySkipPermissions: false,
+    envVars: "",
+    envBindings: {},
+    url: "",
+    args: "",
+    extraArgs: "",
+    maxTurnsPerRun: 10,
+    heartbeatEnabled: false,
+    intervalSec: 60,
+    adapterFallbackChain: [],
+    fallbackToCodexOnRateLimit: false,
+    command: "",
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Always-set fields
+// ============================================================================
+
+describe("buildCursorLocalConfig — always-set fields", () => {
+  it("always sets timeoutSec to 0", () => {
+    const config = buildCursorLocalConfig(base());
+    expect(config.timeoutSec).toBe(0);
+  });
+
+  it("always sets graceSec to 15", () => {
+    const config = buildCursorLocalConfig(base());
+    expect(config.graceSec).toBe(15);
+  });
+
+  it("uses DEFAULT_CURSOR_LOCAL_MODEL when model is empty", () => {
+    const config = buildCursorLocalConfig(base({ model: "" }));
+    expect(config.model).toBe(DEFAULT_CURSOR_LOCAL_MODEL);
+  });
+
+  it("uses the provided model when set", () => {
+    const config = buildCursorLocalConfig(base({ model: "gpt-5.3-codex" }));
+    expect(config.model).toBe("gpt-5.3-codex");
+  });
+});
+
+// ============================================================================
+// mode normalization (thinkingEffort → mode)
+// ============================================================================
+
+describe("buildCursorLocalConfig — mode normalization", () => {
+  it("sets mode to 'plan' for thinkingEffort=plan", () => {
+    const config = buildCursorLocalConfig(base({ thinkingEffort: "plan" }));
+    expect(config.mode).toBe("plan");
+  });
+
+  it("sets mode to 'ask' for thinkingEffort=ask", () => {
+    const config = buildCursorLocalConfig(base({ thinkingEffort: "ask" }));
+    expect(config.mode).toBe("ask");
+  });
+
+  it("normalizes uppercase PLAN to plan", () => {
+    const config = buildCursorLocalConfig(base({ thinkingEffort: "PLAN" }));
+    expect(config.mode).toBe("plan");
+  });
+
+  it("normalizes mixed-case Ask to ask", () => {
+    const config = buildCursorLocalConfig(base({ thinkingEffort: "Ask" }));
+    expect(config.mode).toBe("ask");
+  });
+
+  it("omits mode for unknown thinkingEffort value", () => {
+    const config = buildCursorLocalConfig(base({ thinkingEffort: "high" }));
+    expect(config).not.toHaveProperty("mode");
+  });
+
+  it("omits mode when thinkingEffort is empty", () => {
+    const config = buildCursorLocalConfig(base({ thinkingEffort: "" }));
+    expect(config).not.toHaveProperty("mode");
+  });
+});
+
+// ============================================================================
+// Conditional fields
+// ============================================================================
+
+describe("buildCursorLocalConfig — conditional fields", () => {
+  it("sets cwd when provided", () => {
+    const config = buildCursorLocalConfig(base({ cwd: "/home/user/project" }));
+    expect(config.cwd).toBe("/home/user/project");
+  });
+
+  it("omits cwd when empty", () => {
+    const config = buildCursorLocalConfig(base({ cwd: "" }));
+    expect(config).not.toHaveProperty("cwd");
+  });
+
+  it("sets instructionsFilePath when provided", () => {
+    const config = buildCursorLocalConfig(base({ instructionsFilePath: "/path/to/instructions.md" }));
+    expect(config.instructionsFilePath).toBe("/path/to/instructions.md");
+  });
+
+  it("sets promptTemplate when provided", () => {
+    const config = buildCursorLocalConfig(base({ promptTemplate: "Do {{task}}" }));
+    expect(config.promptTemplate).toBe("Do {{task}}");
+  });
+
+  it("maps bootstrapPrompt to bootstrapPromptTemplate", () => {
+    const config = buildCursorLocalConfig(base({ bootstrapPrompt: "Bootstrap me" }));
+    expect(config.bootstrapPromptTemplate).toBe("Bootstrap me");
+  });
+
+  it("sets command when provided", () => {
+    const config = buildCursorLocalConfig(base({ command: "/usr/local/bin/cursor" }));
+    expect(config.command).toBe("/usr/local/bin/cursor");
+  });
+
+  it("parses extraArgs as comma-separated list", () => {
+    const config = buildCursorLocalConfig(base({ extraArgs: "--verbose, --debug" }));
+    expect(config.extraArgs).toEqual(["--verbose", "--debug"]);
+  });
+
+  it("omits extraArgs when empty", () => {
+    const config = buildCursorLocalConfig(base({ extraArgs: "" }));
+    expect(config).not.toHaveProperty("extraArgs");
+  });
+});
+
+// ============================================================================
+// envVars / envBindings
+// ============================================================================
+
+describe("buildCursorLocalConfig — environment variables", () => {
+  it("parses KEY=VALUE pairs from envVars", () => {
+    const config = buildCursorLocalConfig(base({ envVars: "FOO=bar\nBAZ=qux" }));
+    const env = config.env as Record<string, unknown>;
+    expect(env["FOO"]).toEqual({ type: "plain", value: "bar" });
+    expect(env["BAZ"]).toEqual({ type: "plain", value: "qux" });
+  });
+
+  it("ignores comment lines in envVars", () => {
+    const config = buildCursorLocalConfig(base({ envVars: "# comment\nFOO=1" }));
+    const env = config.env as Record<string, unknown>;
+    expect(Object.keys(env)).toHaveLength(1);
+    expect(env["FOO"]).toBeDefined();
+  });
+
+  it("envBindings take priority over envVars for same key", () => {
+    const config = buildCursorLocalConfig(
+      base({
+        envBindings: { FOO: { type: "plain", value: "from-bindings" } },
+        envVars: "FOO=from-legacy",
+      })
+    );
+    const env = config.env as Record<string, { value: string }>;
+    expect(env["FOO"].value).toBe("from-bindings");
+  });
+
+  it("stores secret_ref binding", () => {
+    const config = buildCursorLocalConfig(
+      base({
+        envBindings: {
+          API_KEY: { type: "secret_ref", secretId: "secret-abc" },
+        },
+      })
+    );
+    const env = config.env as Record<string, unknown>;
+    expect(env["API_KEY"]).toEqual({ type: "secret_ref", secretId: "secret-abc" });
+  });
+
+  it("omits env field when no variables set", () => {
+    const config = buildCursorLocalConfig(base({ envVars: "", envBindings: {} }));
+    expect(config).not.toHaveProperty("env");
+  });
+});
+
+// ============================================================================
+// adapterFallbackChain
+// ============================================================================
+
+describe("buildCursorLocalConfig — adapterFallbackChain", () => {
+  it("sets adapterFallbackChain when provided", () => {
+    const chain = [{ adapterType: "claude_local" }];
+    const config = buildCursorLocalConfig(base({ adapterFallbackChain: chain }));
+    expect(config.adapterFallbackChain).toEqual(chain);
+  });
+
+  it("omits adapterFallbackChain when empty array", () => {
+    const config = buildCursorLocalConfig(base({ adapterFallbackChain: [] }));
+    expect(config).not.toHaveProperty("adapterFallbackChain");
+  });
+
+  it("does not set rateLimitFallback even when fallbackToCodexOnRateLimit is true", () => {
+    // cursor-local does not support rateLimitFallback (unlike claude-local)
+    const config = buildCursorLocalConfig(
+      base({ fallbackToCodexOnRateLimit: true, adapterFallbackChain: [] })
+    );
+    expect(config).not.toHaveProperty("rateLimitFallback");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 168 unit tests across 4 new files for previously untested adapter code
- **`claude-local/src/server/parse.test.ts`** (62 tests): covers `parseClaudeStreamJson` (session extraction, text accumulation, usage/cost parsing, skill invocation tracking), detection helpers (`detectClaudeLoginRequired`, `detectClaudeRateLimited`, `extractClaudeLoginUrl`), and classification helpers (`describeClaudeFailure`, `isClaudeMaxTurnsResult`, `isClaudeUnknownSessionError`)
- **`claude-local/src/ui/build-config.test.ts`** (40 tests): covers `buildClaudeLocalConfig` including always-set fields, conditional fields, env var/binding parsing, priority rules, workspace strategy, runtimeServicesJson, and fallback chain variants
- **`cursor-local/src/server/parse.test.ts`** (40 tests): covers `parseCursorJsonl` with session ID variant normalization, assistant text accumulation, usage accumulation across snake_case/camelCase fields and legacy `step_finish` events, error extraction, and `isCursorUnknownSessionError`
- **`cursor-local/src/ui/build-config.test.ts`** (26 tests): covers `buildCursorLocalConfig` including `DEFAULT_CURSOR_LOCAL_MODEL` fallback, `thinkingEffort` → `mode` normalization (plan/ask/unknown/empty), env parsing, and absence of `rateLimitFallback`

## Test plan

- [x] All 168 tests pass locally (`vitest run`)
- [ ] CI verify job passes (coverage thresholds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)