### PR TITLE
test(plugins/sdk): 32 unit tests for createPluginBundlerPresets

### DIFF
--- a/packages/adapters/cursor-local/src/shared/stream.test.ts
+++ b/packages/adapters/cursor-local/src/shared/stream.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCursorStreamLine } from "./stream.js";
+
+describe("normalizeCursorStreamLine", () => {
+  it("returns empty line and null stream for empty string", () => {
+    expect(normalizeCursorStreamLine("")).toEqual({ stream: null, line: "" });
+  });
+
+  it("returns empty line and null stream for whitespace-only string", () => {
+    expect(normalizeCursorStreamLine("   ")).toEqual({ stream: null, line: "" });
+  });
+
+  it("returns trimmed line with null stream for plain JSON", () => {
+    const result = normalizeCursorStreamLine('{"type":"result"}');
+    expect(result.stream).toBeNull();
+    expect(result.line).toBe('{"type":"result"}');
+  });
+
+  it("strips stdout: prefix and returns stdout stream", () => {
+    const result = normalizeCursorStreamLine('stdout: {"type":"text"}');
+    expect(result.stream).toBe("stdout");
+    expect(result.line).toBe('{"type":"text"}');
+  });
+
+  it("strips stderr: prefix and returns stderr stream", () => {
+    const result = normalizeCursorStreamLine('stderr: {"type":"error"}');
+    expect(result.stream).toBe("stderr");
+    expect(result.line).toBe('{"type":"error"}');
+  });
+
+  it("strips stdout= prefix (equals sign variant)", () => {
+    const result = normalizeCursorStreamLine('stdout= {"type":"result"}');
+    expect(result.stream).toBe("stdout");
+  });
+
+  it("handles case-insensitive STDOUT prefix", () => {
+    const result = normalizeCursorStreamLine('STDOUT: {"type":"ok"}');
+    expect(result.stream).toBe("stdout");
+  });
+
+  it("handles case-insensitive STDERR prefix", () => {
+    const result = normalizeCursorStreamLine('STDERR: {"type":"err"}');
+    expect(result.stream).toBe("stderr");
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    const result = normalizeCursorStreamLine('  stdout: {"x":1}  ');
+    expect(result.stream).toBe("stdout");
+    expect(result.line).toBe('{"x":1}');
+  });
+
+  it("only matches prefix when followed by JSON-like content ([ or {)", () => {
+    // A line starting with "stdout" but not followed by JSON — falls through to plain line
+    const result = normalizeCursorStreamLine("stdout: plain text");
+    expect(result.stream).toBeNull();
+    expect(result.line).toBe("stdout: plain text");
+  });
+
+  it("matches stdout prefix followed by array JSON", () => {
+    const result = normalizeCursorStreamLine("stdout: [1,2,3]");
+    expect(result.stream).toBe("stdout");
+    expect(result.line).toBe("[1,2,3]");
+  });
+});

--- a/packages/adapters/cursor-local/src/shared/trust.test.ts
+++ b/packages/adapters/cursor-local/src/shared/trust.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { hasCursorTrustBypassArg } from "./trust.js";
+
+describe("hasCursorTrustBypassArg", () => {
+  it("returns true for --trust flag", () => {
+    expect(hasCursorTrustBypassArg(["--trust"])).toBe(true);
+  });
+
+  it("returns true for --yolo flag", () => {
+    expect(hasCursorTrustBypassArg(["--yolo"])).toBe(true);
+  });
+
+  it("returns true for -f flag", () => {
+    expect(hasCursorTrustBypassArg(["-f"])).toBe(true);
+  });
+
+  it("returns true for --trust=value", () => {
+    expect(hasCursorTrustBypassArg(["--trust=always"])).toBe(true);
+  });
+
+  it("returns true when trust flag is among other args", () => {
+    expect(hasCursorTrustBypassArg(["--model", "gpt-4", "--yolo", "--output", "file"])).toBe(true);
+  });
+
+  it("returns false for empty array", () => {
+    expect(hasCursorTrustBypassArg([])).toBe(false);
+  });
+
+  it("returns false when no trust flags present", () => {
+    expect(hasCursorTrustBypassArg(["--model", "claude-3", "--output", "file.md"])).toBe(false);
+  });
+
+  it("returns false for similar but non-matching flags", () => {
+    expect(hasCursorTrustBypassArg(["--untrust", "--trusting", "--trust-me"])).toBe(false);
+  });
+
+  it("returns false for partial -f match within a longer flag", () => {
+    expect(hasCursorTrustBypassArg(["--format"])).toBe(false);
+  });
+});

--- a/packages/adapters/openclaw-gateway/src/cli/format-event.test.ts
+++ b/packages/adapters/openclaw-gateway/src/cli/format-event.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { printOpenClawGatewayStreamEvent } from "./format-event.js";
+
+function capture(raw: string, debug: boolean): string[] {
+  const calls: string[] = [];
+  const spy = vi.spyOn(console, "log").mockImplementation((...args) => {
+    calls.push(args.map(String).join(" "));
+  });
+  try {
+    printOpenClawGatewayStreamEvent(raw, debug);
+  } finally {
+    spy.mockRestore();
+  }
+  return calls;
+}
+
+describe("printOpenClawGatewayStreamEvent", () => {
+  it("does nothing for empty string", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    printOpenClawGatewayStreamEvent("", false);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("does nothing for whitespace-only string", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    printOpenClawGatewayStreamEvent("   ", false);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("prints raw line when debug=false regardless of content", () => {
+    const calls = capture("some event data", false);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toBe("some event data");
+  });
+
+  it("prints openclaw-gateway:event lines in debug mode", () => {
+    const calls = capture("[openclaw-gateway:event] something happened", true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("[openclaw-gateway:event]");
+  });
+
+  it("prints openclaw-gateway lines in debug mode", () => {
+    const calls = capture("[openclaw-gateway] general log", true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("[openclaw-gateway]");
+  });
+
+  it("prints other lines in debug mode", () => {
+    const calls = capture("arbitrary debug output", true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("arbitrary debug output");
+  });
+
+  it("trims leading whitespace from input before processing", () => {
+    // The function trims the raw input — an otherwise non-empty line should print
+    const calls = capture("  data  ", false);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("data");
+  });
+});

--- a/packages/plugins/sdk/package.json
+++ b/packages/plugins/sdk/package.json
@@ -103,6 +103,7 @@
   "scripts": {
     "build": "pnpm --filter @paperclipai/shared build && tsc",
     "clean": "rm -rf dist",
+    "test": "vitest run",
     "typecheck": "pnpm --filter @paperclipai/shared build && tsc --noEmit",
     "dev:server": "tsx src/dev-cli.ts"
   },
@@ -113,7 +114,8 @@
   "devDependencies": {
     "@types/node": "^24.6.0",
     "@types/react": "^19.0.8",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
   },
   "peerDependencies": {
     "react": ">=18"

--- a/packages/plugins/sdk/src/bundlers.test.ts
+++ b/packages/plugins/sdk/src/bundlers.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import { createPluginBundlerPresets } from "./bundlers.js";
+
+// ============================================================================
+// createPluginBundlerPresets — default configuration
+// ============================================================================
+
+describe("createPluginBundlerPresets — defaults", () => {
+  it("returns both esbuild and rollup presets", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets).toHaveProperty("esbuild");
+    expect(presets).toHaveProperty("rollup");
+  });
+
+  it("defaults outdir to 'dist'", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.worker.outdir).toBe("dist");
+    expect(presets.rollup.worker.output.dir).toBe("dist");
+  });
+
+  it("defaults workerEntry to 'src/worker.ts'", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.worker.entryPoints).toEqual(["src/worker.ts"]);
+    expect(presets.rollup.worker.input).toBe("src/worker.ts");
+  });
+
+  it("defaults manifestEntry to 'src/manifest.ts'", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.manifest.entryPoints).toEqual(["src/manifest.ts"]);
+    expect(presets.rollup.manifest.input).toBe("src/manifest.ts");
+  });
+
+  it("defaults sourcemap to true", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.worker.sourcemap).toBe(true);
+    expect(presets.esbuild.manifest.sourcemap).toBe(true);
+    expect(presets.rollup.worker.output.sourcemap).toBe(true);
+    expect(presets.rollup.manifest.output.sourcemap).toBe(true);
+  });
+
+  it("defaults minify to false on worker", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.worker.minify).toBe(false);
+  });
+
+  it("does not include ui preset when uiEntry is not provided", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.ui).toBeUndefined();
+    expect(presets.rollup.ui).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// createPluginBundlerPresets — custom configuration
+// ============================================================================
+
+describe("createPluginBundlerPresets — custom configuration", () => {
+  it("respects custom outdir", () => {
+    const presets = createPluginBundlerPresets({ outdir: "build" });
+    expect(presets.esbuild.worker.outdir).toBe("build");
+    expect(presets.rollup.worker.output.dir).toBe("build");
+  });
+
+  it("respects custom workerEntry", () => {
+    const presets = createPluginBundlerPresets({ workerEntry: "custom/worker.ts" });
+    expect(presets.esbuild.worker.entryPoints).toEqual(["custom/worker.ts"]);
+    expect(presets.rollup.worker.input).toBe("custom/worker.ts");
+  });
+
+  it("respects custom manifestEntry", () => {
+    const presets = createPluginBundlerPresets({ manifestEntry: "custom/manifest.ts" });
+    expect(presets.esbuild.manifest.entryPoints).toEqual(["custom/manifest.ts"]);
+    expect(presets.rollup.manifest.input).toBe("custom/manifest.ts");
+  });
+
+  it("sets sourcemap=false when specified", () => {
+    const presets = createPluginBundlerPresets({ sourcemap: false });
+    expect(presets.esbuild.worker.sourcemap).toBe(false);
+    expect(presets.rollup.worker.output.sourcemap).toBe(false);
+  });
+
+  it("sets minify=true when specified", () => {
+    const presets = createPluginBundlerPresets({ minify: true });
+    expect(presets.esbuild.worker.minify).toBe(true);
+  });
+
+  it("includes ui preset when uiEntry is provided", () => {
+    const presets = createPluginBundlerPresets({ uiEntry: "src/ui.tsx" });
+    expect(presets.esbuild.ui).toBeDefined();
+    expect(presets.rollup.ui).toBeDefined();
+  });
+
+  it("sets ui outdir to outdir/ui when uiEntry is provided", () => {
+    const presets = createPluginBundlerPresets({ uiEntry: "src/ui.tsx", outdir: "dist" });
+    expect(presets.esbuild.ui?.outdir).toBe("dist/ui");
+    expect(presets.rollup.ui?.output.dir).toBe("dist/ui");
+  });
+
+  it("sets ui entryPoints to uiEntry", () => {
+    const presets = createPluginBundlerPresets({ uiEntry: "src/ui.tsx" });
+    expect(presets.esbuild.ui?.entryPoints).toEqual(["src/ui.tsx"]);
+    expect(presets.rollup.ui?.input).toBe("src/ui.tsx");
+  });
+
+  it("applies all custom options together", () => {
+    const presets = createPluginBundlerPresets({
+      outdir: "output",
+      workerEntry: "lib/worker.ts",
+      manifestEntry: "lib/manifest.ts",
+      uiEntry: "lib/ui.tsx",
+      sourcemap: false,
+      minify: true,
+    });
+    expect(presets.esbuild.worker.outdir).toBe("output");
+    expect(presets.esbuild.worker.entryPoints).toEqual(["lib/worker.ts"]);
+    expect(presets.esbuild.manifest.entryPoints).toEqual(["lib/manifest.ts"]);
+    expect(presets.esbuild.ui).toBeDefined();
+    expect(presets.esbuild.worker.sourcemap).toBe(false);
+    expect(presets.esbuild.worker.minify).toBe(true);
+  });
+});
+
+// ============================================================================
+// createPluginBundlerPresets — esbuild config details
+// ============================================================================
+
+describe("createPluginBundlerPresets — esbuild config details", () => {
+  it("worker uses ESM format on node platform", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.worker.format).toBe("esm");
+    expect(presets.esbuild.worker.platform).toBe("node");
+  });
+
+  it("worker target is node20", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.worker.target).toBe("node20");
+  });
+
+  it("worker has bundle=true", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.worker.bundle).toBe(true);
+  });
+
+  it("manifest has bundle=false", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.manifest.bundle).toBe(false);
+  });
+
+  it("ui uses browser platform with ESM format", () => {
+    const presets = createPluginBundlerPresets({ uiEntry: "src/ui.tsx" });
+    expect(presets.esbuild.ui?.format).toBe("esm");
+    expect(presets.esbuild.ui?.platform).toBe("browser");
+  });
+
+  it("ui externalizes React and SDK packages", () => {
+    const presets = createPluginBundlerPresets({ uiEntry: "src/ui.tsx" });
+    const ext = presets.esbuild.ui?.external ?? [];
+    expect(ext).toContain("react");
+    expect(ext).toContain("react-dom");
+    expect(ext).toContain("@paperclipai/plugin-sdk/ui");
+  });
+
+  it("worker externalizes react and react-dom", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.esbuild.worker.external).toContain("react");
+    expect(presets.esbuild.worker.external).toContain("react-dom");
+  });
+});
+
+// ============================================================================
+// createPluginBundlerPresets — rollup config details
+// ============================================================================
+
+describe("createPluginBundlerPresets — rollup config details", () => {
+  it("worker output format is 'es'", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.rollup.worker.output.format).toBe("es");
+  });
+
+  it("worker output entryFileNames is worker.js", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.rollup.worker.output.entryFileNames).toBe("worker.js");
+  });
+
+  it("manifest output entryFileNames is manifest.js", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.rollup.manifest.output.entryFileNames).toBe("manifest.js");
+  });
+
+  it("ui output entryFileNames is index.js", () => {
+    const presets = createPluginBundlerPresets({ uiEntry: "src/ui.tsx" });
+    expect(presets.rollup.ui?.output.entryFileNames).toBe("index.js");
+  });
+
+  it("worker externalizes react and react-dom", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.rollup.worker.external).toContain("react");
+    expect(presets.rollup.worker.external).toContain("react-dom");
+  });
+
+  it("manifest externalizes @paperclipai/plugin-sdk", () => {
+    const presets = createPluginBundlerPresets();
+    expect(presets.rollup.manifest.external).toContain("@paperclipai/plugin-sdk");
+  });
+
+  it("ui externalizes React and SDK packages", () => {
+    const presets = createPluginBundlerPresets({ uiEntry: "src/ui.tsx" });
+    const ext = presets.rollup.ui?.external ?? [];
+    expect(ext).toContain("react");
+    expect(ext).toContain("@paperclipai/plugin-sdk/ui");
+  });
+});
+
+// ============================================================================
+// createPluginBundlerPresets — works with empty input object
+// ============================================================================
+
+describe("createPluginBundlerPresets — empty input", () => {
+  it("works when called with empty object", () => {
+    expect(() => createPluginBundlerPresets({})).not.toThrow();
+  });
+
+  it("works when called with no arguments", () => {
+    expect(() => createPluginBundlerPresets()).not.toThrow();
+  });
+});

--- a/packages/plugins/sdk/vitest.config.ts
+++ b/packages/plugins/sdk/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       "packages/adapters/openclaw-gateway",
       "packages/adapters/pi-local",
       "packages/shared",
+      "packages/plugins/sdk",
       "server",
       "ui",
       "cli",


### PR DESCRIPTION
## Summary

- Adds `packages/plugins/sdk/src/bundlers.test.ts` with 32 vitest tests covering `createPluginBundlerPresets`
- Adds `packages/plugins/sdk/vitest.config.ts` so tests run in isolation without picking up the root workspace config
- Registers `packages/plugins/sdk` in the root `vitest.config.ts` workspace projects list so CI includes this package
- Adds `vitest` devDependency and `test` script to the package

**Test coverage:**
- Default values: outdir, workerEntry, manifestEntry, sourcemap, minify, no-ui preset
- Custom configuration overrides for all fields including uiEntry
- esbuild config details: ESM format, node platform, node20 target, bundle=true/false, browser platform for UI, externals
- Rollup config details: es format, entryFileNames per output, externals for worker/manifest/ui

## Test plan

- [x] All 32 tests pass locally with `vitest run --config vitest.config.ts`
- [ ] CI: score, policy, verify, e2e checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)