### PR TITLE
test(cli): 21 unit tests for net, path-resolver, and secrets-key

### DIFF
--- a/cli/src/config/secrets-key.test.ts
+++ b/cli/src/config/secrets-key.test.ts
@@ -1,0 +1,188 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureLocalSecretsKeyFile } from "./secrets-key.js";
+import type { PaperclipConfig } from "./schema.js";
+
+beforeEach(() => {
+  // Clear key-file env overrides that may be set in the outer environment
+  vi.stubEnv("PAPERCLIP_SECRETS_MASTER_KEY", "");
+  vi.stubEnv("PAPERCLIP_SECRETS_MASTER_KEY_FILE", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+
+// Minimal config factory to keep tests concise
+function makeConfig(
+  provider: "local_encrypted" | "env" | "none" = "local_encrypted",
+  keyFilePath = ".paperclip/secrets/master.key",
+): Pick<PaperclipConfig, "secrets"> {
+  return {
+    secrets: {
+      provider,
+      localEncrypted: { keyFilePath },
+    } as PaperclipConfig["secrets"],
+  };
+}
+
+// ============================================================================
+// skipped_provider
+// ============================================================================
+
+describe("ensureLocalSecretsKeyFile — skipped_provider", () => {
+  it("returns skipped_provider when provider is not local_encrypted", () => {
+    const result = ensureLocalSecretsKeyFile(makeConfig("env"));
+    expect(result.status).toBe("skipped_provider");
+    expect(result.path).toBeNull();
+  });
+
+  it("returns skipped_provider when provider is 'none'", () => {
+    const result = ensureLocalSecretsKeyFile(makeConfig("none"));
+    expect(result.status).toBe("skipped_provider");
+    expect(result.path).toBeNull();
+  });
+});
+
+// ============================================================================
+// skipped_env
+// ============================================================================
+
+describe("ensureLocalSecretsKeyFile — skipped_env", () => {
+  it("returns skipped_env when PAPERCLIP_SECRETS_MASTER_KEY is set", () => {
+    vi.stubEnv("PAPERCLIP_SECRETS_MASTER_KEY", "some-secret-value");
+    const result = ensureLocalSecretsKeyFile(makeConfig("local_encrypted"));
+    expect(result.status).toBe("skipped_env");
+    expect(result.path).toBeNull();
+  });
+
+  it("does not skip when PAPERCLIP_SECRETS_MASTER_KEY is empty", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sk-test-"));
+    try {
+      vi.stubEnv("PAPERCLIP_SECRETS_MASTER_KEY", "");
+      const keyFilePath = path.join(tmpDir, "master.key");
+      const result = ensureLocalSecretsKeyFile(makeConfig("local_encrypted", keyFilePath));
+      // should proceed to create or find the file, not skip
+      expect(result.status).not.toBe("skipped_env");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not skip when PAPERCLIP_SECRETS_MASTER_KEY is whitespace only", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sk-test-"));
+    try {
+      vi.stubEnv("PAPERCLIP_SECRETS_MASTER_KEY", "   ");
+      const keyFilePath = path.join(tmpDir, "master.key");
+      const result = ensureLocalSecretsKeyFile(makeConfig("local_encrypted", keyFilePath));
+      expect(result.status).not.toBe("skipped_env");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ============================================================================
+// existing
+// ============================================================================
+
+describe("ensureLocalSecretsKeyFile — existing", () => {
+  it("returns existing when the key file already exists", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sk-test-"));
+    const keyFilePath = path.join(tmpDir, "master.key");
+    fs.writeFileSync(keyFilePath, "existing-key-content");
+
+    try {
+      const result = ensureLocalSecretsKeyFile(makeConfig("local_encrypted", keyFilePath));
+      expect(result.status).toBe("existing");
+      if (result.status === "existing") {
+        expect(result.path).toBe(keyFilePath);
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not overwrite an existing key file", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sk-test-"));
+    const keyFilePath = path.join(tmpDir, "master.key");
+    const originalContent = "my-original-key";
+    fs.writeFileSync(keyFilePath, originalContent);
+
+    try {
+      ensureLocalSecretsKeyFile(makeConfig("local_encrypted", keyFilePath));
+      expect(fs.readFileSync(keyFilePath, "utf8")).toBe(originalContent);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ============================================================================
+// created
+// ============================================================================
+
+describe("ensureLocalSecretsKeyFile — created", () => {
+  it("creates a new key file and returns created status", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sk-test-"));
+    const keyFilePath = path.join(tmpDir, "subdir", "master.key");
+
+    try {
+      const result = ensureLocalSecretsKeyFile(makeConfig("local_encrypted", keyFilePath));
+      expect(result.status).toBe("created");
+      if (result.status === "created") {
+        expect(result.path).toBe(keyFilePath);
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates parent directories recursively", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sk-test-"));
+    const keyFilePath = path.join(tmpDir, "a", "b", "c", "master.key");
+
+    try {
+      ensureLocalSecretsKeyFile(makeConfig("local_encrypted", keyFilePath));
+      expect(fs.existsSync(keyFilePath)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes a non-empty base64 key to the new file", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sk-test-"));
+    const keyFilePath = path.join(tmpDir, "master.key");
+
+    try {
+      ensureLocalSecretsKeyFile(makeConfig("local_encrypted", keyFilePath));
+      const content = fs.readFileSync(keyFilePath, "utf8");
+      expect(content.length).toBeGreaterThan(0);
+      // base64 alphabet check
+      expect(content).toMatch(/^[A-Za-z0-9+/=]+$/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses PAPERCLIP_SECRETS_MASTER_KEY_FILE env override for the key file path", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sk-test-"));
+    const overridePath = path.join(tmpDir, "override-key.key");
+    vi.stubEnv("PAPERCLIP_SECRETS_MASTER_KEY_FILE", overridePath);
+
+    try {
+      const result = ensureLocalSecretsKeyFile(makeConfig("local_encrypted", "/should/not/be/used"));
+      expect(result.status).toBe("created");
+      if (result.status === "created") {
+        expect(result.path).toBe(overridePath);
+      }
+      expect(fs.existsSync(overridePath)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/src/utils/net.test.ts
+++ b/cli/src/utils/net.test.ts
@@ -1,0 +1,63 @@
+import net from "node:net";
+import { describe, expect, it } from "vitest";
+import { checkPort } from "./net.js";
+
+// ============================================================================
+// checkPort
+// ============================================================================
+
+describe("checkPort", () => {
+  it("reports a free port as available", async () => {
+    // Find a free port by binding to 0, note the port, then release it
+    const tempServer = net.createServer();
+    const port = await new Promise<number>((resolve, reject) => {
+      tempServer.once("error", reject);
+      tempServer.listen(0, "127.0.0.1", () => {
+        const addr = tempServer.address() as net.AddressInfo;
+        tempServer.close(() => resolve(addr.port));
+      });
+    });
+
+    const result = await checkPort(port);
+    expect(result.available).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("reports an occupied port as unavailable", async () => {
+    // Start a server to occupy a port
+    const server = net.createServer();
+    const port = await new Promise<number>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        resolve((server.address() as net.AddressInfo).port);
+      });
+    });
+
+    try {
+      const result = await checkPort(port);
+      expect(result.available).toBe(false);
+      expect(result.error).toBeDefined();
+      expect(result.error).toContain(String(port));
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("includes an error message for an occupied port", async () => {
+    const server = net.createServer();
+    const port = await new Promise<number>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        resolve((server.address() as net.AddressInfo).port);
+      });
+    });
+
+    try {
+      const result = await checkPort(port);
+      expect(typeof result.error).toBe("string");
+      expect((result.error ?? "").length).toBeGreaterThan(0);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/cli/src/utils/path-resolver.test.ts
+++ b/cli/src/utils/path-resolver.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveRuntimeLikePath } from "./path-resolver.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+// ============================================================================
+// resolveRuntimeLikePath — absolute paths
+// ============================================================================
+
+describe("resolveRuntimeLikePath — absolute paths", () => {
+  it("returns an absolute path as-is (resolved)", () => {
+    const result = resolveRuntimeLikePath("/absolute/path/to/binary");
+    expect(result).toBe("/absolute/path/to/binary");
+  });
+
+  it("resolves a '~'-prefixed path to the home directory equivalent", () => {
+    const result = resolveRuntimeLikePath("~/some/binary");
+    expect(result).toBe(path.resolve(os.homedir(), "some/binary"));
+  });
+
+  it("returns '~' alone as the home directory", () => {
+    const result = resolveRuntimeLikePath("~");
+    expect(result).toBe(os.homedir());
+  });
+});
+
+// ============================================================================
+// resolveRuntimeLikePath — relative paths with configPath
+// ============================================================================
+
+describe("resolveRuntimeLikePath — relative paths with configPath", () => {
+  it("prefers config-sibling resolution when file exists there", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ppr-test-"));
+    const configDir = path.join(tmpDir, "config");
+    fs.mkdirSync(configDir, { recursive: true });
+    const binaryPath = path.join(configDir, "mybinary");
+    fs.writeFileSync(binaryPath, "");
+
+    try {
+      const configPath = path.join(configDir, "paperclip.json");
+      const result = resolveRuntimeLikePath("mybinary", configPath);
+      expect(result).toBe(binaryPath);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to workspace/server/ candidate when file exists there", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ppr-test-"));
+    const configDir = path.join(tmpDir, "app", "config");
+    fs.mkdirSync(configDir, { recursive: true });
+    const serverDir = path.join(tmpDir, "app", "server");
+    fs.mkdirSync(serverDir, { recursive: true });
+    const binaryPath = path.join(serverDir, "mybinary");
+    fs.writeFileSync(binaryPath, "");
+
+    try {
+      const configPath = path.join(configDir, "paperclip.json");
+      const result = resolveRuntimeLikePath("mybinary", configPath);
+      expect(result).toBe(binaryPath);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns the first candidate when no file exists on disk", () => {
+    const configPath = "/nonexistent/config/dir/paperclip.json";
+    const result = resolveRuntimeLikePath("mybinary", configPath);
+    // When no candidate exists, returns the first candidate (configDir-relative)
+    expect(result).toBe(path.resolve("/nonexistent/config/dir", "mybinary"));
+  });
+});
+
+// ============================================================================
+// resolveRuntimeLikePath — no configPath
+// ============================================================================
+
+describe("resolveRuntimeLikePath — no configPath", () => {
+  it("falls back to cwd when no configPath is provided and file does not exist", () => {
+    const result = resolveRuntimeLikePath("nonexistent-binary-xyz");
+    // Without a configPath, candidates are [workspaceRoot/server/..., workspaceRoot/..., cwd/...]
+    // where workspaceRoot === cwd when no configDir. First candidate should be server-relative.
+    expect(path.isAbsolute(result)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- **`cli/src/utils/net.test.ts`** — 3 tests for `checkPort`: free port reports available, occupied port reports unavailable with an error message including the port number. Uses real `node:net` sockets for integration fidelity.
- **`cli/src/utils/path-resolver.test.ts`** — 7 tests for `resolveRuntimeLikePath`: absolute paths pass through unchanged, `~` prefix expands to home directory, relative paths prefer config-sibling location when file exists there, fall back to `workspace/server/` candidate, return first candidate when nothing exists on disk.
- **`cli/src/config/secrets-key.test.ts`** — 11 tests for `ensureLocalSecretsKeyFile`: `skipped_provider` for non-`local_encrypted` providers, `skipped_env` when `PAPERCLIP_SECRETS_MASTER_KEY` is set (but not when empty/whitespace), `existing` when key file is already present (no overwrite), `created` when key file is new (random base64 content, recursive mkdir, `PAPERCLIP_SECRETS_MASTER_KEY_FILE` env override path). Uses `beforeEach` env stubbing to prevent outer-environment `PAPERCLIP_*` variables from polluting test isolation.

## Test plan

- [x] All 21 tests pass locally
- [ ] CI: score, policy, verify, e2e checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)