### PR TITLE
test(server): 32 unit tests for agent-permissions, default-instructions, paths

### DIFF
--- a/server/src/paths.test.ts
+++ b/server/src/paths.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolvePaperclipConfigPath, resolvePaperclipEnvPath } from "./paths.js";
+
+beforeEach(() => {
+  vi.stubEnv("PAPERCLIP_CONFIG", "");
+  vi.stubEnv("PAPERCLIP_HOME", "");
+  vi.stubEnv("PAPERCLIP_INSTANCE_ID", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+// ============================================================================
+// resolvePaperclipConfigPath — explicit override
+// ============================================================================
+
+describe("resolvePaperclipConfigPath — explicit override", () => {
+  it("uses the provided overridePath when given", () => {
+    const result = resolvePaperclipConfigPath("/custom/path/config.json");
+    expect(result).toBe("/custom/path/config.json");
+  });
+
+  it("resolves the overridePath to an absolute path", () => {
+    const result = resolvePaperclipConfigPath("relative/config.json");
+    expect(path.isAbsolute(result)).toBe(true);
+    expect(result).toContain("relative/config.json");
+  });
+});
+
+// ============================================================================
+// resolvePaperclipConfigPath — PAPERCLIP_CONFIG env
+// ============================================================================
+
+describe("resolvePaperclipConfigPath — PAPERCLIP_CONFIG env", () => {
+  it("uses PAPERCLIP_CONFIG env when no override is provided", () => {
+    vi.stubEnv("PAPERCLIP_CONFIG", "/env/path/config.json");
+    const result = resolvePaperclipConfigPath();
+    expect(result).toBe("/env/path/config.json");
+  });
+
+  it("resolves PAPERCLIP_CONFIG to absolute path", () => {
+    vi.stubEnv("PAPERCLIP_CONFIG", "relative/env-config.json");
+    const result = resolvePaperclipConfigPath();
+    expect(path.isAbsolute(result)).toBe(true);
+  });
+});
+
+// ============================================================================
+// resolvePaperclipConfigPath — ancestor search
+// ============================================================================
+
+describe("resolvePaperclipConfigPath — ancestor search", () => {
+  it("finds a .paperclip/config.json in an ancestor directory", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pcp-test-"));
+    const paperclipDir = path.join(tmpDir, ".paperclip");
+    fs.mkdirSync(paperclipDir, { recursive: true });
+    const configPath = path.join(paperclipDir, "config.json");
+    fs.writeFileSync(configPath, "{}");
+
+    try {
+      // Stub cwd to be a subdirectory so the search must walk up
+      const subDir = path.join(tmpDir, "app", "src");
+      fs.mkdirSync(subDir, { recursive: true });
+      vi.spyOn(process, "cwd").mockReturnValue(subDir);
+      const result = resolvePaperclipConfigPath();
+      expect(result).toBe(configPath);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ============================================================================
+// resolvePaperclipConfigPath — default fallback
+// ============================================================================
+
+describe("resolvePaperclipConfigPath — default fallback", () => {
+  it("falls back to the default config path when no override/env/ancestor is found", () => {
+    // Stub cwd to a temp dir that has no .paperclip ancestor
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pcp-test-"));
+    vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+    const result = resolvePaperclipConfigPath();
+    try {
+      // Should end with config.json in the default instance root
+      expect(result).toMatch(/config\.json$/);
+      expect(path.isAbsolute(result)).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ============================================================================
+// resolvePaperclipEnvPath
+// ============================================================================
+
+describe("resolvePaperclipEnvPath", () => {
+  it("returns a .env file path in the same directory as the config", () => {
+    const result = resolvePaperclipEnvPath("/my/config/path/config.json");
+    expect(result).toBe("/my/config/path/.env");
+  });
+
+  it("produces an absolute path", () => {
+    const result = resolvePaperclipEnvPath("/absolute/config.json");
+    expect(path.isAbsolute(result)).toBe(true);
+  });
+
+  it("places .env alongside the resolved config when no override is given", () => {
+    vi.stubEnv("PAPERCLIP_CONFIG", "/env/config.json");
+    const result = resolvePaperclipEnvPath();
+    expect(result).toBe("/env/.env");
+  });
+
+  it("ends with '.env'", () => {
+    const result = resolvePaperclipEnvPath("/foo/bar/config.json");
+    expect(path.basename(result)).toBe(".env");
+  });
+});

--- a/server/src/services/agent-permissions.test.ts
+++ b/server/src/services/agent-permissions.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  defaultPermissionsForRole,
+  normalizeAgentPermissions,
+} from "./agent-permissions.js";
+
+// ============================================================================
+// defaultPermissionsForRole
+// ============================================================================
+
+describe("defaultPermissionsForRole", () => {
+  it("grants canCreateAgents=true for role 'ceo'", () => {
+    const perms = defaultPermissionsForRole("ceo");
+    expect(perms.canCreateAgents).toBe(true);
+  });
+
+  it("grants canCreateAgents=false for role 'cto'", () => {
+    const perms = defaultPermissionsForRole("cto");
+    expect(perms.canCreateAgents).toBe(false);
+  });
+
+  it("grants canCreateAgents=false for role 'engineer'", () => {
+    const perms = defaultPermissionsForRole("engineer");
+    expect(perms.canCreateAgents).toBe(false);
+  });
+
+  it("grants canCreateAgents=false for empty role", () => {
+    const perms = defaultPermissionsForRole("");
+    expect(perms.canCreateAgents).toBe(false);
+  });
+
+  it("grants canCreateAgents=false for unknown role", () => {
+    const perms = defaultPermissionsForRole("contractor");
+    expect(perms.canCreateAgents).toBe(false);
+  });
+
+  it("returns an object with at least canCreateAgents", () => {
+    const perms = defaultPermissionsForRole("ceo");
+    expect(perms).toHaveProperty("canCreateAgents");
+  });
+});
+
+// ============================================================================
+// normalizeAgentPermissions
+// ============================================================================
+
+describe("normalizeAgentPermissions", () => {
+  it("uses stored canCreateAgents=true when explicitly set", () => {
+    const perms = normalizeAgentPermissions({ canCreateAgents: true }, "engineer");
+    expect(perms.canCreateAgents).toBe(true);
+  });
+
+  it("uses stored canCreateAgents=false when explicitly set", () => {
+    const perms = normalizeAgentPermissions({ canCreateAgents: false }, "ceo");
+    expect(perms.canCreateAgents).toBe(false);
+  });
+
+  it("falls back to role default when canCreateAgents is not in stored object", () => {
+    const perms = normalizeAgentPermissions({}, "ceo");
+    expect(perms.canCreateAgents).toBe(true);
+  });
+
+  it("falls back to role default for non-ceo when field is missing", () => {
+    const perms = normalizeAgentPermissions({}, "engineer");
+    expect(perms.canCreateAgents).toBe(false);
+  });
+
+  it("falls back to role default when stored permissions is null", () => {
+    const perms = normalizeAgentPermissions(null, "ceo");
+    expect(perms.canCreateAgents).toBe(true);
+  });
+
+  it("falls back to role default when stored permissions is undefined", () => {
+    const perms = normalizeAgentPermissions(undefined, "ceo");
+    expect(perms.canCreateAgents).toBe(true);
+  });
+
+  it("falls back to role default when stored permissions is an array", () => {
+    const perms = normalizeAgentPermissions([], "ceo");
+    expect(perms.canCreateAgents).toBe(true);
+  });
+
+  it("falls back to role default when stored permissions is a string", () => {
+    const perms = normalizeAgentPermissions("yes", "ceo");
+    expect(perms.canCreateAgents).toBe(true);
+  });
+
+  it("falls back to role default when canCreateAgents is a non-boolean value", () => {
+    // stored value is string "true" — not a boolean, should use role default
+    const perms = normalizeAgentPermissions({ canCreateAgents: "true" }, "engineer");
+    expect(perms.canCreateAgents).toBe(false); // role default for engineer
+  });
+
+  it("treats canCreateAgents=0 (non-boolean) as missing and uses role default", () => {
+    const perms = normalizeAgentPermissions({ canCreateAgents: 0 }, "ceo");
+    expect(perms.canCreateAgents).toBe(true); // role default for ceo
+  });
+});

--- a/server/src/services/default-agent-instructions.test.ts
+++ b/server/src/services/default-agent-instructions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolveDefaultAgentInstructionsBundleRole } from "./default-agent-instructions.js";
+
+// ============================================================================
+// resolveDefaultAgentInstructionsBundleRole
+// ============================================================================
+
+describe("resolveDefaultAgentInstructionsBundleRole", () => {
+  it("returns 'ceo' for role 'ceo'", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("ceo")).toBe("ceo");
+  });
+
+  it("returns 'default' for role 'cto'", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("cto")).toBe("default");
+  });
+
+  it("returns 'default' for role 'engineer'", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("engineer")).toBe("default");
+  });
+
+  it("returns 'default' for empty string", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("")).toBe("default");
+  });
+
+  it("returns 'default' for unknown role", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("contractor")).toBe("default");
+  });
+
+  it("is case-sensitive — 'CEO' does not map to ceo bundle", () => {
+    expect(resolveDefaultAgentInstructionsBundleRole("CEO")).toBe("default");
+  });
+});


### PR DESCRIPTION
## Summary

- **`server/src/services/agent-permissions.test.ts`** — 16 tests for `defaultPermissionsForRole` (ceo gets `canCreateAgents=true`, all others false) and `normalizeAgentPermissions` (stored boolean values override role defaults, non-boolean/null/undefined/array/string values fall back to role defaults)
- **`server/src/services/default-agent-instructions.test.ts`** — 6 tests for `resolveDefaultAgentInstructionsBundleRole`: `'ceo'` maps to `'ceo'` bundle, all other roles including empty string map to `'default'`, case-sensitive
- **`server/src/paths.test.ts`** — 10 tests for `resolvePaperclipConfigPath` (explicit override passthrough, `PAPERCLIP_CONFIG` env var, ancestor `.paperclip/config.json` search via `process.cwd()` mock, default fallback) and `resolvePaperclipEnvPath` (`.env` sibling of resolved config)

## Test plan

- [x] All 32 tests pass locally
- [ ] CI: score, policy, verify, e2e checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)