### PR TITLE
chore(lockfile): sync vitest entry for packages/plugins/sdk

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.0)(jiti@2.6.1)(jsdom@28.1.0(@noble/hashes@2.0.1))(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes a missing lockfile entry introduced when PR #141 was squash-merged.

PR #141 added `vitest: ^3.2.4` to `packages/plugins/sdk/package.json` devDependencies, but the `pnpm-lock.yaml` was not regenerated before the squash-merge. This caused all subsequent PRs that don't change manifests to fail `pnpm install --frozen-lockfile` because the lockfile specifiers for `packages/plugins/sdk` no longer matched its `package.json`.

This PR runs `pnpm install --lockfile-only --no-frozen-lockfile` to regenerate the lockfile and commits the resulting 3-line diff.

## Test plan

- [ ] CI: policy (lockfile block is bypassed for `chore/refresh-lockfile*` branches)
- [ ] CI: verify (`pnpm install --frozen-lockfile` succeeds)
- [ ] CI: score, e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)