### PR TITLE
test(cli): 22 unit tests for data-dir override and adapter registry

### DIFF
--- a/cli/src/adapters/registry.test.ts
+++ b/cli/src/adapters/registry.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { getCLIAdapter } from "./registry.js";
+
+// ============================================================================
+// getCLIAdapter
+// ============================================================================
+
+describe("getCLIAdapter", () => {
+  it("returns an adapter with type 'claude_local' for 'claude_local'", () => {
+    const adapter = getCLIAdapter("claude_local");
+    expect(adapter.type).toBe("claude_local");
+  });
+
+  it("returns an adapter with type 'cursor' for 'cursor'", () => {
+    const adapter = getCLIAdapter("cursor");
+    expect(adapter.type).toBe("cursor");
+  });
+
+  it("returns an adapter with type 'codex_local' for 'codex_local'", () => {
+    const adapter = getCLIAdapter("codex_local");
+    expect(adapter.type).toBe("codex_local");
+  });
+
+  it("returns an adapter with type 'opencode_local' for 'opencode_local'", () => {
+    const adapter = getCLIAdapter("opencode_local");
+    expect(adapter.type).toBe("opencode_local");
+  });
+
+  it("returns an adapter with type 'gemini_local' for 'gemini_local'", () => {
+    const adapter = getCLIAdapter("gemini_local");
+    expect(adapter.type).toBe("gemini_local");
+  });
+
+  it("returns an adapter with type 'openclaw_gateway' for 'openclaw_gateway'", () => {
+    const adapter = getCLIAdapter("openclaw_gateway");
+    expect(adapter.type).toBe("openclaw_gateway");
+  });
+
+  it("falls back to the process adapter for an unknown type", () => {
+    const adapter = getCLIAdapter("__unknown_type__");
+    expect(adapter).toBeDefined();
+    expect(typeof adapter.formatStdoutEvent).toBe("function");
+  });
+
+  it("has a formatStdoutEvent function on every known adapter", () => {
+    const knownTypes = [
+      "claude_local",
+      "codex_local",
+      "opencode_local",
+      "pi_local",
+      "cursor",
+      "gemini_local",
+      "openclaw_gateway",
+    ];
+    for (const type of knownTypes) {
+      const adapter = getCLIAdapter(type);
+      expect(typeof adapter.formatStdoutEvent).toBe("function");
+    }
+  });
+});

--- a/cli/src/config/data-dir.test.ts
+++ b/cli/src/config/data-dir.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyDataDirOverride } from "./data-dir.js";
+
+beforeEach(() => {
+  vi.stubEnv("PAPERCLIP_HOME", "");
+  vi.stubEnv("PAPERCLIP_CONFIG", "");
+  vi.stubEnv("PAPERCLIP_CONTEXT", "");
+  vi.stubEnv("PAPERCLIP_INSTANCE_ID", "");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ============================================================================
+// applyDataDirOverride — no dataDir
+// ============================================================================
+
+describe("applyDataDirOverride — no dataDir", () => {
+  it("returns null when dataDir is not provided", () => {
+    expect(applyDataDirOverride({})).toBeNull();
+  });
+
+  it("returns null when dataDir is an empty string", () => {
+    expect(applyDataDirOverride({ dataDir: "" })).toBeNull();
+  });
+
+  it("returns null when dataDir is whitespace only", () => {
+    expect(applyDataDirOverride({ dataDir: "   " })).toBeNull();
+  });
+
+  it("does not set PAPERCLIP_HOME when dataDir is absent", () => {
+    applyDataDirOverride({});
+    expect(process.env.PAPERCLIP_HOME).toBe("");
+  });
+});
+
+// ============================================================================
+// applyDataDirOverride — with dataDir
+// ============================================================================
+
+describe("applyDataDirOverride — with dataDir", () => {
+  it("returns the resolved absolute path when dataDir is provided", () => {
+    const result = applyDataDirOverride({ dataDir: "/custom/data" });
+    expect(result).toBe("/custom/data");
+  });
+
+  it("sets PAPERCLIP_HOME to the resolved dataDir", () => {
+    applyDataDirOverride({ dataDir: "/custom/data" });
+    expect(process.env.PAPERCLIP_HOME).toBe("/custom/data");
+  });
+
+  it("resolves a relative dataDir to an absolute path", () => {
+    const result = applyDataDirOverride({ dataDir: "relative/dir" });
+    expect(result).not.toBeNull();
+    if (result) expect(result.startsWith("/")).toBe(true);
+  });
+});
+
+// ============================================================================
+// applyDataDirOverride — hasConfigOption
+// ============================================================================
+
+describe("applyDataDirOverride — hasConfigOption", () => {
+  it("sets PAPERCLIP_CONFIG when hasConfigOption=true and no config override exists", () => {
+    applyDataDirOverride({ dataDir: "/data" }, { hasConfigOption: true });
+    expect(process.env.PAPERCLIP_CONFIG).toBeTruthy();
+    expect(process.env.PAPERCLIP_CONFIG).toContain("config.json");
+  });
+
+  it("does not overwrite PAPERCLIP_CONFIG when it is already set", () => {
+    vi.stubEnv("PAPERCLIP_CONFIG", "/existing/config.json");
+    applyDataDirOverride({ dataDir: "/data" }, { hasConfigOption: true });
+    expect(process.env.PAPERCLIP_CONFIG).toBe("/existing/config.json");
+  });
+
+  it("does not overwrite PAPERCLIP_CONFIG when options.config is provided", () => {
+    applyDataDirOverride(
+      { dataDir: "/data", config: "/override/config.json" },
+      { hasConfigOption: true },
+    );
+    // options.config means there is a config override — PAPERCLIP_CONFIG should not be set
+    expect(process.env.PAPERCLIP_CONFIG ?? "").not.toContain("config.json");
+  });
+
+  it("does not set PAPERCLIP_CONFIG when hasConfigOption is false", () => {
+    applyDataDirOverride({ dataDir: "/data" }, { hasConfigOption: false });
+    expect(process.env.PAPERCLIP_CONFIG ?? "").toBe("");
+  });
+});
+
+// ============================================================================
+// applyDataDirOverride — hasContextOption
+// ============================================================================
+
+describe("applyDataDirOverride — hasContextOption", () => {
+  it("sets PAPERCLIP_CONTEXT when hasContextOption=true and no context override exists", () => {
+    applyDataDirOverride({ dataDir: "/data" }, { hasContextOption: true });
+    expect(process.env.PAPERCLIP_CONTEXT).toBeTruthy();
+    expect(process.env.PAPERCLIP_CONTEXT).toContain("context.json");
+  });
+
+  it("does not overwrite PAPERCLIP_CONTEXT when it is already set", () => {
+    vi.stubEnv("PAPERCLIP_CONTEXT", "/existing/context.json");
+    applyDataDirOverride({ dataDir: "/data" }, { hasContextOption: true });
+    expect(process.env.PAPERCLIP_CONTEXT).toBe("/existing/context.json");
+  });
+
+  it("does not set PAPERCLIP_CONTEXT when hasContextOption is false", () => {
+    applyDataDirOverride({ dataDir: "/data" }, { hasContextOption: false });
+    expect(process.env.PAPERCLIP_CONTEXT ?? "").toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

- **`cli/src/config/data-dir.test.ts`** — 14 tests for `applyDataDirOverride`: returns null when `dataDir` is absent/empty/whitespace; sets `PAPERCLIP_HOME` to the resolved path; with `hasConfigOption=true` sets `PAPERCLIP_CONFIG` unless already set or `options.config` is present; with `hasContextOption=true` sets `PAPERCLIP_CONTEXT` unless already set; uses `beforeEach`/`afterEach` env stubbing for full isolation
- **`cli/src/adapters/registry.test.ts`** — 8 tests for `getCLIAdapter`: each named adapter type (`claude_local`, `cursor`, `codex_local`, `opencode_local`, `gemini_local`, `openclaw_gateway`) returns an adapter with the matching `type` field; unknown type falls back to the process adapter; all known adapters expose a `formatStdoutEvent` function

## Test plan

- [x] All 22 tests pass locally
- [ ] CI: score, policy, verify, e2e checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)