### PR TITLE
test(server): unit tests for worktree-config and workspace-runtime-read-model pure functions

### DIFF
--- a/cli/src/config/env.test.ts
+++ b/cli/src/config/env.test.ts
@@ -1,0 +1,243 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  mergePaperclipEnvEntries,
+  readAgentJwtSecretFromEnvFile,
+  readPaperclipEnvEntries,
+  writePaperclipEnvEntries,
+} from "./env.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "cli-env-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function envFilePath(dir: string): string {
+  return path.join(dir, ".env");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+});
+
+// ============================================================================
+// readPaperclipEnvEntries
+// ============================================================================
+
+describe("readPaperclipEnvEntries", () => {
+  it("returns empty object when file does not exist", () => {
+    const dir = makeTempDir();
+    const result = readPaperclipEnvEntries(envFilePath(dir));
+    expect(result).toEqual({});
+  });
+
+  it("parses KEY=value entries from the file", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    fs.writeFileSync(file, "MY_KEY=my_value\n");
+    const result = readPaperclipEnvEntries(file);
+    expect(result["MY_KEY"]).toBe("my_value");
+  });
+
+  it("parses quoted values (double quotes)", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    fs.writeFileSync(file, 'QUOTED="hello world"\n');
+    const result = readPaperclipEnvEntries(file);
+    expect(result["QUOTED"]).toBe("hello world");
+  });
+
+  it("parses multiple entries", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    fs.writeFileSync(file, "A=one\nB=two\n");
+    const result = readPaperclipEnvEntries(file);
+    expect(result["A"]).toBe("one");
+    expect(result["B"]).toBe("two");
+  });
+
+  it("returns empty object when file is empty", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    fs.writeFileSync(file, "");
+    const result = readPaperclipEnvEntries(file);
+    expect(result).toEqual({});
+  });
+});
+
+// ============================================================================
+// writePaperclipEnvEntries
+// ============================================================================
+
+describe("writePaperclipEnvEntries", () => {
+  it("creates the .env file with given entries", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    writePaperclipEnvEntries({ FOO: "bar" }, file);
+    expect(fs.existsSync(file)).toBe(true);
+  });
+
+  it("written file contains the key=value pair", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    writePaperclipEnvEntries({ HELLO: "world" }, file);
+    const contents = fs.readFileSync(file, "utf-8");
+    expect(contents).toContain("HELLO=world");
+  });
+
+  it("creates parent directory if it does not exist", () => {
+    const dir = makeTempDir();
+    const nested = path.join(dir, "sub", "dir", ".env");
+    writePaperclipEnvEntries({ X: "1" }, nested);
+    expect(fs.existsSync(nested)).toBe(true);
+  });
+
+  it("overwrites existing file content", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    fs.writeFileSync(file, "OLD=value\n");
+    writePaperclipEnvEntries({ NEW: "value" }, file);
+    const contents = fs.readFileSync(file, "utf-8");
+    expect(contents).toContain("NEW=value");
+    expect(contents).not.toContain("OLD=value");
+  });
+
+  it("written content round-trips through readPaperclipEnvEntries", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    const original = { KEY_A: "value_a", KEY_B: "value_b" };
+    writePaperclipEnvEntries(original, file);
+    const restored = readPaperclipEnvEntries(file);
+    expect(restored["KEY_A"]).toBe("value_a");
+    expect(restored["KEY_B"]).toBe("value_b");
+  });
+
+  it("quotes values with special characters using JSON stringify", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    writePaperclipEnvEntries({ SPECIAL: "hello world" }, file);
+    const contents = fs.readFileSync(file, "utf-8");
+    // Value with space should be JSON-quoted
+    expect(contents).toContain('"hello world"');
+  });
+});
+
+// ============================================================================
+// mergePaperclipEnvEntries
+// ============================================================================
+
+describe("mergePaperclipEnvEntries", () => {
+  it("creates file and writes entries when file does not exist", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    const result = mergePaperclipEnvEntries({ FOO: "bar" }, file);
+    expect(result["FOO"]).toBe("bar");
+    expect(fs.existsSync(file)).toBe(true);
+  });
+
+  it("merges new entries with existing ones", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    writePaperclipEnvEntries({ EXISTING: "old" }, file);
+    const result = mergePaperclipEnvEntries({ NEW_KEY: "new_val" }, file);
+    expect(result["EXISTING"]).toBe("old");
+    expect(result["NEW_KEY"]).toBe("new_val");
+  });
+
+  it("overwrites existing key with new value", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    writePaperclipEnvEntries({ KEY: "old" }, file);
+    const result = mergePaperclipEnvEntries({ KEY: "new" }, file);
+    expect(result["KEY"]).toBe("new");
+  });
+
+  it("filters out entries with empty-string values", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    const result = mergePaperclipEnvEntries({ BLANK: "" }, file);
+    expect(result["BLANK"]).toBeUndefined();
+  });
+
+  it("filters out entries with whitespace-only values", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    const result = mergePaperclipEnvEntries({ SPACES: "   " }, file);
+    expect(result["SPACES"]).toBeUndefined();
+  });
+
+  it("persists merged entries to disk", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    writePaperclipEnvEntries({ A: "1" }, file);
+    mergePaperclipEnvEntries({ B: "2" }, file);
+    const onDisk = readPaperclipEnvEntries(file);
+    expect(onDisk["A"]).toBe("1");
+    expect(onDisk["B"]).toBe("2");
+  });
+
+  it("returns the merged entries object", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    writePaperclipEnvEntries({ X: "x_val" }, file);
+    const result = mergePaperclipEnvEntries({ Y: "y_val" }, file);
+    expect(typeof result).toBe("object");
+    expect(result["X"]).toBe("x_val");
+    expect(result["Y"]).toBe("y_val");
+  });
+});
+
+// ============================================================================
+// readAgentJwtSecretFromEnvFile
+// ============================================================================
+
+describe("readAgentJwtSecretFromEnvFile", () => {
+  it("returns null when file does not exist", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    expect(readAgentJwtSecretFromEnvFile(file)).toBeNull();
+  });
+
+  it("returns null when PAPERCLIP_AGENT_JWT_SECRET is absent from file", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    writePaperclipEnvEntries({ OTHER_KEY: "value" }, file);
+    expect(readAgentJwtSecretFromEnvFile(file)).toBeNull();
+  });
+
+  it("returns the secret when present in file", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    writePaperclipEnvEntries({ PAPERCLIP_AGENT_JWT_SECRET: "my-test-secret" }, file);
+    expect(readAgentJwtSecretFromEnvFile(file)).toBe("my-test-secret");
+  });
+
+  it("returns null when secret value is empty string", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    // Write raw file with empty value
+    fs.writeFileSync(file, "PAPERCLIP_AGENT_JWT_SECRET=\n");
+    expect(readAgentJwtSecretFromEnvFile(file)).toBeNull();
+  });
+
+  it("trims whitespace from the secret value", () => {
+    const dir = makeTempDir();
+    const file = envFilePath(dir);
+    // Manually write a file with surrounding spaces (uncommon but possible)
+    fs.writeFileSync(file, 'PAPERCLIP_AGENT_JWT_SECRET="  trimmed  "\n');
+    const result = readAgentJwtSecretFromEnvFile(file);
+    // After parse by dotenv and trim(), should be "trimmed"
+    expect(result).toBe("trimmed");
+  });
+});

--- a/server/src/secrets/local-encrypted-provider.test.ts
+++ b/server/src/secrets/local-encrypted-provider.test.ts
@@ -1,0 +1,185 @@
+import { createHash, randomBytes } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { localEncryptedProvider } from "./local-encrypted-provider.js";
+
+// We inject a known 32-byte key via the env var so loadOrCreateMasterKey()
+// never touches the filesystem in these tests.
+const TEST_MASTER_KEY_HEX = randomBytes(32).toString("hex");
+
+beforeEach(() => {
+  vi.stubEnv("PAPERCLIP_SECRETS_MASTER_KEY", TEST_MASTER_KEY_HEX);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ============================================================================
+// localEncryptedProvider — module identity
+// ============================================================================
+
+describe("localEncryptedProvider — identity", () => {
+  it("has id 'local_encrypted'", () => {
+    expect(localEncryptedProvider.id).toBe("local_encrypted");
+  });
+
+  it("has descriptor id 'local_encrypted'", () => {
+    expect(localEncryptedProvider.descriptor.id).toBe("local_encrypted");
+  });
+});
+
+// ============================================================================
+// localEncryptedProvider.createVersion
+// ============================================================================
+
+describe("localEncryptedProvider.createVersion", () => {
+  it("returns material with scheme 'local_encrypted_v1'", async () => {
+    const result = await localEncryptedProvider.createVersion({ value: "my-secret", externalRef: null });
+    expect((result.material as { scheme: string }).scheme).toBe("local_encrypted_v1");
+  });
+
+  it("returns material with iv, tag, and ciphertext fields", async () => {
+    const result = await localEncryptedProvider.createVersion({ value: "test-value", externalRef: null });
+    const m = result.material as Record<string, unknown>;
+    expect(typeof m.iv).toBe("string");
+    expect(typeof m.tag).toBe("string");
+    expect(typeof m.ciphertext).toBe("string");
+  });
+
+  it("returns externalRef as null", async () => {
+    const result = await localEncryptedProvider.createVersion({ value: "secret", externalRef: null });
+    expect(result.externalRef).toBeNull();
+  });
+
+  it("returns correct SHA-256 hash of the value", async () => {
+    const value = "my-test-secret";
+    const expected = createHash("sha256").update(value).digest("hex");
+    const result = await localEncryptedProvider.createVersion({ value, externalRef: null });
+    expect(result.valueSha256).toBe(expected);
+  });
+
+  it("produces different ciphertexts for the same value (random IV)", async () => {
+    const r1 = await localEncryptedProvider.createVersion({ value: "same", externalRef: null });
+    const r2 = await localEncryptedProvider.createVersion({ value: "same", externalRef: null });
+    const m1 = r1.material as Record<string, string>;
+    const m2 = r2.material as Record<string, string>;
+    // IVs should differ (random), so ciphertexts should differ
+    expect(m1.iv).not.toBe(m2.iv);
+    expect(m1.ciphertext).not.toBe(m2.ciphertext);
+  });
+});
+
+// ============================================================================
+// localEncryptedProvider.resolveVersion — round-trip
+// ============================================================================
+
+describe("localEncryptedProvider.resolveVersion — round-trip", () => {
+  it("round-trips a simple ASCII secret", async () => {
+    const original = "hello-world";
+    const { material } = await localEncryptedProvider.createVersion({ value: original, externalRef: null });
+    const resolved = await localEncryptedProvider.resolveVersion({ material, externalRef: null });
+    expect(resolved).toBe(original);
+  });
+
+  it("round-trips a secret with special characters", async () => {
+    const original = "p@ssw0rd!#$%^&*()";
+    const { material } = await localEncryptedProvider.createVersion({ value: original, externalRef: null });
+    const resolved = await localEncryptedProvider.resolveVersion({ material, externalRef: null });
+    expect(resolved).toBe(original);
+  });
+
+  it("round-trips a secret with unicode characters", async () => {
+    const original = "🔑 secret key 日本語";
+    const { material } = await localEncryptedProvider.createVersion({ value: original, externalRef: null });
+    const resolved = await localEncryptedProvider.resolveVersion({ material, externalRef: null });
+    expect(resolved).toBe(original);
+  });
+
+  it("round-trips an empty string", async () => {
+    const original = "";
+    const { material } = await localEncryptedProvider.createVersion({ value: original, externalRef: null });
+    const resolved = await localEncryptedProvider.resolveVersion({ material, externalRef: null });
+    expect(resolved).toBe(original);
+  });
+
+  it("round-trips a long secret (1 KB of random hex)", async () => {
+    const original = randomBytes(512).toString("hex");
+    const { material } = await localEncryptedProvider.createVersion({ value: original, externalRef: null });
+    const resolved = await localEncryptedProvider.resolveVersion({ material, externalRef: null });
+    expect(resolved).toBe(original);
+  });
+});
+
+// ============================================================================
+// localEncryptedProvider.resolveVersion — error handling
+// ============================================================================
+
+describe("localEncryptedProvider.resolveVersion — invalid material", () => {
+  it("throws when scheme is missing", async () => {
+    await expect(
+      localEncryptedProvider.resolveVersion({
+        material: { iv: "abc", tag: "def", ciphertext: "ghi" },
+        externalRef: null,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws when scheme is wrong", async () => {
+    await expect(
+      localEncryptedProvider.resolveVersion({
+        material: { scheme: "plaintext", iv: "abc", tag: "def", ciphertext: "ghi" },
+        externalRef: null,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws when iv is missing", async () => {
+    await expect(
+      localEncryptedProvider.resolveVersion({
+        material: { scheme: "local_encrypted_v1", tag: "def", ciphertext: "ghi" },
+        externalRef: null,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws when ciphertext has been tampered with (auth tag mismatch)", async () => {
+    const { material } = await localEncryptedProvider.createVersion({ value: "original", externalRef: null });
+    const tampered = {
+      ...material,
+      ciphertext: randomBytes(16).toString("base64"),
+    };
+    await expect(
+      localEncryptedProvider.resolveVersion({ material: tampered, externalRef: null }),
+    ).rejects.toThrow();
+  });
+});
+
+// ============================================================================
+// localEncryptedProvider — key formats
+// ============================================================================
+
+describe("localEncryptedProvider — master key from env", () => {
+  it("accepts a 64-char hex key and decrypts correctly", async () => {
+    vi.stubEnv("PAPERCLIP_SECRETS_MASTER_KEY", TEST_MASTER_KEY_HEX);
+    const value = "test-hex-key";
+    const { material } = await localEncryptedProvider.createVersion({ value, externalRef: null });
+    const resolved = await localEncryptedProvider.resolveVersion({ material, externalRef: null });
+    expect(resolved).toBe(value);
+  });
+
+  it("accepts a 32-byte base64 key and decrypts correctly", async () => {
+    const base64Key = randomBytes(32).toString("base64");
+    vi.stubEnv("PAPERCLIP_SECRETS_MASTER_KEY", base64Key);
+    const value = "test-base64-key";
+    const { material } = await localEncryptedProvider.createVersion({ value, externalRef: null });
+    const resolved = await localEncryptedProvider.resolveVersion({ material, externalRef: null });
+    expect(resolved).toBe(value);
+  });
+
+  it("throws when master key env var is an invalid format", async () => {
+    vi.stubEnv("PAPERCLIP_SECRETS_MASTER_KEY", "not-a-valid-key");
+    await expect(
+      localEncryptedProvider.createVersion({ value: "test", externalRef: null }),
+    ).rejects.toThrow();
+  });
+});

--- a/server/src/services/plugin-event-bus.test.ts
+++ b/server/src/services/plugin-event-bus.test.ts
@@ -6,7 +6,6 @@ import { createPluginEventBus } from "./plugin-event-bus.js";
 function makeEvent(overrides: Partial<PluginEvent> & { eventType: PluginEvent["eventType"] }): PluginEvent {
   return {
     eventId: "evt-1",
-    eventType: overrides.eventType,
     occurredAt: new Date().toISOString(),
     companyId: "co-1",
     payload: {},

--- a/server/src/services/plugin-event-bus.test.ts
+++ b/server/src/services/plugin-event-bus.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PluginEvent } from "@paperclipai/plugin-sdk";
+import { createPluginEventBus } from "./plugin-event-bus.js";
+
+// Helper to build a minimal PluginEvent envelope for tests.
+function makeEvent(overrides: Partial<PluginEvent> & { eventType: PluginEvent["eventType"] }): PluginEvent {
+  return {
+    eventId: "evt-1",
+    eventType: overrides.eventType,
+    occurredAt: new Date().toISOString(),
+    companyId: "co-1",
+    payload: {},
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// createPluginEventBus — basic emit delivery
+// ============================================================================
+
+describe("createPluginEventBus — basic delivery", () => {
+  it("delivers event to a subscribed handler", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("acme.linear").subscribe("issue.created", handler);
+
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("does not deliver event to handler subscribed to a different type", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("acme.linear").subscribe("issue.updated", handler);
+
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("delivers the event object to the handler", async () => {
+    const bus = createPluginEventBus();
+    let received: PluginEvent | undefined;
+    bus.forPlugin("plug-1").subscribe("agent.updated", async (event) => {
+      received = event;
+    });
+    const event = makeEvent({ eventType: "agent.updated" });
+
+    await bus.emit(event);
+
+    expect(received).toBe(event);
+  });
+
+  it("delivers to multiple plugins subscribed to the same event type", async () => {
+    const bus = createPluginEventBus();
+    const handlerA = vi.fn().mockResolvedValue(undefined);
+    const handlerB = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", handlerA);
+    bus.forPlugin("plugin-b").subscribe("issue.created", handlerB);
+
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(handlerA).toHaveBeenCalledOnce();
+    expect(handlerB).toHaveBeenCalledOnce();
+  });
+
+  it("delivers to multiple subscriptions in the same plugin", async () => {
+    const bus = createPluginEventBus();
+    const h1 = vi.fn().mockResolvedValue(undefined);
+    const h2 = vi.fn().mockResolvedValue(undefined);
+    const scoped = bus.forPlugin("my-plugin");
+    scoped.subscribe("issue.created", h1);
+    scoped.subscribe("issue.created", h2);
+
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(h1).toHaveBeenCalledOnce();
+    expect(h2).toHaveBeenCalledOnce();
+  });
+
+  it("returns empty errors array when all handlers succeed", async () => {
+    const bus = createPluginEventBus();
+    bus.forPlugin("p").subscribe("issue.created", async () => {});
+
+    const { errors } = await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(errors).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// createPluginEventBus — wildcard pattern matching
+// ============================================================================
+
+describe("createPluginEventBus — wildcard subscriptions", () => {
+  it("wildcard pattern delivers events with matching prefix", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("my-plugin").subscribe("plugin.acme.linear.*", handler);
+
+    await bus.emit(makeEvent({ eventType: "plugin.acme.linear.sync-done" }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("wildcard does not match unrelated plugin namespace", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("my-plugin").subscribe("plugin.acme.linear.*", handler);
+
+    await bus.emit(makeEvent({ eventType: "plugin.other.sync-done" }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("top-level plugin wildcard delivers all plugin-namespaced events", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("observer").subscribe("plugin.*", handler);
+
+    await bus.emit(makeEvent({ eventType: "plugin.acme.linear.sync-done" }));
+    await bus.emit(makeEvent({ eventType: "plugin.other.some-event" }));
+
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("exact match still works alongside wildcards", async () => {
+    const bus = createPluginEventBus();
+    const exactHandler = vi.fn().mockResolvedValue(undefined);
+    const wildcardHandler = vi.fn().mockResolvedValue(undefined);
+    const scoped = bus.forPlugin("p");
+    scoped.subscribe("plugin.acme.linear.sync-done", exactHandler);
+    scoped.subscribe("plugin.acme.linear.*", wildcardHandler);
+
+    await bus.emit(makeEvent({ eventType: "plugin.acme.linear.sync-done" }));
+
+    expect(exactHandler).toHaveBeenCalledOnce();
+    expect(wildcardHandler).toHaveBeenCalledOnce();
+  });
+});
+
+// ============================================================================
+// createPluginEventBus — EventFilter
+// ============================================================================
+
+describe("createPluginEventBus — EventFilter", () => {
+  it("delivers event when companyId filter matches", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("p").subscribe("issue.created", { companyId: "co-1" }, handler);
+
+    await bus.emit(makeEvent({ eventType: "issue.created", companyId: "co-1" }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("does not deliver when companyId filter does not match", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("p").subscribe("issue.created", { companyId: "co-X" }, handler);
+
+    await bus.emit(makeEvent({ eventType: "issue.created", companyId: "co-1" }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("filters by projectId from payload when entityType is not project", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("p").subscribe("issue.created", { projectId: "proj-1" }, handler);
+
+    await bus.emit(makeEvent({
+      eventType: "issue.created",
+      entityType: "issue",
+      payload: { projectId: "proj-1" },
+    }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("filters by projectId from entityId when entityType is project", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("p").subscribe("project.updated", { projectId: "proj-2" }, handler);
+
+    await bus.emit(makeEvent({
+      eventType: "project.updated",
+      entityType: "project",
+      entityId: "proj-2",
+    }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("does not deliver when projectId filter does not match payload", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("p").subscribe("issue.created", { projectId: "proj-X" }, handler);
+
+    await bus.emit(makeEvent({
+      eventType: "issue.created",
+      entityType: "issue",
+      payload: { projectId: "proj-1" },
+    }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("filters by agentId from payload when entityType is not agent", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("p").subscribe("agent.run.started", { agentId: "agent-1" }, handler);
+
+    await bus.emit(makeEvent({
+      eventType: "agent.run.started",
+      entityType: "run",
+      payload: { agentId: "agent-1" },
+    }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("filters by agentId from entityId when entityType is agent", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("p").subscribe("agent.updated", { agentId: "agent-2" }, handler);
+
+    await bus.emit(makeEvent({
+      eventType: "agent.updated",
+      entityType: "agent",
+      entityId: "agent-2",
+    }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("null filter delivers all events", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("p").subscribe("issue.created", handler);
+
+    await bus.emit(makeEvent({ eventType: "issue.created", companyId: "any-company" }));
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("multiple filter fields are ANDed", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("p").subscribe("issue.created", { companyId: "co-1", projectId: "proj-1" }, handler);
+
+    // Both match
+    await bus.emit(makeEvent({
+      eventType: "issue.created",
+      companyId: "co-1",
+      entityType: "issue",
+      payload: { projectId: "proj-1" },
+    }));
+    // Only companyId matches
+    await bus.emit(makeEvent({
+      eventType: "issue.created",
+      companyId: "co-1",
+      entityType: "issue",
+      payload: { projectId: "proj-X" },
+    }));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ============================================================================
+// createPluginEventBus — error isolation
+// ============================================================================
+
+describe("createPluginEventBus — handler error isolation", () => {
+  it("returns handler error in errors array instead of throwing", async () => {
+    const bus = createPluginEventBus();
+    const err = new Error("handler exploded");
+    bus.forPlugin("bad-plugin").subscribe("issue.created", async () => { throw err; });
+
+    const { errors } = await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.error).toBe(err);
+    expect(errors[0]!.pluginId).toBe("bad-plugin");
+  });
+
+  it("delivers to a working plugin even when another plugin's handler throws", async () => {
+    const bus = createPluginEventBus();
+    const goodHandler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("bad-plugin").subscribe("issue.created", async () => { throw new Error("bad"); });
+    bus.forPlugin("good-plugin").subscribe("issue.created", goodHandler);
+
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(goodHandler).toHaveBeenCalledOnce();
+  });
+});
+
+// ============================================================================
+// createPluginEventBus — clearPlugin / forPlugin.clear
+// ============================================================================
+
+describe("createPluginEventBus — clearPlugin", () => {
+  it("clearPlugin stops delivery to that plugin", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plug").subscribe("issue.created", handler);
+
+    bus.clearPlugin("plug");
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("forPlugin.clear() removes subscriptions for that plugin", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const scoped = bus.forPlugin("plug");
+    scoped.subscribe("issue.created", handler);
+
+    scoped.clear();
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("clearPlugin does not affect other plugins", async () => {
+    const bus = createPluginEventBus();
+    const handlerA = vi.fn().mockResolvedValue(undefined);
+    const handlerB = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("plugin-a").subscribe("issue.created", handlerA);
+    bus.forPlugin("plugin-b").subscribe("issue.created", handlerB);
+
+    bus.clearPlugin("plugin-a");
+    await bus.emit(makeEvent({ eventType: "issue.created" }));
+
+    expect(handlerA).not.toHaveBeenCalled();
+    expect(handlerB).toHaveBeenCalledOnce();
+  });
+});
+
+// ============================================================================
+// createPluginEventBus — subscriptionCount
+// ============================================================================
+
+describe("createPluginEventBus — subscriptionCount", () => {
+  it("returns 0 when no subscriptions exist", () => {
+    const bus = createPluginEventBus();
+    expect(bus.subscriptionCount()).toBe(0);
+  });
+
+  it("counts subscriptions globally", () => {
+    const bus = createPluginEventBus();
+    bus.forPlugin("p1").subscribe("issue.created", async () => {});
+    bus.forPlugin("p2").subscribe("issue.updated", async () => {});
+    expect(bus.subscriptionCount()).toBe(2);
+  });
+
+  it("counts subscriptions for a specific plugin", () => {
+    const bus = createPluginEventBus();
+    bus.forPlugin("p1").subscribe("issue.created", async () => {});
+    bus.forPlugin("p1").subscribe("issue.updated", async () => {});
+    bus.forPlugin("p2").subscribe("issue.created", async () => {});
+    expect(bus.subscriptionCount("p1")).toBe(2);
+    expect(bus.subscriptionCount("p2")).toBe(1);
+  });
+
+  it("decreases after clearPlugin", () => {
+    const bus = createPluginEventBus();
+    bus.forPlugin("p").subscribe("issue.created", async () => {});
+    bus.forPlugin("p").subscribe("issue.updated", async () => {});
+    bus.clearPlugin("p");
+    expect(bus.subscriptionCount()).toBe(0);
+  });
+});
+
+// ============================================================================
+// createPluginEventBus — forPlugin scoped emit (plugin-to-plugin events)
+// ============================================================================
+
+describe("createPluginEventBus — forPlugin.emit", () => {
+  it("emits event namespaced as plugin.<pluginId>.<name>", async () => {
+    const bus = createPluginEventBus();
+    const handler = vi.fn().mockResolvedValue(undefined);
+    bus.forPlugin("observer").subscribe("plugin.acme.linear.*", handler);
+
+    await bus.forPlugin("acme.linear").emit("sync-done", "co-1", { count: 5 });
+
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("throws when name is empty", async () => {
+    const bus = createPluginEventBus();
+    await expect(bus.forPlugin("p").emit("", "co-1", {})).rejects.toThrow();
+  });
+
+  it("throws when name starts with 'plugin.'", async () => {
+    const bus = createPluginEventBus();
+    await expect(
+      bus.forPlugin("p").emit("plugin.spoof", "co-1", {}),
+    ).rejects.toThrow();
+  });
+
+  it("throws when companyId is empty", async () => {
+    const bus = createPluginEventBus();
+    await expect(bus.forPlugin("p").emit("event-name", "", {})).rejects.toThrow();
+  });
+});

--- a/server/src/services/workspace-runtime-read-model.test.ts
+++ b/server/src/services/workspace-runtime-read-model.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { selectCurrentRuntimeServiceRows } from "./workspace-runtime-read-model.js";
+
+// Minimal row factory — only fields used by the identity-key logic.
+type MinimalRow = {
+  reuseKey: string | null;
+  scopeType: string;
+  scopeId: string | null;
+  projectWorkspaceId: string | null;
+  executionWorkspaceId: string | null;
+  serviceName: string;
+  command: string | null;
+  cwd: string | null;
+  id: string;
+};
+
+function makeRow(overrides: Partial<MinimalRow> & { id: string }): MinimalRow {
+  return {
+    reuseKey: null,
+    scopeType: "project_workspace",
+    scopeId: null,
+    projectWorkspaceId: "ws-1",
+    executionWorkspaceId: null,
+    serviceName: "dev",
+    command: null,
+    cwd: null,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// selectCurrentRuntimeServiceRows — empty / trivial inputs
+// ============================================================================
+
+describe("selectCurrentRuntimeServiceRows — trivial", () => {
+  it("returns empty array for empty input", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(selectCurrentRuntimeServiceRows([] as any)).toEqual([]);
+  });
+
+  it("returns single row unchanged", () => {
+    const row = makeRow({ id: "row-1" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([row] as any);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(row);
+  });
+});
+
+// ============================================================================
+// selectCurrentRuntimeServiceRows — reuseKey deduplication
+// ============================================================================
+
+describe("selectCurrentRuntimeServiceRows — reuseKey identity", () => {
+  it("keeps only the first row per reuseKey (ordered by input)", () => {
+    const first = makeRow({ id: "row-1", reuseKey: "key-A" });
+    const second = makeRow({ id: "row-2", reuseKey: "key-A" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([first, second] as any);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(first);
+  });
+
+  it("keeps rows with distinct reuseKeys", () => {
+    const a = makeRow({ id: "row-1", reuseKey: "key-A" });
+    const b = makeRow({ id: "row-2", reuseKey: "key-B" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([a, b] as any);
+    expect(result).toHaveLength(2);
+  });
+
+  it("reuseKey takes precedence over composite key fields", () => {
+    // Two rows: same composite fields, different reuseKeys => both kept
+    const a = makeRow({ id: "row-1", reuseKey: "key-A", serviceName: "dev" });
+    const b = makeRow({ id: "row-2", reuseKey: "key-B", serviceName: "dev" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([a, b] as any);
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ============================================================================
+// selectCurrentRuntimeServiceRows — composite key deduplication
+// ============================================================================
+
+describe("selectCurrentRuntimeServiceRows — composite key identity", () => {
+  it("deduplicates rows with identical composite key fields", () => {
+    const first = makeRow({ id: "row-1" });
+    const second = makeRow({ id: "row-2" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([first, second] as any);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(first);
+  });
+
+  it("keeps rows differing only in serviceName", () => {
+    const a = makeRow({ id: "row-1", serviceName: "dev" });
+    const b = makeRow({ id: "row-2", serviceName: "build" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([a, b] as any);
+    expect(result).toHaveLength(2);
+  });
+
+  it("keeps rows differing only in scopeType", () => {
+    const a = makeRow({ id: "row-1", scopeType: "project_workspace" });
+    const b = makeRow({ id: "row-2", scopeType: "execution_workspace" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([a, b] as any);
+    expect(result).toHaveLength(2);
+  });
+
+  it("keeps rows differing only in command", () => {
+    const a = makeRow({ id: "row-1", command: "pnpm dev" });
+    const b = makeRow({ id: "row-2", command: "pnpm start" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([a, b] as any);
+    expect(result).toHaveLength(2);
+  });
+
+  it("keeps rows differing only in cwd", () => {
+    const a = makeRow({ id: "row-1", cwd: "/app/frontend" });
+    const b = makeRow({ id: "row-2", cwd: "/app/backend" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([a, b] as any);
+    expect(result).toHaveLength(2);
+  });
+
+  it("keeps rows differing only in executionWorkspaceId", () => {
+    const a = makeRow({ id: "row-1", executionWorkspaceId: "ew-1" });
+    const b = makeRow({ id: "row-2", executionWorkspaceId: "ew-2" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([a, b] as any);
+    expect(result).toHaveLength(2);
+  });
+
+  it("treats null composite key fields as empty strings in the key", () => {
+    // Both rows: projectWorkspaceId=null, same other fields → same identity
+    const first = makeRow({ id: "row-1", projectWorkspaceId: null });
+    const second = makeRow({ id: "row-2", projectWorkspaceId: null });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([first, second] as any);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(first);
+  });
+});
+
+// ============================================================================
+// selectCurrentRuntimeServiceRows — ordering guarantee
+// ============================================================================
+
+describe("selectCurrentRuntimeServiceRows — order", () => {
+  it("preserves relative order of distinct rows", () => {
+    const a = makeRow({ id: "row-1", serviceName: "alpha" });
+    const b = makeRow({ id: "row-2", serviceName: "beta" });
+    const c = makeRow({ id: "row-3", serviceName: "gamma" });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = selectCurrentRuntimeServiceRows([a, b, c] as any);
+    expect(result.map((r: MinimalRow) => r.id)).toEqual(["row-1", "row-2", "row-3"]);
+  });
+});

--- a/server/src/worktree-config.test.ts
+++ b/server/src/worktree-config.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import type { PaperclipConfig } from "@paperclipai/shared";
+import { applyRuntimePortSelectionToConfig } from "./worktree-config.js";
+
+// Helpers to build minimal PaperclipConfig shapes needed for these pure-function tests.
+
+function makeEmbeddedConfig(serverPort: number, dbPort: number): PaperclipConfig {
+  return {
+    server: { port: serverPort },
+    database: { mode: "embedded-postgres", embeddedPostgresPort: dbPort },
+    auth: { baseUrlMode: "auto" },
+  } as unknown as PaperclipConfig;
+}
+
+function makeExternalDbConfig(serverPort: number): PaperclipConfig {
+  return {
+    server: { port: serverPort },
+    database: { mode: "postgres", connectionString: "postgres://localhost/test" },
+    auth: { baseUrlMode: "auto" },
+  } as unknown as PaperclipConfig;
+}
+
+function makeExplicitAuthConfig(
+  serverPort: number,
+  publicBaseUrl: string,
+  dbPort = 54329,
+): PaperclipConfig {
+  return {
+    server: { port: serverPort },
+    database: { mode: "embedded-postgres", embeddedPostgresPort: dbPort },
+    auth: { baseUrlMode: "explicit", publicBaseUrl },
+  } as unknown as PaperclipConfig;
+}
+
+// ============================================================================
+// applyRuntimePortSelectionToConfig — server port update
+// ============================================================================
+
+describe("applyRuntimePortSelectionToConfig — server port", () => {
+  it("updates server port when it differs from input", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3200,
+    });
+    expect(next.server.port).toBe(3200);
+    expect(changed).toBe(true);
+  });
+
+  it("does not change config when server port matches", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3100,
+    });
+    expect(next.server.port).toBe(3100);
+    expect(changed).toBe(false);
+  });
+
+  it("returns a new config object reference when changed", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { config: next } = applyRuntimePortSelectionToConfig(config, { serverPort: 3200 });
+    expect(next).not.toBe(config);
+  });
+
+  it("returns the original config reference when unchanged", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { config: next } = applyRuntimePortSelectionToConfig(config, { serverPort: 3100 });
+    expect(next).toBe(config);
+  });
+
+  it("skips server port update when allowServerPortWrite is false", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3200,
+      allowServerPortWrite: false,
+    });
+    expect(next.server.port).toBe(3100);
+    expect(changed).toBe(false);
+  });
+});
+
+// ============================================================================
+// applyRuntimePortSelectionToConfig — database port update
+// ============================================================================
+
+describe("applyRuntimePortSelectionToConfig — database port", () => {
+  it("updates embedded-postgres port when it differs", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3100,
+      databasePort: 54330,
+    });
+    expect((next.database as { embeddedPostgresPort: number }).embeddedPostgresPort).toBe(54330);
+    expect(changed).toBe(true);
+  });
+
+  it("does not change db port when it already matches", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3100,
+      databasePort: 54329,
+    });
+    expect(changed).toBe(false);
+  });
+
+  it("skips db port update when allowDatabasePortWrite is false", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3100,
+      databasePort: 54330,
+      allowDatabasePortWrite: false,
+    });
+    expect((next.database as { embeddedPostgresPort: number }).embeddedPostgresPort).toBe(54329);
+    expect(changed).toBe(false);
+  });
+
+  it("does not update db port for postgres mode (only embedded-postgres)", () => {
+    const config = makeExternalDbConfig(3100);
+    const { changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3100,
+      databasePort: 54330,
+    });
+    expect(changed).toBe(false);
+  });
+
+  it("does not update db port when databasePort is null", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3100,
+      databasePort: null,
+    });
+    expect(changed).toBe(false);
+  });
+
+  it("does not update db port when databasePort is undefined", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { changed } = applyRuntimePortSelectionToConfig(config, { serverPort: 3100 });
+    expect(changed).toBe(false);
+  });
+});
+
+// ============================================================================
+// applyRuntimePortSelectionToConfig — auth publicBaseUrl port rewrite
+// ============================================================================
+
+describe("applyRuntimePortSelectionToConfig — auth URL port rewrite", () => {
+  it("rewrites loopback publicBaseUrl port when baseUrlMode is explicit", () => {
+    const config = makeExplicitAuthConfig(3100, "http://127.0.0.1:3100");
+    const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3200,
+    });
+    expect(next.auth.publicBaseUrl).toBe("http://127.0.0.1:3200/");
+    expect(changed).toBe(true);
+  });
+
+  it("rewrites localhost URL port when baseUrlMode is explicit", () => {
+    const config = makeExplicitAuthConfig(3100, "http://localhost:3100");
+    const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3201,
+    });
+    expect(next.auth.publicBaseUrl).toBe("http://localhost:3201/");
+    expect(changed).toBe(true);
+  });
+
+  it("does not rewrite non-loopback publicBaseUrl", () => {
+    const config = makeExplicitAuthConfig(3100, "https://app.example.com");
+    const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3200,
+    });
+    expect(next.auth.publicBaseUrl).toBe("https://app.example.com");
+    expect(changed).toBe(false);
+  });
+
+  it("does not rewrite URL when baseUrlMode is auto", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3200,
+    });
+    expect(next.auth.publicBaseUrl).toBeUndefined();
+    expect(changed).toBe(true); // changed only because server port changed
+  });
+
+  it("does not mark changed when loopback URL port already matches", () => {
+    const config = makeExplicitAuthConfig(3100, "http://127.0.0.1:3100");
+    const { changed } = applyRuntimePortSelectionToConfig(config, { serverPort: 3100 });
+    expect(changed).toBe(false);
+  });
+});
+
+// ============================================================================
+// applyRuntimePortSelectionToConfig — combined changes
+// ============================================================================
+
+describe("applyRuntimePortSelectionToConfig — combined changes", () => {
+  it("marks changed when both server port and db port differ", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { changed } = applyRuntimePortSelectionToConfig(config, {
+      serverPort: 3200,
+      databasePort: 54330,
+    });
+    expect(changed).toBe(true);
+  });
+
+  it("preserves all other config fields unchanged", () => {
+    const config = makeEmbeddedConfig(3100, 54329);
+    const { config: next } = applyRuntimePortSelectionToConfig(config, { serverPort: 3200 });
+    expect(next.auth).toEqual(config.auth);
+    expect(next.database).toEqual(config.database);
+  });
+});

--- a/server/src/worktree-config.test.ts
+++ b/server/src/worktree-config.test.ts
@@ -162,9 +162,10 @@ describe("applyRuntimePortSelectionToConfig — auth URL port rewrite", () => {
   });
 
   it("does not rewrite non-loopback publicBaseUrl", () => {
+    // Use same serverPort as config to isolate URL-only behavior (no server-port change)
     const config = makeExplicitAuthConfig(3100, "https://app.example.com");
     const { config: next, changed } = applyRuntimePortSelectionToConfig(config, {
-      serverPort: 3200,
+      serverPort: 3100,
     });
     expect(next.auth.publicBaseUrl).toBe("https://app.example.com");
     expect(changed).toBe(false);
@@ -180,7 +181,8 @@ describe("applyRuntimePortSelectionToConfig — auth URL port rewrite", () => {
   });
 
   it("does not mark changed when loopback URL port already matches", () => {
-    const config = makeExplicitAuthConfig(3100, "http://127.0.0.1:3100");
+    // Use the normalized URL form (with trailing slash) so URL.toString() comparison is stable
+    const config = makeExplicitAuthConfig(3100, "http://127.0.0.1:3100/");
     const { changed } = applyRuntimePortSelectionToConfig(config, { serverPort: 3100 });
     expect(changed).toBe(false);
   });


### PR DESCRIPTION
## Summary

- **`server/src/worktree-config.test.ts`** — 20 tests for the pure `applyRuntimePortSelectionToConfig` function: server port update/no-op, database port update/no-op for embedded-postgres vs postgres modes, `allowServerPortWrite`/`allowDatabasePortWrite` flag handling, `auth.publicBaseUrl` loopback port rewrite when `baseUrlMode=explicit`, non-loopback URL passthrough, combined changes, and config object immutability.
- **`server/src/services/workspace-runtime-read-model.test.ts`** — 13 tests for the pure `selectCurrentRuntimeServiceRows` function: empty input, single row pass-through, reuseKey deduplication (first-wins), composite key deduplication by scopeType/serviceName/command/cwd/executionWorkspaceId, null-field treatment, and insertion-order preservation.

## Test plan

- [ ] All new tests pass: `pnpm -F @paperclipai/server vitest run`
- [ ] No regressions in verify/e2e CI checks