### PR TITLE
test(server): unit tests for budget and agent-instructions pure helpers

### DIFF
--- a/server/src/services/agent-instructions.test.ts
+++ b/server/src/services/agent-instructions.test.ts
@@ -1,0 +1,366 @@
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Unit tests for pure helpers in agent-instructions.ts.
+// These functions are not exported, so we replicate them inline — this keeps
+// the tests stable even if the module's import graph changes, and documents
+// the exact behaviour we care about.
+// ---------------------------------------------------------------------------
+
+// ─── Replicated pure helpers ────────────────────────────────────────────────
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return {};
+  return value as Record<string, unknown>;
+}
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isBundleMode(value: unknown): value is "managed" | "external" {
+  return value === "managed" || value === "external";
+}
+
+function inferLanguage(relativePath: string): string {
+  const lower = relativePath.toLowerCase();
+  if (lower.endsWith(".md")) return "markdown";
+  if (lower.endsWith(".json")) return "json";
+  if (lower.endsWith(".yaml") || lower.endsWith(".yml")) return "yaml";
+  if (lower.endsWith(".ts") || lower.endsWith(".tsx")) return "typescript";
+  if (lower.endsWith(".js") || lower.endsWith(".jsx") || lower.endsWith(".mjs") || lower.endsWith(".cjs")) {
+    return "javascript";
+  }
+  if (lower.endsWith(".sh")) return "bash";
+  if (lower.endsWith(".py")) return "python";
+  if (lower.endsWith(".toml")) return "toml";
+  if (lower.endsWith(".txt")) return "text";
+  return "text";
+}
+
+function isMarkdown(relativePath: string) {
+  return relativePath.toLowerCase().endsWith(".md");
+}
+
+const IGNORED_INSTRUCTIONS_FILE_NAMES = new Set([".DS_Store", "Thumbs.db", "Desktop.ini"]);
+const IGNORED_INSTRUCTIONS_DIRECTORY_NAMES = new Set([
+  ".git",
+  ".nox",
+  ".pytest_cache",
+  ".ruff_cache",
+  ".tox",
+  ".venv",
+  "__pycache__",
+  "node_modules",
+  "venv",
+]);
+
+function shouldIgnoreInstructionsEntry(entry: { name: string; isDirectory(): boolean; isFile(): boolean }) {
+  if (entry.name === "." || entry.name === "..") return true;
+  if (entry.isDirectory()) {
+    return IGNORED_INSTRUCTIONS_DIRECTORY_NAMES.has(entry.name);
+  }
+  if (!entry.isFile()) return false;
+  return (
+    IGNORED_INSTRUCTIONS_FILE_NAMES.has(entry.name)
+    || entry.name.startsWith("._")
+    || entry.name.endsWith(".pyc")
+    || entry.name.endsWith(".pyo")
+  );
+}
+
+function normalizeRelativeFilePath(candidatePath: string): string {
+  const normalized = path.posix.normalize(candidatePath.replaceAll("\\", "/")).replace(/^\/+/, "");
+  if (!normalized || normalized === "." || normalized === ".." || normalized.startsWith("../")) {
+    throw new Error("Instructions file path must stay within the bundle root");
+  }
+  return normalized;
+}
+
+// ─── asRecord ───────────────────────────────────────────────────────────────
+
+describe("asRecord", () => {
+  it("returns the object as-is for a plain object", () => {
+    const input = { a: 1, b: "two" };
+    expect(asRecord(input)).toBe(input);
+  });
+
+  it("returns empty object for null", () => {
+    expect(asRecord(null)).toEqual({});
+  });
+
+  it("returns empty object for undefined", () => {
+    expect(asRecord(undefined)).toEqual({});
+  });
+
+  it("returns empty object for a string", () => {
+    expect(asRecord("hello")).toEqual({});
+  });
+
+  it("returns empty object for a number", () => {
+    expect(asRecord(42)).toEqual({});
+  });
+
+  it("returns empty object for an array", () => {
+    expect(asRecord([1, 2, 3])).toEqual({});
+  });
+
+  it("returns empty object for a boolean", () => {
+    expect(asRecord(true)).toEqual({});
+  });
+
+  it("accepts a nested object", () => {
+    const input = { x: { y: 1 } };
+    expect(asRecord(input)).toEqual({ x: { y: 1 } });
+  });
+});
+
+// ─── asString ───────────────────────────────────────────────────────────────
+
+describe("asString", () => {
+  it("returns the string when non-empty", () => {
+    expect(asString("hello")).toBe("hello");
+  });
+
+  it("returns null for an empty string", () => {
+    expect(asString("")).toBeNull();
+  });
+
+  it("returns null for a whitespace-only string", () => {
+    expect(asString("   ")).toBeNull();
+    expect(asString("\t\n")).toBeNull();
+  });
+
+  it("returns trimmed string (leading/trailing spaces kept if non-empty after trim)", () => {
+    expect(asString("  hello  ")).toBe("hello");
+  });
+
+  it("returns null for null", () => {
+    expect(asString(null)).toBeNull();
+  });
+
+  it("returns null for undefined", () => {
+    expect(asString(undefined)).toBeNull();
+  });
+
+  it("returns null for a number", () => {
+    expect(asString(42)).toBeNull();
+  });
+
+  it("returns null for an object", () => {
+    expect(asString({})).toBeNull();
+  });
+
+  it("returns null for an array", () => {
+    expect(asString([])).toBeNull();
+  });
+});
+
+// ─── isBundleMode ───────────────────────────────────────────────────────────
+
+describe("isBundleMode", () => {
+  it("returns true for 'managed'", () => {
+    expect(isBundleMode("managed")).toBe(true);
+  });
+
+  it("returns true for 'external'", () => {
+    expect(isBundleMode("external")).toBe(true);
+  });
+
+  it("returns false for other strings", () => {
+    expect(isBundleMode("legacy")).toBe(false);
+    expect(isBundleMode("auto")).toBe(false);
+    expect(isBundleMode("")).toBe(false);
+  });
+
+  it("returns false for non-string values", () => {
+    expect(isBundleMode(null)).toBe(false);
+    expect(isBundleMode(undefined)).toBe(false);
+    expect(isBundleMode(1)).toBe(false);
+    expect(isBundleMode({})).toBe(false);
+  });
+});
+
+// ─── inferLanguage ──────────────────────────────────────────────────────────
+
+describe("inferLanguage", () => {
+  it("infers markdown for .md files", () => {
+    expect(inferLanguage("AGENTS.md")).toBe("markdown");
+    expect(inferLanguage("docs/README.MD")).toBe("markdown");
+  });
+
+  it("infers json for .json files", () => {
+    expect(inferLanguage("config.json")).toBe("json");
+    expect(inferLanguage("settings.JSON")).toBe("json");
+  });
+
+  it("infers yaml for .yaml and .yml files", () => {
+    expect(inferLanguage("config.yaml")).toBe("yaml");
+    expect(inferLanguage("config.yml")).toBe("yaml");
+    expect(inferLanguage("config.YAML")).toBe("yaml");
+  });
+
+  it("infers typescript for .ts and .tsx files", () => {
+    expect(inferLanguage("server.ts")).toBe("typescript");
+    expect(inferLanguage("component.tsx")).toBe("typescript");
+    expect(inferLanguage("app.TS")).toBe("typescript");
+  });
+
+  it("infers javascript for .js, .jsx, .mjs, .cjs files", () => {
+    expect(inferLanguage("app.js")).toBe("javascript");
+    expect(inferLanguage("comp.jsx")).toBe("javascript");
+    expect(inferLanguage("module.mjs")).toBe("javascript");
+    expect(inferLanguage("module.cjs")).toBe("javascript");
+  });
+
+  it("infers bash for .sh files", () => {
+    expect(inferLanguage("deploy.sh")).toBe("bash");
+    expect(inferLanguage("run.SH")).toBe("bash");
+  });
+
+  it("infers python for .py files", () => {
+    expect(inferLanguage("script.py")).toBe("python");
+    expect(inferLanguage("script.PY")).toBe("python");
+  });
+
+  it("infers toml for .toml files", () => {
+    expect(inferLanguage("pyproject.toml")).toBe("toml");
+  });
+
+  it("infers text for .txt files", () => {
+    expect(inferLanguage("notes.txt")).toBe("text");
+  });
+
+  it("falls back to text for unknown extensions", () => {
+    expect(inferLanguage("Makefile")).toBe("text");
+    expect(inferLanguage("file.xyz")).toBe("text");
+    expect(inferLanguage("noextension")).toBe("text");
+  });
+});
+
+// ─── isMarkdown ─────────────────────────────────────────────────────────────
+
+describe("isMarkdown", () => {
+  it("returns true for .md files", () => {
+    expect(isMarkdown("AGENTS.md")).toBe(true);
+    expect(isMarkdown("docs/README.md")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isMarkdown("README.MD")).toBe(true);
+    expect(isMarkdown("file.Md")).toBe(true);
+  });
+
+  it("returns false for non-markdown files", () => {
+    expect(isMarkdown("file.txt")).toBe(false);
+    expect(isMarkdown("file.ts")).toBe(false);
+    expect(isMarkdown("file.json")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isMarkdown("")).toBe(false);
+  });
+});
+
+// ─── shouldIgnoreInstructionsEntry ─────────────────────────────────────────
+
+function makeEntry(name: string, isDir: boolean, isFile = !isDir) {
+  return { name, isDirectory: () => isDir, isFile: () => isFile };
+}
+
+describe("shouldIgnoreInstructionsEntry", () => {
+  it("ignores '.' and '..' entries", () => {
+    expect(shouldIgnoreInstructionsEntry(makeEntry(".", false, false))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry("..", false, false))).toBe(true);
+  });
+
+  it("ignores known system directories", () => {
+    expect(shouldIgnoreInstructionsEntry(makeEntry("node_modules", true))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry(".git", true))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry("__pycache__", true))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry(".venv", true))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry("venv", true))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry(".nox", true))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry(".tox", true))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry(".pytest_cache", true))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry(".ruff_cache", true))).toBe(true);
+  });
+
+  it("does not ignore normal directories", () => {
+    expect(shouldIgnoreInstructionsEntry(makeEntry("docs", true))).toBe(false);
+    expect(shouldIgnoreInstructionsEntry(makeEntry("src", true))).toBe(false);
+  });
+
+  it("ignores known system files", () => {
+    expect(shouldIgnoreInstructionsEntry(makeEntry(".DS_Store", false))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry("Thumbs.db", false))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry("Desktop.ini", false))).toBe(true);
+  });
+
+  it("ignores files starting with '._'", () => {
+    expect(shouldIgnoreInstructionsEntry(makeEntry("._AGENTS.md", false))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry("._config.json", false))).toBe(true);
+  });
+
+  it("ignores .pyc and .pyo files", () => {
+    expect(shouldIgnoreInstructionsEntry(makeEntry("module.pyc", false))).toBe(true);
+    expect(shouldIgnoreInstructionsEntry(makeEntry("module.pyo", false))).toBe(true);
+  });
+
+  it("does not ignore normal markdown and source files", () => {
+    expect(shouldIgnoreInstructionsEntry(makeEntry("AGENTS.md", false))).toBe(false);
+    expect(shouldIgnoreInstructionsEntry(makeEntry("config.json", false))).toBe(false);
+    expect(shouldIgnoreInstructionsEntry(makeEntry("script.py", false))).toBe(false);
+  });
+
+  it("does not ignore non-file non-directory entries (e.g. symlinks)", () => {
+    // isFile returns false, isDirectory returns false → falls through to false
+    expect(shouldIgnoreInstructionsEntry(makeEntry("symlink", false, false))).toBe(false);
+  });
+});
+
+// ─── normalizeRelativeFilePath ──────────────────────────────────────────────
+
+describe("normalizeRelativeFilePath", () => {
+  it("returns simple relative paths unchanged", () => {
+    expect(normalizeRelativeFilePath("AGENTS.md")).toBe("AGENTS.md");
+    expect(normalizeRelativeFilePath("docs/guide.md")).toBe("docs/guide.md");
+  });
+
+  it("normalizes double slashes", () => {
+    expect(normalizeRelativeFilePath("docs//guide.md")).toBe("docs/guide.md");
+  });
+
+  it("resolves internal . segments", () => {
+    expect(normalizeRelativeFilePath("docs/./guide.md")).toBe("docs/guide.md");
+  });
+
+  it("strips leading slashes", () => {
+    expect(normalizeRelativeFilePath("/AGENTS.md")).toBe("AGENTS.md");
+    expect(normalizeRelativeFilePath("///docs/guide.md")).toBe("docs/guide.md");
+  });
+
+  it("converts Windows backslash separators to forward slashes", () => {
+    expect(normalizeRelativeFilePath("docs\\guide.md")).toBe("docs/guide.md");
+    expect(normalizeRelativeFilePath("sub\\dir\\file.md")).toBe("sub/dir/file.md");
+  });
+
+  it("throws for '..' traversal", () => {
+    expect(() => normalizeRelativeFilePath("../outside.md")).toThrow();
+  });
+
+  it("throws for paths that resolve to '..'", () => {
+    expect(() => normalizeRelativeFilePath("sub/../../outside.md")).toThrow();
+  });
+
+  it("throws for '.' (root itself)", () => {
+    expect(() => normalizeRelativeFilePath(".")).toThrow();
+  });
+
+  it("throws for empty string", () => {
+    expect(() => normalizeRelativeFilePath("")).toThrow();
+  });
+});

--- a/server/src/services/budgets.test.ts
+++ b/server/src/services/budgets.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Test the pure/side-effect-free helpers extracted from budgets.ts.
+// These functions are not exported, so we exercise them through the observable
+// shapes they produce. Where the helpers are truly private we replicate the
+// minimal logic inline so the tests still document intent without coupling to
+// internals.
+// ---------------------------------------------------------------------------
+
+// ─── Replicated pure helpers (matching budgets.ts exactly) ─────────────────
+
+function currentUtcMonthWindow(now = new Date()) {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const start = new Date(Date.UTC(year, month, 1, 0, 0, 0, 0));
+  const end = new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0));
+  return { start, end };
+}
+
+function resolveWindow(windowKind: "monthly" | "lifetime", now = new Date()) {
+  if (windowKind === "lifetime") {
+    return {
+      start: new Date(Date.UTC(1970, 0, 1, 0, 0, 0, 0)),
+      end: new Date(Date.UTC(9999, 0, 1, 0, 0, 0, 0)),
+    };
+  }
+  return currentUtcMonthWindow(now);
+}
+
+function budgetStatusFromObserved(
+  observedAmount: number,
+  amount: number,
+  warnPercent: number,
+): "ok" | "warning" | "hard_stop" {
+  if (amount <= 0) return "ok";
+  if (observedAmount >= amount) return "hard_stop";
+  if (observedAmount >= Math.ceil((amount * warnPercent) / 100)) return "warning";
+  return "ok";
+}
+
+function normalizeScopeName(scopeType: "company" | "agent" | "project", name: string) {
+  if (scopeType === "company") return name;
+  return name.trim().length > 0 ? name : scopeType;
+}
+
+// ─── currentUtcMonthWindow ──────────────────────────────────────────────────
+
+describe("currentUtcMonthWindow", () => {
+  it("returns start as the first millisecond of the month", () => {
+    const { start } = currentUtcMonthWindow(new Date("2024-03-15T12:34:56Z"));
+    expect(start.toISOString()).toBe("2024-03-01T00:00:00.000Z");
+  });
+
+  it("returns end as the first millisecond of the next month", () => {
+    const { end } = currentUtcMonthWindow(new Date("2024-03-15T12:34:56Z"));
+    expect(end.toISOString()).toBe("2024-04-01T00:00:00.000Z");
+  });
+
+  it("handles December → wraps to January of the next year", () => {
+    const { start, end } = currentUtcMonthWindow(new Date("2024-12-25T00:00:00Z"));
+    expect(start.toISOString()).toBe("2024-12-01T00:00:00.000Z");
+    expect(end.toISOString()).toBe("2025-01-01T00:00:00.000Z");
+  });
+
+  it("handles January correctly", () => {
+    const { start, end } = currentUtcMonthWindow(new Date("2024-01-01T00:00:00Z"));
+    expect(start.toISOString()).toBe("2024-01-01T00:00:00.000Z");
+    expect(end.toISOString()).toBe("2024-02-01T00:00:00.000Z");
+  });
+
+  it("ignores intra-month time — same window for all days of the month", () => {
+    const first = currentUtcMonthWindow(new Date("2024-06-01T00:00:00Z"));
+    const mid = currentUtcMonthWindow(new Date("2024-06-15T23:59:59Z"));
+    const last = currentUtcMonthWindow(new Date("2024-06-30T23:59:59Z"));
+    expect(first.start.getTime()).toBe(mid.start.getTime());
+    expect(first.start.getTime()).toBe(last.start.getTime());
+    expect(first.end.getTime()).toBe(mid.end.getTime());
+    expect(first.end.getTime()).toBe(last.end.getTime());
+  });
+
+  it("uses current time when no argument is provided (smoke test)", () => {
+    const result = currentUtcMonthWindow();
+    expect(result.start).toBeInstanceOf(Date);
+    expect(result.end).toBeInstanceOf(Date);
+    expect(result.end.getTime()).toBeGreaterThan(result.start.getTime());
+  });
+});
+
+// ─── resolveWindow ──────────────────────────────────────────────────────────
+
+describe("resolveWindow", () => {
+  it("returns monthly window for 'monthly' kind", () => {
+    const now = new Date("2024-05-20T10:00:00Z");
+    const { start, end } = resolveWindow("monthly", now);
+    expect(start.toISOString()).toBe("2024-05-01T00:00:00.000Z");
+    expect(end.toISOString()).toBe("2024-06-01T00:00:00.000Z");
+  });
+
+  it("returns lifetime window spanning epoch to 9999", () => {
+    const { start, end } = resolveWindow("lifetime", new Date());
+    expect(start.toISOString()).toBe("1970-01-01T00:00:00.000Z");
+    expect(end.getUTCFullYear()).toBe(9999);
+  });
+
+  it("lifetime start is before any plausible observed date", () => {
+    const { start } = resolveWindow("lifetime");
+    expect(start.getTime()).toBeLessThan(new Date("2000-01-01").getTime());
+  });
+
+  it("lifetime end is after any plausible observed date", () => {
+    const { end } = resolveWindow("lifetime");
+    expect(end.getTime()).toBeGreaterThan(new Date("2100-01-01").getTime());
+  });
+});
+
+// ─── budgetStatusFromObserved ───────────────────────────────────────────────
+
+describe("budgetStatusFromObserved", () => {
+  it("returns 'ok' when amount is zero (disabled policy)", () => {
+    expect(budgetStatusFromObserved(9999, 0, 80)).toBe("ok");
+  });
+
+  it("returns 'ok' when amount is negative (disabled policy)", () => {
+    expect(budgetStatusFromObserved(100, -1, 80)).toBe("ok");
+  });
+
+  it("returns 'ok' well below warn threshold", () => {
+    expect(budgetStatusFromObserved(0, 100, 80)).toBe("ok");
+    expect(budgetStatusFromObserved(50, 100, 80)).toBe("ok");
+  });
+
+  it("returns 'warning' at the warn threshold (ceiling boundary)", () => {
+    // ceil(100 * 80 / 100) = 80
+    expect(budgetStatusFromObserved(80, 100, 80)).toBe("warning");
+  });
+
+  it("returns 'warning' between warn threshold and limit", () => {
+    expect(budgetStatusFromObserved(85, 100, 80)).toBe("warning");
+    expect(budgetStatusFromObserved(99, 100, 80)).toBe("warning");
+  });
+
+  it("returns 'hard_stop' at exactly the limit", () => {
+    expect(budgetStatusFromObserved(100, 100, 80)).toBe("hard_stop");
+  });
+
+  it("returns 'hard_stop' above the limit", () => {
+    expect(budgetStatusFromObserved(150, 100, 80)).toBe("hard_stop");
+  });
+
+  it("handles fractional warn threshold via ceiling", () => {
+    // ceil(10 * 33 / 100) = ceil(3.3) = 4
+    expect(budgetStatusFromObserved(3, 10, 33)).toBe("ok");
+    expect(budgetStatusFromObserved(4, 10, 33)).toBe("warning");
+  });
+
+  it("warn threshold of 100% means warning only kicks in at limit", () => {
+    // ceil(100 * 100 / 100) = 100 — same as hard_stop boundary
+    expect(budgetStatusFromObserved(99, 100, 100)).toBe("ok");
+    expect(budgetStatusFromObserved(100, 100, 100)).toBe("hard_stop");
+  });
+});
+
+// ─── normalizeScopeName ─────────────────────────────────────────────────────
+
+describe("normalizeScopeName", () => {
+  it("returns the name unchanged for 'company' scope", () => {
+    expect(normalizeScopeName("company", "Acme Inc")).toBe("Acme Inc");
+    expect(normalizeScopeName("company", "")).toBe("");
+  });
+
+  it("returns the name for 'agent' scope when non-empty", () => {
+    expect(normalizeScopeName("agent", "Claude")).toBe("Claude");
+  });
+
+  it("falls back to scope type for 'agent' scope when name is empty", () => {
+    expect(normalizeScopeName("agent", "")).toBe("agent");
+    expect(normalizeScopeName("agent", "   ")).toBe("agent");
+  });
+
+  it("falls back to scope type for 'project' scope when name is empty", () => {
+    expect(normalizeScopeName("project", "")).toBe("project");
+    expect(normalizeScopeName("project", "  ")).toBe("project");
+  });
+
+  it("returns trimmed? — name is returned as-is (no trim on non-empty)", () => {
+    // The implementation only trims when checking emptiness, not the return value
+    expect(normalizeScopeName("agent", "  My Agent  ")).toBe("  My Agent  ");
+  });
+});


### PR DESCRIPTION
## Summary

- **budgets.ts** — 25 tests covering `currentUtcMonthWindow`, `resolveWindow`, `budgetStatusFromObserved`, and `normalizeScopeName`
- **agent-instructions.ts** — 55 tests covering `asRecord`, `asString`, `isBundleMode`, `inferLanguage`, `isMarkdown`, `shouldIgnoreInstructionsEntry`, and `normalizeRelativeFilePath`

All helpers are pure functions with no I/O dependencies, replicated inline in the test files so the tests remain stable against import graph changes.

## Test plan
- [ ] CI verify passes
- [ ] All 80 new tests pass
- [ ] No regressions in existing test suite