### PR TITLE
feat(observability): inject traceId/spanId into pino logs for Loki-Tempo correlation (ANGA-1020)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -69,6 +69,7 @@
     "jsdom": "^28.1.0",
     "multer": "^2.1.1",
     "open": "^11.0.0",
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.56.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.57.2",
     "@opentelemetry/sdk-node": "^0.57.2",

--- a/server/src/middleware/logger.ts
+++ b/server/src/middleware/logger.ts
@@ -1,11 +1,26 @@
 import path from "node:path";
 import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { trace, isSpanContextValid } from "@opentelemetry/api";
 import pino from "pino";
 import { pinoHttp } from "pino-http";
 import { readConfigFile } from "../config-file.js";
 import { resolveDefaultLogsDir, resolveHomeAwarePath } from "../home-paths.js";
 import { shouldSilenceHttpSuccessLog } from "./http-log-policy.js";
+
+/**
+ * Returns the active OTel trace/span IDs for the current async context, or an
+ * empty object when no active span exists or tracing is not enabled.
+ * These fields are included in every pino log line so that Loki entries can be
+ * correlated with Tempo traces via the traceId.
+ */
+function getTraceContext(): Record<string, string> {
+  const span = trace.getActiveSpan();
+  if (!span) return {};
+  const ctx = span.spanContext();
+  if (!isSpanContextValid(ctx)) return {};
+  return { traceId: ctx.traceId, spanId: ctx.spanId };
+}
 
 /** pino-http callback request type — IncomingMessage extended with Express body/params/query/route. */
 type PinoReq = IncomingMessage & {
@@ -86,6 +101,7 @@ function buildTransportTargets() {
 
 export const logger = pino({
   level: "debug",
+  mixin: getTraceContext,
 }, pino.transport({
   targets: buildTransportTargets(),
 }));


### PR DESCRIPTION
## Summary

- Adds `@opentelemetry/api ^1.9.0` as a direct dependency of `server` (was only an implicit transitive dep via `sdk-node`; making it direct gives a stable import and ensures pnpm links it correctly)
- Adds a `mixin` to the pino logger in `server/src/middleware/logger.ts` that reads the active OTel span context and injects `traceId` + `spanId` into every log line
- When no span is active (or OTel is not initialized), `getTraceContext()` returns `{}` — zero-cost no-op with no performance impact

## Background

[ANGA-1020](/ANGA/issues/ANGA-1020) — parent [ANGA-384](/ANGA/issues/ANGA-384)

Work plan items 1–3 (OTel packages, `tracing.ts`, `initTracing()` call) were already merged in `c40a3f013`. This PR delivers item 4: **traceId/spanId correlation in pino logs** — the last outstanding piece so Loki log entries can be correlated with Tempo traces by traceId.

## Changes (2 files)

- `server/package.json` — add `@opentelemetry/api ^1.9.0` as direct dependency
- `server/src/middleware/logger.ts` — add `getTraceContext()` helper and pino `mixin`

Note: no lockfile changes included — CI owns lockfile updates per policy.

## Test plan

- [x] TypeScript build passes (`tsc --noEmit`)
- [ ] With observability stack running (`docker compose -f docker-compose.yml -f docker-compose.observability.yml up`), Loki log lines include `traceId` + `spanId` fields
- [ ] Without `PAPERCLIP_OTEL_ENDPOINT`, no trace fields appear and server starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)