### PR TITLE
feat(skills): tag workspace skills with publishTo + scaffold plugin repos (ANGA-1021)

### DIFF
--- a/skills/derive-issues/SKILL.md
+++ b/skills/derive-issues/SKILL.md
@@ -7,6 +7,7 @@ description: >
   Creates issues directly in Paperclip under a specified parent and goal.
 argument-hint: "[--parent ISSUE-ID] [--dry-run] [focus: tests|docs|ci|refactor|all]"
 roles: [cto, developer]
+publishTo: claude-private
 ---
 
 # Derive Issues Skill

--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -5,6 +5,7 @@ description: >
   to inspect adapter configuration options, compare existing agent configs,
   draft a new agent prompt/config, and submit a hire request.
 roles: [ceo, manager]
+publishTo: claude-public
 ---
 
 # Paperclip Create Agent Skill

--- a/skills/paperclip-create-plugin/SKILL.md
+++ b/skills/paperclip-create-plugin/SKILL.md
@@ -6,6 +6,7 @@ description: >
   authoring docs. Covers the supported worker/UI surface, route conventions,
   scaffold flow, and verification steps.
 roles: [cto, developer]
+publishTo: claude-public
 ---
 
 # Create a Paperclip Plugin

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -8,6 +8,7 @@ description: >
   use for the actual domain work itself (writing code, research, etc.) — only for
   Paperclip coordination.
 roles: [all]
+publishTo: claude-public
 ---
 
 # Paperclip Skill

--- a/skills/para-memory-files/SKILL.md
+++ b/skills/para-memory-files/SKILL.md
@@ -9,6 +9,7 @@ description: >
   Trigger on any memory operation: saving facts, writing daily notes, creating
   entities, running weekly synthesis, recalling past context, or managing plans.
 roles: [all]
+publishTo: claude-public
 ---
 
 # PARA Memory Files

--- a/skills/tradingview/SKILL.md
+++ b/skills/tradingview/SKILL.md
@@ -5,6 +5,7 @@ description: >
   for TradingView-style price, volume, range, analyst, earnings, and news
   checks. TradingView itself is egress-blocked in this environment.
 roles: [analyst, trader]
+publishTo: claude-public
 ---
 
 # Market Data Browser Skill


### PR DESCRIPTION
## Summary

Closes ANGA-1021. Scaffolds the `claude-private` and `claude-public` plugin repository split.

- Both repos already existed — verified contents and identified gaps
- Tagged all 6 workspace skills with `publishTo` frontmatter (`claude-public` or `claude-private`)
- Created `README.md` in `anhermon/claude-private` (was missing) with directory structure, quick-start, and contribution pipeline docs
- Fixed stale `library.yaml` in `anhermon/claude-private` — removed non-existent `testing` and `taskfile-patterns` entries

### Skill classification

| Skill | publishTo |
|-------|-----------|
| `paperclip` | `claude-public` |
| `paperclip-create-agent` | `claude-public` |
| `paperclip-create-plugin` | `claude-public` |
| `para-memory-files` | `claude-public` |
| `tradingview` | `claude-public` |
| `derive-issues` | `claude-private` |

Actual migration/publication deferred per board directive (separate decision).

### External repo changes

Direct commits to `anhermon/claude-private`:
- Created `README.md` (b24c8e81)
- Fixed `library.yaml` — removed stale entries `testing`, `taskfile-patterns` (4dbb06eb)

### Governance note

Pre-existing: `doc/PROCESS.md` referenced in `AGENTS.md` but never created. Filed as [ANGA-1022](/ANGA/issues/ANGA-1022).

## Test plan

- [ ] Verify `publishTo` field present in all 6 SKILL.md frontmatters
- [ ] Verify `anhermon/claude-private` README renders correctly on GitHub
- [ ] Verify `library.yaml` no longer references `testing` or `taskfile-patterns`
- [ ] Confirm `claude-public` structure and README unchanged (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)